### PR TITLE
add -email-uri log:// for david's local development

### DIFF
--- a/users/main.go
+++ b/users/main.go
@@ -27,7 +27,7 @@ func main() {
 		port          = flag.Int("port", 80, "port to listen on")
 		domain        = flag.String("domain", "https://scope.weave.works", "domain where scope service is runnning.")
 		databaseURI   = flag.String("database-uri", "postgres://postgres@users-db.weave.local/users?sslmode=disable", "URI where the database can be found (for dev you can use memory://)")
-		emailURI      = flag.String("email-uri", "", "uri of smtp server to send email through, of the format: smtp://username:password@hostname:port.  Either email-uri or sendgrid-api-key must be provided.")
+		emailURI      = flag.String("email-uri", "", "uri of smtp server to send email through, of the format: smtp://username:password@hostname:port.  Either email-uri or sendgrid-api-key must be provided. For local development, you can set this to: log://, which will log all emails.")
 		logLevel      = flag.String("log-level", "info", "logging level (debug, info, warning, error)")
 		sessionSecret = flag.String("session-secret", "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "Secret used validate sessions")
 		directLogin   = flag.Bool("direct-login", false, "Approve user and send login token in the signup response (DEV only)")


### PR DESCRIPTION
Lets you launch the users service locally with: `./users -email-uri log:// -port 8080 --database-uri memory:// --direct-login`

Logs look like:

```
paulbellamy@Pauls-MacBook-Pro:service/users » ./users -email-uri log:// -port 12345 --database-uri memory://
INFO[0000] Listening on port 12345
INFO[0005] [Email] From: "Scope Support <support@weave.works>", To: ["paul.a.bellamy@gmail.com"], Subject: "Welcome to Scope", Body:
Thanks for your interest in the Weave Scope Early Access Program!

You've been added to the program waitlist, and our team is working hard to review and select participants. If a spot opens up, we'll send you an invitation and instructions for activating your new account.

In the meantime, learn more about Weave Scope on our website[1]. Our blog features guest posts from the community describing their Scope use cases (cool examples here[2], here[3], and plenty more!), or dive in and start building your Docker app using Weave on Amazon ECS in this step-by-step Getting Started Guide[4].

Thank you for being a valued member of the Weaveworks community!

The @weaveworks team

----

[1] http://weave.works/scope/
[2] http://blog.weave.works/2015/08/04/using-weave-scope-with-calico-networking/
[3] http://blog.weave.works/2015/09/18/using-weave-and-scope-with-convox/
[4] http://weave.works/guides/service-discovery-with-weave-aws-ecs.html

INFO[0005] /api/users/signup: POST api_users_signup (200) 1.284580511s
```
