### PR TITLE
Dont pass service history state to iframe

### DIFF
--- a/client/src/router.jsx
+++ b/client/src/router.jsx
@@ -13,7 +13,7 @@ import RouterComponent from './components/router';
 export default function getRoutes() {
   return (
     <Route name="app" path="/" component={RouterComponent}>
-      <Route name="wrapper" path="app/:orgId(/state/:state)" component={WrapperPage} />
+      <Route name="wrapper" path="app/:orgId" component={WrapperPage} />
       <Route name="organization" path="org/:orgId" component={OrganizationPage} />
       <Route component={LandingPage}>
         <IndexRoute component={CookieCheck} />


### PR DESCRIPTION
- this prevents re-renders
- service state was useless to scope (parse error), and caused a lag
  since it still triggered a route event in scope

Fixes #393
