### PR TITLE
Fixing up some bits of the circle tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,7 +33,9 @@ test:
     - cd $SRCDIR; $TOOLS/lint .
     - cd $SRCDIR; $TOOLS/test
     - cd $SRCDIR/users; make
+    - cd $SRCDIR/users; make test
     - cd $SRCDIR/app-mapper; make
+    - cd $SRCDIR/app-mapper; make test
     - cd $SRCDIR/frontend; make
     - cd $SRCDIR/client; make RM= tests
     - cd $SRCDIR/client; make RM=


### PR DESCRIPTION
We were having some trouble removing the old go1.4 gubbins, and weren't running the unit tests for users and app-mapper.
