### PR TITLE
Fix alert rules to exclude metrics scraped via the kubeproxy

### DIFF
--- a/monitoring/prometheus/alert.rules
+++ b/monitoring/prometheus/alert.rules
@@ -1,26 +1,26 @@
 ALERT AppMapperErrorRate
- IF          sum(rate( scope_appmapper_request_duration_nanoseconds_count{status_code !~ "[1234][0-9][0-9]"}[1m] )) > 1.0
+ IF          sum(rate( scope_appmapper_request_duration_nanoseconds_count{status_code !~ "[1234][0-9][0-9]", kubernetes_role="endpoint"}[1m] )) > 1.0
  FOR         5m
  WITH        { severity="critical" }
  SUMMARY     "app-mapper service: high error rate"
  DESCRIPTION "The app-mapper service has an error rate (response code >= 500) of {{$value}} errors per second."
 
 ALERT UsersErrorRate
- IF          sum(rate( scope_users_request_duration_nanoseconds_count{status_code !~ "[1234][0-9][0-9]"}[1m] )) > 1.0
+ IF          sum(rate( scope_users_request_duration_nanoseconds_count{status_code !~ "[1234][0-9][0-9]", kubernetes_role="endpoint"}[1m] )) > 1.0
  FOR         5m
  WITH        { severity="critical" }
  SUMMARY     "users service: high error rate"
  DESCRIPTION "The users service has an error rate (response code >= 500) of {{$value}} errors per second."
 
 ALERT AppMapper4xxRate
- IF          sum(rate( scope_appmapper_request_duration_nanoseconds_count{status_code =~ "4[0-9][0-9]"}[1m] )) > 1.0
+ IF          sum(rate( scope_appmapper_request_duration_nanoseconds_count{status_code =~ "4[0-9][0-9]", kubernetes_role="endpoint"}[1m] )) > 1.0
  FOR         5m
  WITH        { severity="warning" }
  SUMMARY     "app-mapper service: high 4xx rate"
  DESCRIPTION "The app-mapper service has a 4xx rate of {{$value}} errors per second."
 
 ALERT Users4xxRate
- IF          sum(rate( scope_users_request_duration_nanoseconds_count{status_code =~ "4[0-9][0-9]"}[1m] )) > 1.0
+ IF          sum(rate( scope_users_request_duration_nanoseconds_count{status_code =~ "4[0-9][0-9]", kubernetes_role="endpoint"}[1m] )) > 1.0
  FOR         5m
  WITH        { severity="warning" }
  SUMMARY     "users service: high 4xx rate"
@@ -30,14 +30,14 @@ ALERT Users4xxRate
 # https://github.com/prometheus/prometheus/issues/1289
 
 ALERT AppMapperLatency
- IF          max(sort_desc( scope_appmapper_request_duration_nanoseconds{route!="api_control", route!="api_app_topology_ws", route!="api_app_pipe", route!="api_probe_pipe", status_code="200", quantile="0.9"}/1e6 )) > 5000.0
+ IF          max(sort_desc( scope_appmapper_request_duration_nanoseconds{route!="api_control", route!="api_app_topology_ws", route!="api_app_pipe", route!="api_probe_pipe", status_code="200", quantile="0.9", kubernetes_role="endpoint"}/1e6 )) > 5000.0
  FOR         5m
  WITH        { severity="warning" }
  SUMMARY     "app-mapper service: high latency"
  DESCRIPTION "The app-mapper service has a max 90th-quantile latency of {{$value}} ms."
 
 ALERT UsersLatency
- IF          max(sort_desc( scope_users_request_duration_nanoseconds{status_code="200", quantile="0.9"}/1e6 )) > 5000.0
+ IF          max(sort_desc( scope_users_request_duration_nanoseconds{status_code="200", quantile="0.9", kubernetes_role="endpoint"}/1e6 )) > 5000.0
  FOR         5m
  WITH        { severity="warning" }
  SUMMARY     "users service: high latency"


### PR DESCRIPTION
Fixes #320 
