### PR TITLE
Server a static file for ./api

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,5 +7,6 @@ RUN rm /etc/nginx/sites-available/default && \
   ln -sf /dev/stdout /var/log/nginx/access.log && \
   ln -sf /dev/stderr /var/log/nginx/error.log
 COPY default.conf /etc/nginx/conf.d/
+COPY api.json /home/weave/
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -5,7 +5,7 @@ IMAGE_NAME=quay.io/weaveworks/frontend
 
 all: $(IMAGE_UPTODATE)
 
-$(IMAGE_UPTODATE): Dockerfile default.conf
+$(IMAGE_UPTODATE): Dockerfile default.conf api.json
 	docker build -t $(IMAGE_NAME) .
 	touch $@
 

--- a/frontend/api.json
+++ b/frontend/api.json
@@ -1,0 +1,1 @@
+{"id": "sccopeservice", "version": "0.1"}

--- a/frontend/default.conf
+++ b/frontend/default.conf
@@ -37,6 +37,10 @@ server {
         proxy_pass http://app-mapper.weave.local$request_uri;
     }
 
+    location =/api {
+        alias /home/weave/api.json;
+    }
+
     location /api/app/ {
         proxy_pass http://app-mapper.weave.local$request_uri;
     }


### PR DESCRIPTION
Fixes #180

This is a temporary fix until we can send the token from the probe when fetching /api.
