### PR TITLE
Serve scope/index.html w/ no-cache

### DIFF
--- a/frontend-mt/routes.conf
+++ b/frontend-mt/routes.conf
@@ -17,7 +17,7 @@ location /api/users/ {
 }
 
 # Serve scope index.html with no caching
-location ~ ^/api/app/[^/]/+$ {
+location ~ ^/api/app/[^/]+/$ {
   add_header Cache-Control no-cache;
   proxy_pass http://authfe.default.svc.cluster.local$request_uri;
 }


### PR DESCRIPTION
Small bug in the previous PR.

Fixes #472 
