### PR TITLE
Serve up service and scope index.html with no-cache

### DIFF
--- a/frontend-mt/routes.conf
+++ b/frontend-mt/routes.conf
@@ -16,6 +16,12 @@ location /api/users/ {
   proxy_pass http://users.default.svc.cluster.local$request_uri;
 }
 
+# Serve scope index.html with no caching
+location ~ ^/api/app/[^/]+$ {
+  add_header Cache-Control no-cache;
+  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
+}
+
 location /api/app/ {
   proxy_pass http://authfe.default.svc.cluster.local$request_uri;
 }
@@ -64,6 +70,12 @@ location /launch/k8s/ {
 location ~ ^/login-via/ {
   rewrite ^ /#$uri redirect;
   break;
+}
+
+# Serve service index.html with no-caching.
+location = / {
+  add_header Cache-Control no-cache;
+  proxy_pass http://ui-server.default.svc.cluster.local$request_uri;
 }
 
 # The rest will be served by the ui-server


### PR DESCRIPTION
Force the browser to check the etag, which it doesn't do sometimes when
there are hashing in the URL.

Fixes #472 
