### PR TITLE
[users] encode probe and login tokens as zbase32, so they look nicer

### DIFF
--- a/users/main.go
+++ b/users/main.go
@@ -136,7 +136,7 @@ func signup(directLogin bool) http.HandlerFunc {
 }
 
 func generateUserToken(storage database, user *user) (string, error) {
-	token, err := user.GenerateToken()
+	token, err := generateToken()
 	if err != nil {
 		return "", err
 	}

--- a/users/organization.go
+++ b/users/organization.go
@@ -19,7 +19,7 @@ func (o *organization) RegenerateName() {
 }
 
 func (o *organization) RegenerateProbeToken() error {
-	t, err := secureRandomBase64(20)
+	t, err := generateToken()
 	if err != nil {
 		return err
 	}

--- a/users/tokens.go
+++ b/users/tokens.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/base32"
+)
+
+var (
+	zbase32 = base32.NewEncoding("ybndrfg8ejkmcpqxot1uwisza345h769")
+
+	// You want charCount to be large enough to provide lots of uniqueness, but
+	// small enough to be easy for users. Ideally you want charCount and
+	// byteCount to both work out as whole integers, otherwise you will have ====
+	// on the end of the token, which is ugly when urlencoded.
+	charCount = 32
+	byteCount = charCount * 5 / 8 // base32 uses 8 characters per 5 bytes
+)
+
+func generateToken() (string, error) {
+	var (
+		randomData = make([]byte, byteCount)
+	)
+	_, err := rand.Read(randomData)
+	if err != nil {
+		return "", err
+	}
+	return zbase32.EncodeToString(randomData), nil
+}

--- a/users/user.go
+++ b/users/user.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"crypto/rand"
-	"encoding/base64"
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
@@ -17,20 +15,6 @@ type user struct {
 	FirstLoginAt   time.Time
 	CreatedAt      time.Time
 	Organization   *organization
-}
-
-func (u *user) GenerateToken() (string, error) {
-	return secureRandomBase64(20)
-}
-
-func secureRandomBase64(charCount int) (string, error) {
-	byteCount := (charCount * 3) / 4
-	randomData := make([]byte, byteCount)
-	_, err := rand.Read(randomData)
-	if err != nil {
-		return "", err
-	}
-	return base64.URLEncoding.EncodeToString(randomData), nil
 }
 
 func (u *user) CompareToken(other string) bool {


### PR DESCRIPTION
Also upped the character count a bit, to include more bytes for more
uniqueness (160 bits).

For example, tokens now look like `kzr8exzinb6dnwj135zgsbfdii87w5pa`.

As mentioned in #67
