### PR TITLE
update local oauth for cloud.weave.works

### DIFF
--- a/k8s/local/default/users-rc.yaml
+++ b/k8s/local/default/users-rc.yaml
@@ -23,9 +23,9 @@ spec:
         - -direct-login=true
         - -github-client-id=361dfaca09eb0be8c9fc
         - -github-client-secret=7559ecdcbff17f2886dd66c7e9ca4b878b893377
-        - -github-redirect-url=https://scope.weave.works/login-via/github
-        - -google-client-id=1087353951550-6gmmc1jfdplma6sadbi641kd0rprcd15.apps.googleusercontent.com
-        - -google-client-secret=r--sKsXIG0BHugk5pzyjLE0z
-        - -google-redirect-url=https://scope.weave.works/login-via/google
+        - -github-redirect-url=https://cloud.weave.works/login-via/github
+        - -google-client-id=75701914109-rpmffah8g4d563fndlo80rvmce2b193r.apps.googleusercontent.com
+        - -google-client-secret=S2b0pyVojKXR1ffAw9RjVJK_
+        - -google-redirect-url=https://cloud.weave.works/login-via/google
         ports:
         - containerPort: 80


### PR DESCRIPTION
Also, moved the oauth app to the scope-integration-tests project (for lack of somewhere better)

Note: I had to enable the Google+ API in the scope-integration-tests project.
