### PR TITLE
[RFC] Create simple shortcuts for kubectl

### DIFF
--- a/kubectl.sh
+++ b/kubectl.sh
@@ -1,0 +1,7 @@
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+parent_script="$(basename "${0}")"
+env="${parent_script/kubectl_/}"
+
+# TODO: check if kubectl is present and what version it is
+
+exec kubectl --kubeconfig="${script_dir}/infra/${env}/kubeconfig" "$@"

--- a/kubectl_dev
+++ b/kubectl_dev
@@ -1,0 +1,3 @@
+#!/bin/bash -eu
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${script_dir}/kubectl.sh"

--- a/kubectl_dev-ka
+++ b/kubectl_dev-ka
@@ -1,0 +1,3 @@
+#!/bin/bash -eu
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${script_dir}/kubectl.sh"

--- a/kubectl_local
+++ b/kubectl_local
@@ -1,0 +1,3 @@
+#!/bin/bash -eu
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${script_dir}/kubectl.sh"

--- a/kubectl_prod
+++ b/kubectl_prod
@@ -1,0 +1,3 @@
+#!/bin/bash -eu
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${script_dir}/kubectl.sh"


### PR DESCRIPTION
Just something I've been thinking of for a while, would make all of us type less.

I find that long explicit commands we type are good, because they are explicit, without no context variables... However, I think having many string repeating all over the command hide the `env` segment.

Let's consider usage with relative path:

```
kubectl --kubeconfig=infra/<env>/kubeconfig ...
```

Here `kube` substring is repeated 3 times, and `kubeconfig` substring is repeated 2 times.

Also consider usage with absolute path:

```
kubectl --kubeconfig=/Users/ilya/Code/infra/<env>/kubeconfig ...
```

This adds a long path string, which buries the `env` segment even more.

Alternative to what I'm proposing here may be to move (or symlink) kubeconfig files into toplevel directory, but I like this version better. This is also completely optional for people to use and doesn't not rely on shell alisases or `chdir` hooks, which are too personal of a thing.
