### PR TITLE
Pin to a specific tag of KA toolbox image and respect `WEAVE_VERSION`

### DIFF
--- a/infra/local-k8s
+++ b/infra/local-k8s
@@ -17,7 +17,7 @@ fi
 
 mode="$1"
 
-version="${LOCAL_K8S_VERSION:-"v1.2"}"
+toolbox="${TOOLBOX_IMAGE:-"weaveworks/kubernetes-anywhere:toolbox-v1.2.4-6c14c77"}"
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 local_k8s_dir="${script_dir}/../k8s/local"
@@ -57,7 +57,7 @@ function write_kubeconfig {
         docker run --rm --tty \
           --env=APISERVER_LOCAL_PORT \
           --volumes-from=kube-toolbox-pki \
-          "weaveworks/kubernetes-anywhere:toolbox-${version}" \
+          "${toolbox}" \
             print-local-config > "${kubeconfig}"
 
         if check_docker_machine
@@ -79,8 +79,8 @@ function remove_kubeconfig {
 }
 
 function pull_toolbox() {
-        [ "$(docker images -q "weaveworks/kubernetes-anywhere:toolbox-${version}" | wc -l)" -eq 1 ] \
-          || docker pull "weaveworks/kubernetes-anywhere:toolbox-${version}"
+        [ "$(docker images -q "${toolbox}" | wc -l)" -eq 1 ] \
+          || docker pull "${toolbox}"
 }
 
 function tear_down {
@@ -89,7 +89,7 @@ function tear_down {
         docker run --rm --tty \
           --volume="/:/rootfs" \
           --volume="/var/run/docker.sock:/docker.sock" \
-            "weaveworks/kubernetes-anywhere:toolbox-${version}" \
+            "${toolbox}" \
               reset-single-node > /dev/null 2>&1
         remove_kubeconfig
         local -a -r apps=($(docker ps -q -f 'name=k8s_*'))
@@ -151,14 +151,15 @@ function stand_up {
         docker run --rm --tty \
           --volume="/:/rootfs" \
           --volume="/var/run/weave/weave.sock:/docker.sock" \
-            "weaveworks/kubernetes-anywhere:toolbox-${version}" \
+            "${toolbox}" \
               setup-single-node
 
         docker run --rm --tty \
           --env=APISERVER_LOCAL_BIND \
           --env=APISERVER_LOCAL_PORT \
+          --env=WEAVE_VERSION \
           --volume="/var/run/weave/weave.sock:/docker.sock" \
-            "weaveworks/kubernetes-anywhere:toolbox-${version}" \
+            "${toolbox}" \
               compose -p kube up -d
 
         write_kubeconfig


### PR DESCRIPTION
his particular version allows one to set `WEAVE_VERSION` and use  that to test latest build etc (see https://github.com/weaveworks/kubernetes-anywhere/pull/93, the image with this is on Docker Hub already).

To use latest build of Weave Net, one can do this now:

```
infra/local-k8s down
weave reset
docker pull weaveworks/weave:latest
docker pull weaveworks/weaveexec:latest
docker pull weaveworks/plugin:latest
env WEAVE_VERSION=latest infra/local-k8s up
```
