### PR TITLE
Don't allow people to build and push with DOCKER_HOST set.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,9 +3,10 @@
 set -eu
 
 if echo "$DOCKER_HOST" | grep "127.0.0.1" >/dev/null; then
-    echo "!! DOCKER_HOST is set to \"$DOCKER_HOST\" !!"
+    echo "DOCKER_HOST is set to \"$DOCKER_HOST\"!"
+    echo "If you are trying to build for dev/prod, this is probably a mistake."
     while true; do
-        read -p "!! Please confirm you are not building on dev/prod by saying 'yes':" yn
+        read -p "Are you sure you want to continue? " yn
         case $yn in
             yes ) break;;
             no ) exit;;

--- a/push.sh
+++ b/push.sh
@@ -7,9 +7,10 @@ usage() {
 }
 
 if echo "$DOCKER_HOST" | grep "127.0.0.1" >/dev/null; then
-    echo "!! DOCKER_HOST is set to \"$DOCKER_HOST\" !!"
+    echo "DOCKER_HOST is set to \"$DOCKER_HOST\"!"
+    echo "If you are trying to build for dev/prod, this is probably a mistake."
     while true; do
-        read -p "!! Please confirm you are not building on dev/prod by saying 'yes':" yn
+        read -p "Are you sure you want to continue? " yn
         case $yn in
             yes ) break;;
             no ) exit;;


### PR DESCRIPTION
Fixes #178 

This is to make sure one doesn't build or push whilst connected to a dev/prod cluster, which will cause the build to happen remotely, and the push to go from remote->remote, which makes no sense.

How does this affect @peterbourgon & @davkal?  Do you do the build.sh and push.sh steps from your linux box?
