### PR TITLE
Add memcached service & graphs on local

### DIFF
--- a/k8s/local/default/memcached-rc.yaml
+++ b/k8s/local/default/memcached-rc.yaml
@@ -16,8 +16,16 @@ spec:
         image: memcached:1.4.25
         imagePullPolicy: IfNotPresent
         args:
-        - -p 11211  # Default port, but being explicit is nice.
-        - -vv  # This gets us to the level of request logs.
+          - -p 11211  # Default port, but being explicit is nice.
+          - -vv  # This gets us to the level of request logs.
         ports:
-        - containerPort: 11211
-      # TODO(jml): memcached exporter
+          - name: clients
+            containerPort: 11211
+      - name: exporter
+        image: prom/memcached-exporter:master
+        args:
+          - -memcached.address=localhost:11211
+          - -web.listen-address=0.0.0.0:9150
+        ports:
+        - name: prom
+          containerPort: 9150

--- a/k8s/local/default/memcached-svc.yaml
+++ b/k8s/local/default/memcached-svc.yaml
@@ -2,8 +2,13 @@ apiVersion: v1
 kind: Service
 metadata:
   name: memcached
+  annotations:
+    prometheus.io.port: "9150"
 spec:
   ports:
-    - port: 11211
+    - name: clients
+      port: 11211
+    - name: prom
+      port: 9150
   selector:
     name: memcached

--- a/monitoring/grafana/reports.json
+++ b/monitoring/grafana/reports.json
@@ -749,6 +749,166 @@
         }
       ],
       "title": "New row"
+    },
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "Scope-as-a-Service Prometheus",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 10,
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(irate(memcached_commands_total[1m])) by (command)",
+              "intervalFactor": 2,
+              "legendFormat": "",
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "memcached QPS",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "Scope-as-a-Service Prometheus",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 11,
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(irate(memcached_commands_total{status=\"hit\"}[1m])) by (command) / sum(irate(memcached_commands_total[1m])) by (command)",
+              "intervalFactor": 2,
+              "legendFormat": "",
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "memcached hit ratio",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "title": "New row"
     }
   ],
   "schemaVersion": 12,


### PR DESCRIPTION
We don't do anything with it, but maybe it's OK to merge anyway.

Progress on #442

Graphs are:
#### QPS

```
sum(irate(memcached_commands_total[1m])) by (command)
```
#### Cache hit

```
sum(rate(scope_dynamo_cache_hits[1m])) / sum(rate(scope_dynamo_cache_hits[1m]) + rate(scope_dynamo_cache_miss[1m]))
```
