### PR TITLE
Latest Docker Machine supports autodetection of tcsh

### DIFF
--- a/infra/local-k8s
+++ b/infra/local-k8s
@@ -209,7 +209,7 @@ function stand_up {
 
 if check_docker_machine
 then
-      eval "$(docker-machine env "${DOCKER_MACHINE_NAME}")"
+      eval "$(docker-machine env --shell bash "${DOCKER_MACHINE_NAME}")"
 fi
 
 case "${mode}" in


### PR DESCRIPTION
This broke for me, as `docker-machine env` now outputs commands based on `SHELL`, and I am using `tcsh`, so it's not compatible. Anyhow, this should had been explicit in the first place.
