### PR TITLE
Monitor report sizes via histogram

### DIFF
--- a/monitoring/grafana/reports.json
+++ b/monitoring/grafana/reports.json
@@ -378,6 +378,101 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
+          "id": 17,
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 6,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(irate(scope_s3_request_duration_seconds_count{method=\"Get\"}[5m]))",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "S3",
+              "refId": "C",
+              "step": 10
+            },
+            {
+              "expr": "sum(irate(scope_memcache_hits_total[5m]))",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "Memcache",
+              "refId": "B",
+              "step": 10
+            },
+            {
+              "expr": "sum(irate(scope_in_process_cache_hits_total[5m]))",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "In-process Cache",
+              "metric": "",
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Report Hits by Store",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "Scope-as-a-Service Prometheus",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
           "id": 2,
           "isNew": true,
           "legend": {
@@ -398,7 +493,7 @@
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
-          "span": 12,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -407,7 +502,7 @@
               "intervalFactor": 2,
               "legendFormat": "",
               "refId": "A",
-              "step": 4
+              "step": 10
             }
           ],
           "timeFrom": null,


### PR DESCRIPTION
Fixes #632.

Depends on weaveworks/scope#1668.

While here, I also added a stacked graph of hits by store - fixes #626 - and renamed the memcache graph - fixes #614.
