### PR TITLE
[frontend] Forward endpoints with prefix /api/org/ to app-mapper

### DIFF
--- a/frontend/default.conf
+++ b/frontend/default.conf
@@ -41,6 +41,10 @@ server {
         proxy_pass http://app-mapper.weave.local$request_uri;
     }
 
+    location /api/org/ {
+        proxy_pass http://app-mapper.weave.local$request_uri;
+    }
+
     location / {
         proxy_pass http://ui-server.weave.local$request_uri;
     }


### PR DESCRIPTION
The app-mapper currently implements `/api/org/<orgName>/probes` which lists the known
probes.
