### PR TITLE
Use git rev-parse --abbrev-ref to get the branch name

### DIFF
--- a/image-tag
+++ b/image-tag
@@ -13,5 +13,5 @@ WORKING_SUFFIX=$(if ! git diff --exit-code ${OUTPUT} HEAD >&2; \
                  then echo "-WIP"; \
                  else echo ""; \
                  fi)
-BRANCH_PREFIX=$(git name-rev --name-only HEAD)
+BRANCH_PREFIX=$(git rev-parse --abbrev-ref HEAD)
 echo "$BRANCH_PREFIX-$(git rev-parse --short HEAD)$WORKING_SUFFIX"


### PR DESCRIPTION
If you're not at the tip of a branch, `git name-rev ...` will give a
name like `master~3`, which doesn't work in an image tag. `git
rev-parse --abbrev-ref` will give the branch name at a branch tip, but
fall back to `HEAD` otherwise, which is OK for our purposes.
