### PR TITLE
change namespace of demo service to extra

### DIFF
--- a/frontend-mt/routes.conf
+++ b/frontend-mt/routes.conf
@@ -90,7 +90,7 @@ location = /demo {
 }
 
 location ~ ^/demo/?((?<=/).*)?$ {
-  proxy_pass http://demo.default.svc.cluster.local/$1$is_args$args;
+  proxy_pass http://demo.extra.svc.cluster.local/$1$is_args$args;
 
   proxy_redirect off;
   proxy_pass_request_headers on;


### PR DESCRIPTION
Since @jml, rightly, suggested it should live in it's own namespace: https://github.com/weaveworks/service-conf/pull/19
