### PR TITLE
Increase replicas of services in dev and prod.

### DIFF
--- a/terraform/app-mapper.tf
+++ b/terraform/app-mapper.tf
@@ -4,7 +4,7 @@ resource "docker_image" "appmapper" {
 }
 
 resource "docker_container" "appmapper" {
-    count = 1
+    count = "${var.appmapper_count}"
     image = "${docker_image.appmapper.latest}"
     name = "appmapper${count.index+1}"
     hostname = "app-mapper"

--- a/terraform/client.tf
+++ b/terraform/client.tf
@@ -4,7 +4,7 @@ resource "docker_image" "ui-server" {
 }
 
 resource "docker_container" "ui-server" {
-    count = 1
+    count = "${var.uiserver_count}"
     image = "${docker_image.ui-server.latest}"
     name = "ui-server${count.index+1}"
     hostname = "ui-server"

--- a/terraform/dev.tfvars
+++ b/terraform/dev.tfvars
@@ -8,3 +8,9 @@ appmapper_docker_host = "tcp://swarm-master.weave.local:4567"
 
 # Disable dev containers
 dev_containers_count = 0
+
+# Run one frontend per host
+frontend_count = 3
+appmapper_count = 2
+uiserver_count = 2
+users_count = 2

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -11,3 +11,6 @@ dev_containers_count = 0
 
 # Run one frontend per host
 frontend_count = 3
+appmapper_count = 2
+uiserver_count = 2
+users_count = 2

--- a/terraform/users.tf
+++ b/terraform/users.tf
@@ -4,7 +4,7 @@ resource "docker_image" "users" {
 }
 
 resource "docker_container" "users" {
-    count = 1
+    count = "${var.users_count}"
     image = "${docker_image.users.latest}"
     name = "users${count.index+1}"
     hostname = "users"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -25,3 +25,18 @@ variable "frontend_count" {
     description = "Number of replicas of the frontend to deploy"
     default = 1
 }
+
+variable "appmapper_count" {
+    description = "Number of replicas of the appmapper service to deploy"
+    default = 1
+}
+
+variable "users_count" {
+    description = "Number of replicas of the users service to deploy"
+    default = 1
+}
+
+variable "uiserver_count" {
+    description = "Number of replicas of the uiserver to deploy"
+    default = 1
+}


### PR DESCRIPTION
With the changes to deploy.sh (-parallel, pushed straight to master) and the custom terraform build, this should allow us do zero downtime pushes to prod.

These changes have not yet been applied to dev.  We can do that together to convince ourselves that it all works.
