### PR TITLE
Descriptive text for login links

### DIFF
--- a/users/templates/invite_email.html
+++ b/users/templates/invite_email.html
@@ -4,7 +4,7 @@ You've been invited to join the organization "{{.OrganizationName}}" on Weave Cl
 
 <p>Click this link to login to Weave Cloud:</p>
 
-<p><a href="{{.LoginURL}}">{{.LoginURL}}</a></p>
+<p><a href="{{.LoginURL}}">Log in to Weave Cloud</a></p>
 
 <p>This single-use login link is valid for 3 days. You can generate a new one at any time by logging in at <a href="{{.RootURL}}">{{.RootURL}}</a></p>
 

--- a/users/templates/login_email.html
+++ b/users/templates/login_email.html
@@ -1,6 +1,6 @@
 <p>Click this link to login to Weave Cloud:</p>
 
-<p><a href="{{.LoginURL}}">{{.LoginURL}}</a></p>
+<p><a href="{{.LoginURL}}">Log in to Weave Cloud</a></p>
 
 <p>This single-use login link is valid for 3 days. You can generate a new one at any time by logging in at <a href="{{.RootURL}}">{{.RootURL}}</a></p>
 


### PR DESCRIPTION
- using the url triggered spam warnings in Thunderbird
- use text instead: "Log in to Weave Cloud"

Fixes #485
