### PR TITLE
Make the git diff part of image-tag optional

### DIFF
--- a/image-tag
+++ b/image-tag
@@ -4,13 +4,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-WORKING_SUFFIX=$(if ! git diff-index --quiet HEAD; then echo "-WIP"; else echo ""; fi)
-
-if [ -n "$WORKING_SUFFIX" ]; then
-    echo "The working directory has uncomitted changes; adding -WIP to tag" >&2
+if [ "${1:-}" = '--show-diff' ]; then
+    echo "Diff to HEAD:" >&2
     echo >&2
-    git diff HEAD >&2
+    git diff-index -p HEAD >&2
 fi
 
+WORKING_SUFFIX=$(if ! git diff-index --quiet HEAD; then echo "-WIP"; else echo ""; fi)
 BRANCH_PREFIX=$(git name-rev --name-only HEAD)
 echo "$BRANCH_PREFIX-$(git rev-parse --short HEAD)$WORKING_SUFFIX"


### PR DESCRIPTION
It is confusing to see this output if you are in the edit-test-commit cycle using your own build; however, it's still useful for CI, so keep it as an option.

The WIP check of the CI build needs to be fixed. But in the meantime, this makes local builds more bearable. (With apologies to @tomwilkie who furnished a very similar PR earlier ..)
