### PR TITLE
Recreate accidently deleted ELB

### DIFF
--- a/infra/dev/tfstate
+++ b/infra/dev/tfstate
@@ -1,6 +1,6 @@
 {
     "version": 1,
-    "serial": 16,
+    "serial": 17,
     "modules": [
         {
             "path": [
@@ -134,9 +134,9 @@
                         "id": "Z12AMLFW9TRQPN_frontend.dev.weave.works_A",
                         "attributes": {
                             "alias.#": "1",
-                            "alias.1311589414.evaluate_target_health": "false",
-                            "alias.1311589414.name": "a41e2c423dad111e5aafc12d46bad2ae-287976260.us-east-1.elb.amazonaws.com",
-                            "alias.1311589414.zone_id": "Z3DZXE0Q79N41H",
+                            "alias.3126433601.evaluate_target_health": "false",
+                            "alias.3126433601.name": "a67d06bd3f08611e5aafc12d46bad2ae-1433816556.us-east-1.elb.amazonaws.com",
+                            "alias.3126433601.zone_id": "Z3DZXE0Q79N41H",
                             "failover": "",
                             "fqdn": "frontend.dev.weave.works",
                             "health_check_id": "",

--- a/infra/dev/tfvars
+++ b/infra/dev/tfvars
@@ -13,5 +13,5 @@ users_db_password = "us45dcd40163798d"
 
 route53_zone_name = "dev.weave.works"
 route53_resource_name = "frontend.dev.weave.works"
-route53_frontend_elb_endpoint = "a41e2c423dad111e5aafc12d46bad2ae-287976260.us-east-1.elb.amazonaws.com"
+route53_frontend_elb_endpoint = "a67d06bd3f08611e5aafc12d46bad2ae-1433816556.us-east-1.elb.amazonaws.com"
 route53_frontend_elb_zone_id = "Z3DZXE0Q79N41H"


### PR DESCRIPTION
While testing latest Kubernetes Anywhere stuff (v1.2 + CNI), I've had to manually garbage-collect a dozen of ELBs in dev account and accidentally deleted one that `frontend.dev.weave.works` was pointing too. Here is the fix, and the good news is that we can go with Kubernetes Anywhere to production as soon as we would like, it's ready for most part and fully supports v1.2 now.
