### PR TITLE
For local dev, set the pull policy on scope components to IfNotPresent

### DIFF
--- a/k8s/local/authfe-rc.yaml
+++ b/k8s/local/authfe-rc.yaml
@@ -14,6 +14,7 @@ spec:
       containers:
       - name: authfe
         image: quay.io/weaveworks/authfe
+        imagePullPolicy: IfNotPresent
         args:
         - -log.level=debug
         ports:

--- a/k8s/local/collection-rc.yaml
+++ b/k8s/local/collection-rc.yaml
@@ -14,6 +14,7 @@ spec:
       containers:
       - name: collection
         image: weaveworks/scope
+        imagePullPolicy: IfNotPresent
         args:
         - --no-probe
         - --app.log.http=true

--- a/k8s/local/consul-rc.yaml
+++ b/k8s/local/consul-rc.yaml
@@ -14,6 +14,7 @@ spec:
       containers:
       - name: consul
         image: progrium/consul
+        imagePullPolicy: IfNotPresent
         args:
         - -server
         - -bootstrap

--- a/k8s/local/control-rc.yaml
+++ b/k8s/local/control-rc.yaml
@@ -14,6 +14,7 @@ spec:
       containers:
       - name: control
         image: weaveworks/scope
+        imagePullPolicy: IfNotPresent
         args:
         - --no-probe
         - --app.log.http=true

--- a/k8s/local/db/dynamodb-rc.yaml
+++ b/k8s/local/db/dynamodb-rc.yaml
@@ -14,5 +14,6 @@ spec:
       containers:
       - name: dynamodb
         image: deangiberson/aws-dynamodb-local
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8000

--- a/k8s/local/db/sqs-rc.yaml
+++ b/k8s/local/db/sqs-rc.yaml
@@ -14,5 +14,6 @@ spec:
       containers:
       - name: sqs
         image: pakohan/elasticmq
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9324

--- a/k8s/local/db/users-db-rc.yaml
+++ b/k8s/local/db/users-db-rc.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
       - name: users-db
         image: weaveworks/users-db
+        imagePullPolicy: IfNotPresent
         command:
         ports:
         - containerPort: 5432

--- a/k8s/local/frontend-rc.yaml
+++ b/k8s/local/frontend-rc.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
       - name: frontend
         image: quay.io/weaveworks/frontend
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         - containerPort: 443

--- a/k8s/local/monitoring-rc.yaml
+++ b/k8s/local/monitoring-rc.yaml
@@ -16,18 +16,23 @@ spec:
       containers:
       - name: prometheus
         image: quay.io/weaveworks/prometheus
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9090
       - name: grafana
         image: quay.io/weaveworks/grafana
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000
       - name: gfdatasource
         image: quay.io/weaveworks/gfdatasource
+        imagePullPolicy: IfNotPresent
       - name: loadgen
         image: quay.io/weaveworks/loadgen
+        imagePullPolicy: IfNotPresent
       - name: alertmanager
         image: quay.io/weaveworks/alertmanager
+        imagePullPolicy: IfNotPresent
         command:
         - /alertmanager/alertmanager
         - -config.file=/etc/alertmanager/alertmanager-local.yml

--- a/k8s/local/pipe-rc.yaml
+++ b/k8s/local/pipe-rc.yaml
@@ -14,6 +14,7 @@ spec:
       containers:
       - name: pipe
         image: weaveworks/scope
+        imagePullPolicy: IfNotPresent
         args:
         - --no-probe
         - --app.log.http=true

--- a/k8s/local/query-rc.yaml
+++ b/k8s/local/query-rc.yaml
@@ -14,6 +14,7 @@ spec:
       containers:
       - name: query
         image: weaveworks/scope
+        imagePullPolicy: IfNotPresent
         args:
         - --no-probe
         - --app.log.http=true

--- a/k8s/local/scope/scope-app-rc.yaml
+++ b/k8s/local/scope/scope-app-rc.yaml
@@ -14,6 +14,7 @@ spec:
     spec:
       containers:
       - name: weave-scope-app
+        imagePullPolicy: IfNotPresent
         image: weaveworks/scope
         env:
         - name: CHECKPOINT_DISABLE

--- a/k8s/local/scope/scope-probe-ds.yaml
+++ b/k8s/local/scope/scope-probe-ds.yaml
@@ -18,6 +18,7 @@ spec:
       containers:
       - name:  weave-scope-probe
         image: weaveworks/scope
+        imagePullPolicy: IfNotPresent
         env:
         - name: CHECKPOINT_DISABLE
           value: "true"

--- a/k8s/local/ui-server-rc.yaml
+++ b/k8s/local/ui-server-rc.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
       - name: ui-server
         image: quay.io/weaveworks/ui-server
+        imagePullPolicy: IfNotPresent
         command:
         ports:
         - containerPort: 80

--- a/k8s/local/users-rc.yaml
+++ b/k8s/local/users-rc.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
       - name: users
         image: quay.io/weaveworks/users
+        imagePullPolicy: IfNotPresent
         args:
         - -session-secret=9334f0f44a271d686714c475b093a133fab81f90536b0de6a231af7dc78cb56e
         - -email-uri=smtp://mailcatcher:587


### PR DESCRIPTION
Seems to have been a change in defaults with the move to 1.2 in local; k8s will now always pull the image from docker hub, making the dev/test cycle harder.  This fixes that.
