### PR TITLE
[frontend] Rate limit requests to prevent bruteforce and DoS attacks

### DIFF
--- a/frontend/default.conf
+++ b/frontend/default.conf
@@ -18,10 +18,12 @@ server {
         proxy_pass http://users.weave.local$request_uri;
     }
 
+    # Apply a more relaxed anti-DoS rate-limiting to all
+    # authentication-unrelated endpoints
+    limit_req zone=antidos burst=10;
+
     location /api/users/ {
         proxy_pass http://users.weave.local$request_uri;
-        # Apply anti-DoS rate-limiting
-        limit_req zone=antidos burst=10;
     }
 
     location ~ ^/api/app/[^/]+/api/topology/[^/]+/ws {
@@ -29,25 +31,17 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-        # Apply anti-DoS rate-limiting
-        limit_req zone=antidos burst=10;
     }
 
     location = /api/report {
         proxy_pass http://app-mapper.weave.local$request_uri;
-        # Apply anti-DoS rate-limiting
-        limit_req zone=antidos burst=10;
     }
 
     location /api/app/ {
         proxy_pass http://app-mapper.weave.local$request_uri;
-        # Apply anti-DoS rate-limiting
-        limit_req zone=antidos burst=10;
     }
 
     location / {
         proxy_pass http://ui-server.weave.local$request_uri;
-        # Apply anti-DoS rate-limiting
-        limit_req zone=antidos burst=10;
     }
 }


### PR DESCRIPTION
@tomwilkie please review

This is how I tested that the rate limiting works:

```
$ DOCKER_HOST=unix:///var/run/weave.sock docker run --rm -ti --rm golang:1.4
root@d012dc89aa16:/go# TARGET_HOST=frontend.weave.local; REQUEST_PERIOD=0.2; while true; do (DATE=`date +"%T.%3N"`; curl -s -o /dev/null -w "Request spawned at $DATE, Duration %{time_total}, return code: %{http_code}\\n" http://${TARGET_HOST}/api/users/login &);  sleep $REQUEST_PERIOD; done
Request spawned at 16:56:19.137, Duration 0.057, return code: 400
Request spawned at 16:56:19.344, Duration 0.847, return code: 400
Request spawned at 16:56:20.584, Duration 0.006, return code: 503
Request spawned at 16:56:20.794, Duration 0.005, return code: 503
Request spawned at 16:56:21.000, Duration 0.006, return code: 503
Request spawned at 16:56:19.551, Duration 1.639, return code: 400
Request spawned at 16:56:21.415, Duration 0.011, return code: 503
Request spawned at 16:56:21.619, Duration 0.014, return code: 503
Request spawned at 16:56:21.827, Duration 0.005, return code: 503
Request spawned at 16:56:22.032, Duration 0.092, return code: 503
Request spawned at 16:56:19.755, Duration 2.435, return code: 400
Request spawned at 16:56:22.445, Duration 0.005, return code: 503
Request spawned at 16:56:22.654, Duration 0.013, return code: 503
Request spawned at 16:56:22.864, Duration 0.007, return code: 503
Request spawned at 16:56:23.068, Duration 0.005, return code: 503
```
