### PR TITLE
Re-add netgo build tag

### DIFF
--- a/app-mapper/Makefile
+++ b/app-mapper/Makefile
@@ -6,6 +6,14 @@ APP_MAPPER_IMAGE=weaveworks/app-mapper
 APP_MAPPER_DB_IMAGE=weaveworks/app-mapper-db
 APP_MAPPER_EXE=app-mapper
 SUDO=sudo
+NETGO_CHECK=@strings $@ | grep cgo_stub\\\.go >/dev/null || { \
+	rm $@; \
+	echo "\nYour go standard library was built without the 'netgo' build tag."; \
+	echo "To fix that, run"; \
+	echo "    sudo go clean -i net"; \
+	echo "    sudo go install -tags netgo std"; \
+	false; \
+}
 
 all: $(IMAGE_TAR)
 
@@ -15,8 +23,9 @@ $(IMAGE_TAR): Dockerfile $(APP_MAPPER_EXE) db/Dockerfile db/schema.sql
 	$(SUDO) docker save $(APP_MAPPER_IMAGE):latest $(APP_MAPPER_DB_IMAGE):latest > $@
 
 $(APP_MAPPER_EXE): *.go
-	go get -d ./...
-	go build -ldflags "-extldflags \"-static\" -linkmode=external" -o $@ ./$(@D)
+	go get -d -tags netgo ./...
+	go build -ldflags "-extldflags \"-static\" -linkmode=external" -tags netgo -o $@ ./$(@D)
+	$(NETGO_CHECK)
 
 integration-test:
 	script/integration-test.sh

--- a/circle.yml
+++ b/circle.yml
@@ -19,6 +19,8 @@ dependencies:
     - rm -rf /usr/local/go; curl -s https://storage.googleapis.com/golang/go1.5.1.linux-amd64.tar.gz | tar xz -C /usr/local
     - mkdir -p $TOOLS
     - git clone https://github.com/weaveworks/tools.git $TOOLS
+    - go clean -i net
+    - go install -tags netgo std
     - mkdir -p $(dirname $SRCDIR)
     - cp -r $(pwd)/ $SRCDIR
     - cd $SRCDIR; make

--- a/users/Makefile
+++ b/users/Makefile
@@ -4,6 +4,14 @@ IMAGE_TAR=image.tar
 IMAGE_NAME=weaveworks/users
 USERS_EXE=users
 ENV=development
+NETGO_CHECK=@strings $@ | grep cgo_stub\\\.go >/dev/null || { \
+	rm $@; \
+	echo "\nYour go standard library was built without the 'netgo' build tag."; \
+	echo "To fix that, run"; \
+	echo "    sudo go clean -i net"; \
+	echo "    sudo go install -tags netgo std"; \
+	false; \
+}
 DB_IMAGE_TAR=db_image.tar
 DB_IMAGE_NAME=weaveworks/db_image
 
@@ -17,9 +25,10 @@ $(IMAGE_TAR): Dockerfile templates/* $(USERS_EXE) db/* ca-certificates.crt
 ca-certificates.crt: /etc/ssl/certs/ca-certificates.crt
 	cp $? $@
 
-$(USERS_EXE): *.go
-	go get -d ./...
-	go build -ldflags "-extldflags \"-static\" -linkmode=external" -o $@ ./$(@D)
+$(USERS_EXE): *.go names/*.go
+	go get -d -tags netgo ./...
+	go build -tags netgo -ldflags "-extldflags \"-static\" -linkmode=external" -o $@ ./$(@D)
+	$(NETGO_CHECK)
 
 test:
 	go test ./...


### PR DESCRIPTION
Because otherwise DNS does not work from the go apps (users, in
particular).
