### PR TITLE
Retry cookie login even if token link is expired

### DIFF
--- a/client/src/pages/landing/login-form.jsx
+++ b/client/src/pages/landing/login-form.jsx
@@ -198,7 +198,7 @@ export default class LoginForm extends React.Component {
       unauthorizedWrapper: {
         marginTop: 16,
         textAlign: 'center',
-        display: unauthorized ? 'block' : 'none'
+        display: unauthorized && !submitSuccess ? 'block' : 'none'
       }
     };
 


### PR DESCRIPTION
- allows for using the email link if it worked once already (given your
  and your cookie is still valid) fixes #517
- clear expired message when requesting new email (fixes #507)
