### PR TITLE
A service which periodically runs kubediff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ app-mapper/app-mapper
 users/users
 users/db/migrate
 authfe/authfe
+kubediff/prom-run
 Vagrantfile.local
 .dir-locals.el
 image.tar

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Monitoring
 Management
 - [Consul UI](http://consul.default.svc.cluster.local:8500)
 - [Users Service](http://users.default.svc.cluster.local:80)
+- [Kubediff](http://kubediff.default.svc.cluster.local:80)
 
 ## Prerequisites
 

--- a/k8s/kubediff
+++ b/k8s/kubediff
@@ -55,8 +55,7 @@ def check_file(path):
   try:
     running = subprocess.check_output(["kubectl", "get"] + args + [kind, name], stderr=subprocess.STDOUT)
   except subprocess.CalledProcessError, e:
-    print " *** %s" % e.output
-    failed = True
+    check(False, " *** %s", e.output)
     return
 
   running = yaml.load(running)
@@ -92,4 +91,3 @@ supply the kubeconfig for the appropriate environment.""")
 
   if failed:
     sys.exit(2)
-

--- a/k8s/local/kubediff-rc.yaml
+++ b/k8s/local/kubediff-rc.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: kubediff
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: kubediff
+    spec:
+      volumes:
+      - name: repo
+        emptyDir: {}
+      containers:
+      - name: git-sync
+        # Images should be built by us, of from official docker hubs build.
+        # These is an official google build of git-sync, but its out of date
+        # wrt private repos.  Also git-sync is a pain to integrate with our
+        # build (uses godeps etc).  So for not, use a pinned custom built
+        # version.
+        image: tomwilkie/git-sync:f6165715ce9d
+        args:
+          - -repo=https://github.com/weaveworks/service
+          - -wait=60
+          - -dest=/data/service
+        env:
+        - name: GIT_SYNC_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: kubediff-secret
+              key: username
+        - name: GIT_SYNC_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: kubediff-secret
+              key: password
+        volumeMounts:
+        - name: repo
+          mountPath: /data
+      - name: prom-run
+        image: quay.io/weaveworks/kubediff
+        imagePullPolicy: IfNotPresent
+        args:
+        - -period=60s
+        - -listen-addr=:80
+        - /data/service/k8s/kubediff /data/service/k8s/local
+        volumeMounts:
+        - name: repo
+          mountPath: /data
+        ports:
+        - containerPort: 80
+

--- a/k8s/local/kubediff-secret.yaml
+++ b/k8s/local/kubediff-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubediff-secret
+type: Opaque
+data:
+  username: dG9td2lsa2ll
+  password: YmIyYTZkYjI2ZmYxYWVhNTM1NzhlNTdjNjc0ZTcwYjgwZTk2NGZiYQ==
+

--- a/k8s/local/kubediff-svc.yaml
+++ b/k8s/local/kubediff-svc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubediff
+spec:
+  ports:
+    - port: 80
+      name: http
+  selector:
+    name: kubediff

--- a/kubediff/Dockerfile
+++ b/kubediff/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine
+MAINTAINER Weaveworks Inc <help@weave.works>
+RUN apk update && \
+   apk add py-yaml curl && \
+   curl -o /bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.2.4/bin/linux/amd64/kubectl && \
+   chmod u+x /bin/kubectl
+WORKDIR /
+COPY prom-run /
+EXPOSE 80
+ENTRYPOINT ["/prom-run"]

--- a/vendor/github.com/tomwilkie/prom-run/main.go
+++ b/vendor/github.com/tomwilkie/prom-run/main.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"html/template"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	statusCode = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "command_exit_code",
+		Help: "Exit code of command.",
+	})
+	commandDuration = prometheus.NewSummary(prometheus.SummaryOpts{
+		Name: "command_duration_seconds",
+		Help: "Time spent running command.",
+	})
+)
+
+func main() {
+	var (
+		period     = flag.Duration("period", 10*time.Second, "Period with which to run the command.")
+		listenAddr = flag.String("listen-addr", ":9152", "Address to listen on")
+	)
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s (options) command...\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+	if len(flag.Args()) <= 0 {
+		flag.Usage()
+		os.Exit(2)
+	}
+	command := flag.Args()[0]
+	args := flag.Args()[1:]
+
+	var (
+		outputLock      sync.Mutex
+		outputBuf       []byte
+		lastRunStart    time.Time
+		lastRunDuration time.Duration
+		withLock        = func(f func()) {
+			outputLock.Lock()
+			defer outputLock.Unlock()
+			f()
+		}
+	)
+
+	go func() {
+		for range time.Tick(*period) {
+			log.Printf("Running '%s' with argments %v", command, args)
+			start := time.Now()
+			out, err := exec.Command(command, args...).CombinedOutput()
+			duration := time.Now().Sub(start)
+			commandDuration.Observe(duration.Seconds())
+
+			withLock(func() {
+				lastRunStart = start
+				lastRunDuration = duration
+				outputBuf = out
+			})
+
+			if err != nil {
+				if exiterr, ok := err.(*exec.ExitError); ok {
+					if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+						code := status.ExitStatus()
+						log.Printf("Command exited with code: %d", code)
+						statusCode.Set(float64(code))
+						continue
+					}
+				}
+				log.Printf("Error running command: %v", err)
+				statusCode.Set(255)
+				continue
+			}
+
+			log.Printf("Command exited successfully")
+			statusCode.Set(0)
+		}
+	}()
+
+	tmpl, err := template.New("index").Parse(`<html>
+	<head><title>Prometheus Command Runner</title></head>
+	<body>
+	  <h2>Prometheus Command Runner</h2>
+	  <p>"{{.Command}}" output:</p>
+	  <pre>{{.Output}}</pre>
+	  <p>Run at {{.Time}} took {{.Duration}}<p>
+	</body>
+	</html>`)
+	if err != nil {
+		log.Fatalf("Failed to parse template: %v", err)
+	}
+
+	prometheus.MustRegister(statusCode)
+	prometheus.MustRegister(commandDuration)
+	http.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		withLock(func() {
+			tmpl.Execute(w, struct {
+				Command, Output string
+				Time            time.Time
+				Duration        time.Duration
+			}{
+				Command:  command + " " + strings.Join(args, " "),
+				Output:   string(outputBuf),
+				Time:     lastRunStart,
+				Duration: lastRunDuration,
+			})
+		})
+	}))
+	http.Handle("/metrics", prometheus.Handler())
+
+	log.Printf("Listening on address %s", *listenAddr)
+	http.ListenAndServe(*listenAddr, nil)
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -482,6 +482,14 @@
 			"path": "/require"
 		},
 		{
+			"importpath": "github.com/tomwilkie/prom-run",
+			"repository": "https://github.com/tomwilkie/prom-run",
+			"vcs": "git",
+			"revision": "fe36d85588336c8183ab0306d2d578a1dffb423e",
+			"branch": "master",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/ugorji/go/codec",
 			"repository": "https://github.com/ugorji/go",
 			"vcs": "",


### PR DESCRIPTION
`kubediff` is a little script which tells us if the checked-in k8s config matches what is running.

This service maintains a checkout of the service report (updated every 60s) and runs `kubediff` every 60s.  The exist status of `kubediff` is exported as a prometheus metric, and the output of `kubediff` is made available via http/html page on port 80.
