### PR TITLE
Move launch generator to extra namespace

### DIFF
--- a/frontend-mt/routes.conf
+++ b/frontend-mt/routes.conf
@@ -73,7 +73,7 @@ location = /api {
 }
 
 location /launch/k8s/ {
-  proxy_pass http://launch-generator.default.svc.cluster.local$request_uri;
+  proxy_pass http://launch-generator.extra.svc.cluster.local$request_uri;
 }
 
 # Some OAuth providers (e.g. Google) disallow redirecting to a fragment, so


### PR DESCRIPTION
This should be merged / deployed after https://github.com/weaveworks/service-conf/pull/63
