### PR TITLE
Improve authfe monitoring & add flag to users to skip approval.

### DIFF
--- a/authfe/main.go
+++ b/authfe/main.go
@@ -21,7 +21,7 @@ var (
 		Subsystem: "authfe",
 		Name:      "request_duration_nanoseconds",
 		Help:      "Time spent serving HTTP requests.",
-	}, []string{"method", "route", "status_code"})
+	}, []string{"method", "route", "status_code", "ws"})
 	wsConnections = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "scope",
 		Subsystem: "authfe",
@@ -79,11 +79,11 @@ func main() {
 
 	// orgRouter is for all ui <-> app communication, authenticated using cookie credentials
 	orgRouter := mux.NewRouter().StrictSlash(false)
-	orgRouter.PathPrefix("/api").Name("api_app").Handler(queryFwd)
 	orgRouter.PathPrefix("/api/report").Name("api_app_report").Handler(queryFwd)
 	orgRouter.PathPrefix("/api/topology").Name("api_app_topology").Handler(queryFwd)
 	orgRouter.PathPrefix("/api/control").Name("api_app_control").Handler(contolFwd)
 	orgRouter.PathPrefix("/api/pipe").Name("api_app_pipe").Handler(pipeFwd)
+	orgRouter.PathPrefix("/").Name("api_app").Handler(queryFwd) // catch all forward to query service, for /api and static html
 
 	// probeRouter is for all probe <-> app communication, authenticated using header credentials
 	probeRouter := mux.NewRouter().StrictSlash(false)

--- a/users/integration_test.go
+++ b/users/integration_test.go
@@ -29,7 +29,7 @@ func setup(t *testing.T) {
 	// TODO: Use some more realistic mailer here
 	sentEmails = nil
 
-	var directLogin = false
+	var directLogin, approvalRequired = false, true
 
 	setupLogging("debug")
 	storage = mustNewDatabase(*databaseURI)
@@ -39,7 +39,7 @@ func setup(t *testing.T) {
 	truncateDatabase(t)
 
 	emailer := smtpEmailer{templates, testEmailSender, domain}
-	app = newAPI(directLogin, emailer, sessions, storage, templates)
+	app = newAPI(directLogin, approvalRequired, emailer, sessions, storage, templates)
 }
 
 func cleanup(t *testing.T) {

--- a/users/unit_test.go
+++ b/users/unit_test.go
@@ -20,7 +20,7 @@ var (
 func setup(t *testing.T) {
 	passwordHashingCost = bcrypt.MinCost
 
-	var directLogin = false
+	var directLogin, approvalRequired = false, true
 
 	setupLogging("debug")
 	storage = mustNewDatabase("memory://")
@@ -29,7 +29,7 @@ func setup(t *testing.T) {
 
 	sentEmails = nil
 	emailer := smtpEmailer{templates, testEmailSender, domain}
-	app = newAPI(directLogin, emailer, sessions, storage, templates)
+	app = newAPI(directLogin, approvalRequired, emailer, sessions, storage, templates)
 }
 
 func cleanup(t *testing.T) {

--- a/vendor/github.com/weaveworks/scope/common/middleware/logging.go
+++ b/vendor/github.com/weaveworks/scope/common/middleware/logging.go
@@ -30,10 +30,14 @@ var Logging = Func(func(next http.Handler) http.Handler {
 type interceptor struct {
 	http.ResponseWriter
 	statusCode int
+	recorded   bool
 }
 
 func (i *interceptor) WriteHeader(code int) {
-	i.statusCode = code
+	if !i.recorded {
+		i.statusCode = code
+		i.recorded = true
+	}
 	i.ResponseWriter.WriteHeader(code)
 }
 

--- a/vendor/github.com/weaveworks/scope/common/middleware/path_rewrite.go
+++ b/vendor/github.com/weaveworks/scope/common/middleware/path_rewrite.go
@@ -21,6 +21,7 @@ type pathRewrite struct {
 func (p pathRewrite) Wrap(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		r.RequestURI = p.regexp.ReplaceAllString(r.RequestURI, p.replacement)
+		r.URL.Path = p.regexp.ReplaceAllString(r.RequestURI, p.replacement)
 		next.ServeHTTP(w, r)
 	})
 }

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -589,7 +589,7 @@
 			"importpath": "github.com/weaveworks/scope/common/middleware",
 			"repository": "https://github.com/weaveworks/scope",
 			"vcs": "git",
-			"revision": "7631116ff52c37c863e7938b74633a87f294d631",
+			"revision": "d13784092b8cff3df6d533eb9d0d90a5d6b8a829",
 			"branch": "master",
 			"path": "/common/middleware",
 			"notests": true


### PR DESCRIPTION
- Improve authfe monitoring by adding field to instrumentation to differentiate websocket connections
- Vendor in up to date scope middleware
- Add `--approval-required` flag to users, default true.

(From #352)
