### PR TITLE
Set Docker log level to warn

### DIFF
--- a/infra/k8s
+++ b/infra/k8s
@@ -38,6 +38,7 @@ function export_variables {
 	export NUM_MINIONS="${K8S_NUM_MINIONS}"
 	export KUBE_AWS_INSTANCE_PREFIX="${K8S_INSTANCE_PREFIX}"
 	export KUBE_ENABLE_DAEMONSETS="true"
+	export KUBE_DOCKER_LOG_LEVEL="warn"
 }
 
 function ensure_release {


### PR DESCRIPTION
Depends on https://github.com/peterbourgon/kubernetes/pull/1

This will fix #261 for newly created clusters, but not for the existing ones, since the docker cmdline flags are configured based on variable 'DOCKER_OPTS' as part of the AWS Launch-configuration User Data of the cluster, which is not editable.

Note that this is fixed upstream since v1.2.0-alpha.2 , in which the log level of docker defaults to `warn`: https://github.com/kubernetes/kubernetes/pull/15728

@peterbourgon PTAL
