### PR TITLE
Enable RDS automatic backups

### DIFF
--- a/infra/rds.template
+++ b/infra/rds.template
@@ -125,7 +125,8 @@ resource "aws_db_instance" "users_database" {
     password = "${var.users_db_password}"
     vpc_security_group_ids = ["${aws_security_group.rds_sg.id}"]
     final_snapshot_identifier = "users-final"
-    backup_retention_period = 3
+    backup_retention_period = 5
+    apply_immediately = true
 }
 
 resource "aws_db_instance" "app_mapper_database" {
@@ -139,5 +140,6 @@ resource "aws_db_instance" "app_mapper_database" {
     password = "${var.app_mapper_db_password}"
     vpc_security_group_ids = ["${aws_security_group.rds_sg.id}"]
     final_snapshot_identifier = "app-mapper-final"
-    backup_retention_period = 3
+    backup_retention_period = 5
+    apply_immediately = true
 }


### PR DESCRIPTION
@peterbourgon PTAL

I have tested this in the dev environment by doing

```
cd infra/
./tfgen dev
./rds up dev # this kind of stuff is why I think the up command should really be called apply
```

As a result the dev databases have queued the change for the next maintenance window (tomorrow morning between 7:26 and 7:56) . See [this blog post](https://aws.amazon.com/blogs/aws/amazon-rds-maintenance-windows-shortened/) and [documentation](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithAutomatedBackups.html) for details on what that means. 

<img width="1219" alt="screen shot 2015-12-02 at 6 07 17 pm" src="https://cloud.githubusercontent.com/assets/2362916/11539674/3ee32fcc-9920-11e5-8838-f6bb375a023d.png">

We could use the [`apply_immediately`](https://www.terraform.io/docs/providers/aws/r/db_instance.html) parameter if we don't want to wait for the maintenance window to apply the changes (I am not sure what's the advantage of waiting in this particular case)

Fixes #237 
