### PR TITLE
Fixes scrollbar visibility issues.

### DIFF
--- a/ui-server/client/src/components/router.jsx
+++ b/ui-server/client/src/components/router.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 export default class RouterComponent extends React.Component {
   render() {
     return (
-      <div id="container" style={{overflow: 'scroll', height: '100%'}}>
+      <div id="container" style={{overflow: 'auto', height: '100%'}}>
         {this.props.children}
       </div>
     );

--- a/ui-server/client/src/pages/account/page.jsx
+++ b/ui-server/client/src/pages/account/page.jsx
@@ -66,7 +66,7 @@ export default class AccountPage extends React.Component {
     const orgName = get(this.state, ['organizations', 0, 'name']);
 
     return (
-      <div style={{height: '100%', overflowY: 'scroll', position: 'relative'}}>
+      <div style={{height: '100%', position: 'relative'}}>
         <Toolbar
           user={this.state.user}
           organization={orgName}

--- a/ui-server/client/src/pages/organization/page.jsx
+++ b/ui-server/client/src/pages/organization/page.jsx
@@ -176,7 +176,7 @@ export default class OrganizationPage extends React.Component {
     };
 
     return (
-      <div style={{height: '100%', overflowY: 'scroll', position: 'relative'}}>
+      <div style={{height: '100%', position: 'relative'}}>
         <Toolbar user={this.state.user} organization={this.props.params.orgId} />
         <div style={styles.logoWrapper}>
           <Logo />

--- a/ui-server/client/src/pages/wrapper/page.jsx
+++ b/ui-server/client/src/pages/wrapper/page.jsx
@@ -138,7 +138,7 @@ export default class Wrapper extends React.Component {
         display: 'block',
         border: 'none',
         height: 'calc(100vh - 56px)',
-        width: '100vw'
+        width: '100%'
       }
     };
 


### PR DESCRIPTION
The default "hide scrollbars when not scrolling" allowed us to be a bit
more relaxed about our overflow code. When a user opts to "always show
scrollbars" (a browser or OS setting), we're showing too many
scrollbars. Re-org our overflows a bit so even in this case we don't
show too many scrollbars. Scrollbars.

Fixes #593 
