### PR TITLE
Making user approval idempotent

### DIFF
--- a/users/main.go
+++ b/users/main.go
@@ -112,9 +112,7 @@ func Signup(directLogin bool) http.HandlerFunc {
 		}
 		if directLogin {
 			// approve user, and return token
-			if user.Organization == nil {
-				_, err = storage.ApproveUser(user.ID)
-			}
+			_, err = storage.ApproveUser(user.ID)
 			view.Token = token
 		} else if user.ApprovedAt.IsZero() {
 			err = SendWelcomeEmail(user)

--- a/users/memory_storage.go
+++ b/users/memory_storage.go
@@ -70,6 +70,10 @@ func (s memoryStorage) ApproveUser(id string) (*User, error) {
 		return nil, err
 	}
 
+	if !user.ApprovedAt.IsZero() {
+		return user, nil
+	}
+
 	if o, err := s.createOrganization(); err == nil {
 		user.ApprovedAt = time.Now().UTC()
 		user.Organization = o


### PR DESCRIPTION
This way we can't accidentally get orphaned organizations in the db.

Fixes #45
