### PR TITLE
Update to Prometheus 1.0

### DIFF
--- a/monitoring/prometheus/Dockerfile
+++ b/monitoring/prometheus/Dockerfile
@@ -1,4 +1,4 @@
-FROM prom/prometheus:0.17.0
+FROM prom/prometheus:v1.0.0
 LABEL works.weave.role=system
 
 COPY prometheus.yml alert.rules /etc/prometheus/

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -12,6 +12,7 @@ scrape_configs:
   - api_servers:
     - 'https://kubernetes.default.svc.cluster.local'
     in_cluster: true
+    role: endpoint
 
   # You can specify the following annotations (on services):
   #   prometheus.io.scrape: false - don't scrape this service
@@ -19,9 +20,6 @@ scrape_configs:
   #   prometheus.io.port - scrape this port
   #   prometheus.io.path - scrape this path
   relabel_configs:
-  - source_labels: [__meta_kubernetes_role]
-    action: keep
-    regex: endpoint
   - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
     action: drop
     regex: false
@@ -59,8 +57,4 @@ scrape_configs:
   - api_servers:
     - 'https://kubernetes.default.svc.cluster.local'
     in_cluster: true
-
-  relabel_configs:
-  - source_labels: [__meta_kubernetes_role]
-    action: keep
-    regex: node
+    role: node


### PR DESCRIPTION
- Bump version
- Specify `role` in config (as per https://prometheus.io/docs/operating/configuration/#<kubernetes_sd_config> and https://github.com/prometheus/prometheus/blob/master/CHANGELOG.md#100--2016-07-18)
- Drop our custom rules for dropping metrics outside the role.

Depends on weaveworks/service-conf#62

Fixes #655 
