### PR TITLE
Reorg report storage page, break out S3 QPS by status

### DIFF
--- a/monitoring/grafana/reports.json
+++ b/monitoring/grafana/reports.json
@@ -47,7 +47,7 @@
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
-          "span": 12,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -56,14 +56,14 @@
               "intervalFactor": 2,
               "legendFormat": "{{method}} 2xx",
               "refId": "A",
-              "step": 4
+              "step": 10
             },
             {
               "expr": "sum(rate(scope_dynamo_request_duration_nanoseconds_count{method=\"Query\",status_code=~\"5..\"}[1m])) by (method)",
               "intervalFactor": 2,
               "legendFormat": "{{method}} 5xx",
               "refId": "B",
-              "step": 4
+              "step": 10
             }
           ],
           "timeFrom": null,
@@ -96,15 +96,7 @@
               "show": true
             }
           ]
-        }
-      ],
-      "title": "New row"
-    },
-    {
-      "collapse": false,
-      "editable": true,
-      "height": "250px",
-      "panels": [
+        },
         {
           "aliasColors": {},
           "bars": false,
@@ -138,7 +130,7 @@
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
-          "span": 12,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -147,7 +139,7 @@
               "intervalFactor": 2,
               "legendFormat": "{{method}} {{quantile}} quantile",
               "refId": "A",
-              "step": 4
+              "step": 10
             }
           ],
           "timeFrom": null,
@@ -222,7 +214,7 @@
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
-          "span": 12,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -231,7 +223,7 @@
               "intervalFactor": 2,
               "legendFormat": "{{method}}",
               "refId": "A",
-              "step": 4
+              "step": 10
             }
           ],
           "timeFrom": null,
@@ -250,6 +242,82 @@
             {
               "format": "short",
               "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "Scope-as-a-Service Prometheus",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 3,
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(scope_report_size_bytes[1m]))  by (method)",
+              "intervalFactor": 2,
+              "legendFormat": "reports written (compressed)",
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Report Sizes",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": "bytes/s",
               "logBase": 1,
               "max": null,
               "min": null,
@@ -370,90 +438,6 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
-          "id": 3,
-          "isNew": true,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 2,
-          "links": [],
-          "nullPointMode": "connected",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "span": 12,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(rate(scope_report_size_bytes[1m]))  by (method)",
-              "intervalFactor": 2,
-              "legendFormat": "reports written (compressed)",
-              "refId": "A",
-              "step": 4
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Report Sizes",
-          "tooltip": {
-            "msResolution": true,
-            "shared": true,
-            "value_type": "cumulative"
-          },
-          "type": "graph",
-          "xaxis": {
-            "show": true
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "bytes/s",
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ]
-        }
-      ],
-      "title": "New row"
-    },
-    {
-      "collapse": false,
-      "editable": true,
-      "height": "250px",
-      "panels": [
-        {
-          "aliasColors": {},
-          "bars": false,
-          "datasource": "Scope-as-a-Service Prometheus",
-          "editable": true,
-          "error": false,
-          "fill": 1,
-          "grid": {
-            "threshold1": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2": null,
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
           "id": 6,
           "isNew": true,
           "legend": {
@@ -474,16 +458,16 @@
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
-          "span": 12,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(scope_s3_request_duration_nanoseconds_count[1m])) by (method)",
+              "expr": "sum(rate(scope_s3_request_duration_nanoseconds_count[1m])) by (method,status_code)",
               "intervalFactor": 2,
-              "legendFormat": "{{method}}",
+              "legendFormat": "{{method}} {{status_code}}",
               "refId": "A",
-              "step": 4
+              "step": 10
             }
           ],
           "timeFrom": null,
@@ -516,15 +500,7 @@
               "show": true
             }
           ]
-        }
-      ],
-      "title": "New row"
-    },
-    {
-      "collapse": false,
-      "editable": true,
-      "height": "250px",
-      "panels": [
+        },
         {
           "aliasColors": {},
           "bars": false,
@@ -558,7 +534,7 @@
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
-          "span": 12,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -567,7 +543,7 @@
               "intervalFactor": 2,
               "legendFormat": "{{method}} {{quantile}} quantile",
               "refId": "A",
-              "step": 4
+              "step": 10
             }
           ],
           "timeFrom": null,
@@ -602,6 +578,13 @@
           ]
         }
       ],
+      "title": "New row"
+    },
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [],
       "title": "New row"
     }
   ],


### PR DESCRIPTION
Puts rows in for dynamodb qps, latency and s3 qps, latency - as per service dashboard.
