### PR TITLE
Test helper for making requests as a given user

### DIFF
--- a/users/account_test.go
+++ b/users/account_test.go
@@ -24,7 +24,7 @@ func Test_Account_AttachOauthAccount(t *testing.T) {
 
 	// Hit the endpoint that the oauth login will redirect to (with our session)
 	w := httptest.NewRecorder()
-	r, _ := requestAs(t, user, "GET", "/api/users/logins/mock/attach?code=joe&state=state", nil)
+	r := requestAs(t, user, "GET", "/api/users/logins/mock/attach?code=joe&state=state", nil)
 	app.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.True(t, hasCookie(w, cookieName))
@@ -69,7 +69,7 @@ func Test_Account_AttachOauthAccount_AlreadyAttachedToAnotherAccount(t *testing.
 
 	// Hit the endpoint that the oauth login will redirect to (with our session)
 	w := httptest.NewRecorder()
-	r, _ := requestAs(t, user, "GET", "/api/users/logins/mock/attach?code=fran&state=state", nil)
+	r := requestAs(t, user, "GET", "/api/users/logins/mock/attach?code=fran&state=state", nil)
 	app.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.True(t, hasCookie(w, cookieName))
@@ -119,7 +119,7 @@ func Test_Account_AttachOauthAccount_AlreadyAttachedToSameAccount(t *testing.T) 
 
 	// Hit the endpoint that the oauth login will redirect to (with our session)
 	w := httptest.NewRecorder()
-	r, _ := requestAs(t, user, "GET", "/api/users/logins/mock/attach?code=joe&state=state", nil)
+	r := requestAs(t, user, "GET", "/api/users/logins/mock/attach?code=joe&state=state", nil)
 	app.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.True(t, hasCookie(w, cookieName))
@@ -158,7 +158,7 @@ func Test_Account_ListAttachedLoginProviders(t *testing.T) {
 	// Listing when none attached
 	{
 		w := httptest.NewRecorder()
-		r, _ := requestAs(t, user, "GET", "/api/users/attached_logins", nil)
+		r := requestAs(t, user, "GET", "/api/users/attached_logins", nil)
 		app.ServeHTTP(w, r)
 		assert.Equal(t, http.StatusOK, w.Code)
 		var body struct {
@@ -181,7 +181,7 @@ func Test_Account_ListAttachedLoginProviders(t *testing.T) {
 		assert.Len(t, user.Logins, 1)
 
 		w := httptest.NewRecorder()
-		r, _ := requestAs(t, user, "GET", "/api/users/attached_logins", nil)
+		r := requestAs(t, user, "GET", "/api/users/attached_logins", nil)
 		app.ServeHTTP(w, r)
 		assert.Equal(t, http.StatusOK, w.Code)
 		var body struct {
@@ -215,7 +215,7 @@ func Test_Account_DetachOauthAccount(t *testing.T) {
 
 	// Hit the endpoint that the oauth login will redirect to (with our session)
 	w := httptest.NewRecorder()
-	r, _ := requestAs(t, user, "POST", "/api/users/logins/mock/detach", nil)
+	r := requestAs(t, user, "POST", "/api/users/logins/mock/detach", nil)
 	app.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusNoContent, w.Code)
 

--- a/users/delete_users_test.go
+++ b/users/delete_users_test.go
@@ -23,7 +23,7 @@ func Test_DeleteUser(t *testing.T) {
 	assert.Equal(t, org.ID, fran.Organizations[0].ID)
 
 	w := httptest.NewRecorder()
-	r, _ := requestAs(t, user, "DELETE", "/api/users/org/"+org.Name+"/users/"+fran.Email, nil)
+	r := requestAs(t, user, "DELETE", "/api/users/org/"+org.Name+"/users/"+fran.Email, nil)
 
 	app.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusOK, w.Code)

--- a/users/helpers_test.go
+++ b/users/helpers_test.go
@@ -12,17 +12,15 @@ import (
 )
 
 // requestAs makes a request as the given user.
-func requestAs(t *testing.T, u *user, method, endpoint string, body io.Reader) (*http.Request, error) {
+func requestAs(t *testing.T, u *user, method, endpoint string, body io.Reader) *http.Request {
 	cookie, err := sessions.Cookie(u.ID, "")
 	assert.NoError(t, err)
 
 	r, err := http.NewRequest(method, endpoint, body)
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(t, err)
 
 	r.AddCookie(cookie)
-	return r, nil
+	return r
 }
 
 // getApprovedUser makes a randomly named, approved user

--- a/users/invite_test.go
+++ b/users/invite_test.go
@@ -18,7 +18,7 @@ func Test_Invite(t *testing.T) {
 	user, org := getOrg(t)
 
 	w := httptest.NewRecorder()
-	r, _ := requestAs(t, user, "POST", "/api/users/org/"+org.Name+"/users", strings.NewReader(`{"email":"fran@weave.works"}`))
+	r := requestAs(t, user, "POST", "/api/users/org/"+org.Name+"/users", strings.NewReader(`{"email":"fran@weave.works"}`))
 
 	app.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -42,7 +42,7 @@ func Test_Invite_WithInvalidJSON(t *testing.T) {
 	user, org := getOrg(t)
 
 	w := httptest.NewRecorder()
-	r, _ := requestAs(t, user, "POST", "/api/users/org/"+org.Name+"/users", strings.NewReader(`garbage`))
+	r := requestAs(t, user, "POST", "/api/users/org/"+org.Name+"/users", strings.NewReader(`garbage`))
 
 	app.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -56,7 +56,7 @@ func Test_Invite_WithBlankEmail(t *testing.T) {
 	user, org := getOrg(t)
 
 	w := httptest.NewRecorder()
-	r, _ := requestAs(t, user, "POST", "/api/users/org/"+org.Name+"/users", strings.NewReader(`{"email":""}`))
+	r := requestAs(t, user, "POST", "/api/users/org/"+org.Name+"/users", strings.NewReader(`{"email":""}`))
 
 	app.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -78,7 +78,7 @@ func Test_Invite_UserAlreadyInSameOrganization(t *testing.T) {
 	assert.Equal(t, org.ID, fran.Organizations[0].ID)
 
 	w := httptest.NewRecorder()
-	r, _ := requestAs(t, user, "POST", "/api/users/org/"+org.Name+"/users", strings.NewReader(`{"email":"fran@weave.works"}`))
+	r := requestAs(t, user, "POST", "/api/users/org/"+org.Name+"/users", strings.NewReader(`{"email":"fran@weave.works"}`))
 
 	app.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -105,7 +105,7 @@ func Test_Invite_UserNotApproved(t *testing.T) {
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()
-	r, _ := requestAs(t, user, "POST", "/api/users/org/"+org.Name+"/users", strings.NewReader(`{"email":"fran@weave.works"}`))
+	r := requestAs(t, user, "POST", "/api/users/org/"+org.Name+"/users", strings.NewReader(`{"email":"fran@weave.works"}`))
 
 	app.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -130,7 +130,7 @@ func Test_Invite_UserInDifferentOrganization(t *testing.T) {
 	fran, franOrg := getOrg(t)
 
 	w := httptest.NewRecorder()
-	r, _ := requestAs(t, user, "POST", "/api/users/org/"+org.Name+"/users", strings.NewReader(fmt.Sprintf(`{"email":%q}`, fran.Email)))
+	r := requestAs(t, user, "POST", "/api/users/org/"+org.Name+"/users", strings.NewReader(fmt.Sprintf(`{"email":%q}`, fran.Email)))
 
 	app.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusBadRequest, w.Code)

--- a/users/org_test.go
+++ b/users/org_test.go
@@ -33,7 +33,7 @@ func Test_Org(t *testing.T) {
 	require.NotNil(t, org.FirstProbeUpdateAt)
 
 	w := httptest.NewRecorder()
-	r, _ := requestAs(t, user, "GET", "/api/users/org/"+user.Organizations[0].Name, nil)
+	r := requestAs(t, user, "GET", "/api/users/org/"+user.Organizations[0].Name, nil)
 	app.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusOK, w.Code)
 	body := map[string]interface{}{}
@@ -54,7 +54,7 @@ func Test_Org_NoProbeUpdates(t *testing.T) {
 	user, org := getOrg(t)
 
 	w := httptest.NewRecorder()
-	r, _ := requestAs(t, user, "GET", "/api/users/org/"+org.Name, nil)
+	r := requestAs(t, user, "GET", "/api/users/org/"+org.Name, nil)
 
 	app.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -79,7 +79,7 @@ func Test_ListOrganizationUsers(t *testing.T) {
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()
-	r, _ := requestAs(t, user, "GET", "/api/users/org/"+org.Name+"/users", nil)
+	r := requestAs(t, user, "GET", "/api/users/org/"+org.Name+"/users", nil)
 
 	app.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -95,7 +95,7 @@ func Test_RelabelOrganization(t *testing.T) {
 
 	{
 		w := httptest.NewRecorder()
-		r, _ := requestAs(t, otherUser, "PUT", "/api/users/org/"+org.Name, strings.NewReader(`{"label":"my-organization"}`))
+		r := requestAs(t, otherUser, "PUT", "/api/users/org/"+org.Name, strings.NewReader(`{"label":"my-organization"}`))
 
 		app.ServeHTTP(w, r)
 		assert.Equal(t, http.StatusForbidden, w.Code)
@@ -109,7 +109,7 @@ func Test_RelabelOrganization(t *testing.T) {
 	// Should 404 for not found orgs
 	{
 		w := httptest.NewRecorder()
-		r, _ := requestAs(t, otherUser, "PUT", "/api/users/org/not-found-org", strings.NewReader(`{"label":"my-organization"}`))
+		r := requestAs(t, otherUser, "PUT", "/api/users/org/not-found-org", strings.NewReader(`{"label":"my-organization"}`))
 
 		app.ServeHTTP(w, r)
 
@@ -118,12 +118,12 @@ func Test_RelabelOrganization(t *testing.T) {
 	// Should update my org
 	{
 		w := httptest.NewRecorder()
-		r, _ := requestAs(t, user, "PUT", "/api/users/org/"+org.Name, strings.NewReader(`{"label":"my-organization"}`))
+		r := requestAs(t, user, "PUT", "/api/users/org/"+org.Name, strings.NewReader(`{"label":"my-organization"}`))
 
 		app.ServeHTTP(w, r)
 		assert.Equal(t, http.StatusNoContent, w.Code)
 
-		user, err = storage.FindUserByID(user.ID)
+		user, err := storage.FindUserByID(user.ID)
 		require.NoError(t, err)
 		if assert.Len(t, user.Organizations, 1) {
 			assert.Equal(t, org.ID, user.Organizations[0].ID)
@@ -140,7 +140,7 @@ func Test_RenameOrganization_NotAllowed(t *testing.T) {
 	user, org := getOrg(t)
 
 	w := httptest.NewRecorder()
-	r, _ := requestAs(t, user, "PUT", "/api/users/org/"+org.Name, strings.NewReader(`{"name":"my-organization"}`))
+	r := requestAs(t, user, "PUT", "/api/users/org/"+org.Name, strings.NewReader(`{"name":"my-organization"}`))
 
 	app.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -165,7 +165,7 @@ func Test_RelabelOrganization_Validation(t *testing.T) {
 		"": "Label cannot be blank",
 	} {
 		w := httptest.NewRecorder()
-		r, _ := requestAs(t, user, "PUT", "/api/users/org/"+org.Name, strings.NewReader(fmt.Sprintf(`{"label":%q}`, label)))
+		r := requestAs(t, user, "PUT", "/api/users/org/"+org.Name, strings.NewReader(fmt.Sprintf(`{"label":%q}`, label)))
 
 		app.ServeHTTP(w, r)
 		assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -188,7 +188,7 @@ func Test_CustomNameOrganization(t *testing.T) {
 	user := getApprovedUser(t)
 
 	w := httptest.NewRecorder()
-	r, _ := requestAs(t, user, "POST", "/api/users/org", strings.NewReader(`{"name":"my-organization","label":"my organization"}`))
+	r := requestAs(t, user, "POST", "/api/users/org", strings.NewReader(`{"name":"my-organization","label":"my organization"}`))
 
 	app.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusCreated, w.Code)
@@ -214,7 +214,7 @@ func Test_CustomNameOrganization_Validation(t *testing.T) {
 		otherOrg.Name:                  "Name is already taken",
 	} {
 		w := httptest.NewRecorder()
-		r, _ := requestAs(t, user, "POST", "/api/users/org", strings.NewReader(fmt.Sprintf(`{"name":%q,"label":"my organization"}`, name)))
+		r := requestAs(t, user, "POST", "/api/users/org", strings.NewReader(fmt.Sprintf(`{"name":%q,"label":"my organization"}`, name)))
 
 		app.ServeHTTP(w, r)
 		assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -236,7 +236,7 @@ func Test_Organization_GenerateOrgName(t *testing.T) {
 	user := getApprovedUser(t)
 
 	// Generate a new org name
-	r, _ := requestAs(t, user, "GET", "/api/users/generateOrgName", nil)
+	r := requestAs(t, user, "GET", "/api/users/generateOrgName", nil)
 	w := httptest.NewRecorder()
 	app.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -260,7 +260,7 @@ func Test_Organization_CheckIfNameExists(t *testing.T) {
 	name, err := storage.GenerateOrganizationName()
 	require.NoError(t, err)
 
-	r, _ := requestAs(t, user, "GET", "/api/users/org/"+name, nil)
+	r := requestAs(t, user, "GET", "/api/users/org/"+name, nil)
 
 	{
 		w := httptest.NewRecorder()
@@ -285,13 +285,13 @@ func Test_Organization_CreateMultiple(t *testing.T) {
 
 	user := getApprovedUser(t)
 
-	r1, _ := requestAs(t, user, "POST", "/api/users/org", strings.NewReader(`{"name":"my-first-org","label":"my first org"}`))
+	r1 := requestAs(t, user, "POST", "/api/users/org", strings.NewReader(`{"name":"my-first-org","label":"my first org"}`))
 
 	w := httptest.NewRecorder()
 	app.ServeHTTP(w, r1)
 	assert.Equal(t, http.StatusCreated, w.Code)
 
-	r2, _ := requestAs(t, user, "POST", "/api/users/org", strings.NewReader(`{"name":"my-second-org","label":"my second org"}`))
+	r2 := requestAs(t, user, "POST", "/api/users/org", strings.NewReader(`{"name":"my-second-org","label":"my second org"}`))
 
 	w = httptest.NewRecorder()
 	app.ServeHTTP(w, r2)


### PR DESCRIPTION
@paulbellamy you should review this, since it is based on https://github.com/weaveworks/service/pull/650

Adds `requestAs` to `helpers_test`, and updates almost all of the tests which used to manually create & add a cookie to use that instead. I've left `lookup_test` untouched, since it seemed that part of the purpose of those tests was to guarantee behaviour under different authentication mechanisms.
