### PR TITLE
Enable nginx gzip compression

### DIFF
--- a/frontend-mt/default.conf
+++ b/frontend-mt/default.conf
@@ -50,6 +50,27 @@ server {
     # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
     add_header Strict-Transport-Security "max-age=15724800; includeSubdomains; preload";
 
+    # Compression for assets and JSON
+    gzip on;
+    gzip_disable "msie6";
+
+    gzip_comp_level 6;
+    gzip_min_length 1100;
+    gzip_buffers 16 8k;
+    gzip_proxied any;
+    gzip_types
+        text/plain
+        text/css
+        text/js
+        text/xml
+        text/javascript
+        application/javascript
+        application/x-javascript
+        application/json
+        application/xml
+        application/rss+xml
+        image/svg+xml;
+
     # The resolver is hardcoded to the DNS server in all local/dev/prod k8s
     # clusters. Also, the 'cluster.local' domain that is in reverse-proxy targets is
     # configurable, but all local/dev/prod k8s cluster are configured


### PR DESCRIPTION
- compression for assets
- compression for JSON responses
- works for proxied requests

Possible fix for #478 

gzip compression of js works quite well 290KB + 320 KB ----> 88 KB + 72 KB

Compression of JSON (our backend API) responses need more testing.
