### PR TITLE
[1] renaming org.name -> org.externalID

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -50,7 +50,7 @@ func routes(c Config) (http.Handler, error) {
 
 		// For all ui <-> app communication, authenticated using cookie credentials
 		prefix{
-			"/api/app/{orgName}",
+			"/api/app/{orgExternalID}",
 			[]path{
 				{"/api/report", newProxy(c.queryHost)},
 				{"/api/topology", newProxy(c.queryHost)},
@@ -64,8 +64,8 @@ func routes(c Config) (http.Handler, error) {
 			middleware.Merge(
 				users.AuthOrgMiddleware{
 					Authenticator: c.authenticator,
-					OrgName: func(r *http.Request) (string, bool) {
-						v, ok := mux.Vars(r)["orgName"]
+					OrgExternalID: func(r *http.Request) (string, bool) {
+						v, ok := mux.Vars(r)["orgExternalID"]
 						return v, ok
 					},
 					OutputHeader: c.outputHeader,

--- a/users/db/migrations/007_add_column_organizations_external_id.up.sql
+++ b/users/db/migrations/007_add_column_organizations_external_id.up.sql
@@ -1,0 +1,13 @@
+ALTER TABLE organizations ADD COLUMN external_id text;
+
+DO
+  $$
+  BEGIN
+    CREATE UNIQUE INDEX organizations_lower_external_id_idx ON organizations (lower(external_id)) WHERE deleted_at IS NULL;
+    EXCEPTION WHEN duplicate_table THEN
+      -- do nothing, it's already there
+END
+$$ LANGUAGE plpgsql;
+
+UPDATE organizations SET external_id = name;
+ALTER TABLE organizations ALTER COLUMN external_id SET NOT NULL;

--- a/users/externalIDs/generate.go
+++ b/users/externalIDs/generate.go
@@ -1,4 +1,4 @@
-package names
+package externalIDs
 
 import (
 	"fmt"
@@ -34,7 +34,7 @@ var (
 	}
 )
 
-// Generate a new name of the form autumn-waterfall-99
+// Generate a new id of the form autumn-waterfall-99
 func Generate() string {
 	return fmt.Sprintf(
 		"%s-%s-%02d",

--- a/users/helpers_test.go
+++ b/users/helpers_test.go
@@ -37,19 +37,19 @@ func getApprovedUser(t *testing.T) *user {
 	return user
 }
 
-// getOrg makes a randomly named org and user for testing
+// getOrg makes org with a random ExternalID and user for testing
 func getOrg(t *testing.T) (*user, *organization) {
 	user := getApprovedUser(t)
 
-	name, err := storage.GenerateOrganizationName()
+	externalID, err := storage.GenerateOrganizationExternalID()
 	require.NoError(t, err)
 
-	org, err := storage.CreateOrganization(user.ID, name, name)
+	org, err := storage.CreateOrganization(user.ID, externalID, externalID)
 	require.NoError(t, err)
 
 	assert.NotEqual(t, "", org.ID)
-	assert.NotEqual(t, "", org.Name)
-	assert.Equal(t, org.Name, org.Label)
+	assert.NotEqual(t, "", org.ExternalID)
+	assert.Equal(t, org.ExternalID, org.Label)
 
 	return user, org
 }

--- a/users/lookup_test.go
+++ b/users/lookup_test.go
@@ -19,7 +19,7 @@ func Test_Lookup(t *testing.T) {
 	user, org := getOrg(t)
 
 	w := httptest.NewRecorder()
-	r := requestAs(t, user, "GET", "/private/api/users/lookup/"+org.Name, nil)
+	r := requestAs(t, user, "GET", "/private/api/users/lookup/"+org.ExternalID, nil)
 
 	app.ServeHTTP(w, r)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -64,7 +64,8 @@ func Test_PublicLookup(t *testing.T) {
 		"email": user.Email,
 		"organizations": []interface{}{
 			map[string]interface{}{
-				"name":               org.Name,
+				"id":                 org.ExternalID,
+				"name":               org.ExternalID,
 				"label":              org.Label,
 				"firstProbeUpdateAt": org.FirstProbeUpdateAt.UTC().Format(time.RFC3339),
 			},

--- a/users/organization.go
+++ b/users/organization.go
@@ -6,12 +6,12 @@ import (
 )
 
 var (
-	orgNameRegex = regexp.MustCompile(`\A[a-zA-Z0-9_-]+\z`)
+	orgExternalIDRegex = regexp.MustCompile(`\A[a-zA-Z0-9_-]+\z`)
 )
 
 type organization struct {
 	ID                 string
-	Name               string
+	ExternalID         string
 	Label              string
 	ProbeToken         string
 	FirstProbeUpdateAt time.Time
@@ -29,10 +29,10 @@ func (o *organization) RegenerateProbeToken() error {
 
 func (o *organization) valid() error {
 	switch {
-	case o.Name == "":
-		return errOrgNameCannotBeBlank
-	case !orgNameRegex.MatchString(o.Name):
-		return errOrgNameFormat
+	case o.ExternalID == "":
+		return errOrgExternalIDCannotBeBlank
+	case !orgExternalIDRegex.MatchString(o.ExternalID):
+		return errOrgExternalIDFormat
 	case o.Label == "":
 		return errOrgLabelCannotBeBlank
 	}

--- a/users/storage_test.go
+++ b/users/storage_test.go
@@ -12,18 +12,18 @@ func Test_Storage_RemoveOtherUsersAccess(t *testing.T) {
 
 	_, org := getOrg(t)
 	otherUser := getApprovedUser(t)
-	otherUser, err := storage.InviteUser(otherUser.Email, org.Name)
+	otherUser, err := storage.InviteUser(otherUser.Email, org.ExternalID)
 	require.NoError(t, err)
 	require.Len(t, otherUser.Organizations, 1)
 
-	orgUsers, err := storage.ListOrganizationUsers(org.Name)
+	orgUsers, err := storage.ListOrganizationUsers(org.ExternalID)
 	require.NoError(t, err)
 	require.Len(t, orgUsers, 2)
 
-	err = storage.RemoveUserFromOrganization(org.Name, otherUser.Email)
+	err = storage.RemoveUserFromOrganization(org.ExternalID, otherUser.Email)
 	require.NoError(t, err)
 
-	orgUsers, err = storage.ListOrganizationUsers(org.Name)
+	orgUsers, err = storage.ListOrganizationUsers(org.ExternalID)
 	require.NoError(t, err)
 	require.Len(t, orgUsers, 1)
 }

--- a/users/templates/invite_email.html
+++ b/users/templates/invite_email.html
@@ -1,5 +1,5 @@
 <p>
-You've been invited to join "{{.OrganizationName}}" on Weave Cloud.
+You've been invited to join "{{.OrganizationID}}" on Weave Cloud.
 </p>
 
 <p>Click here to login to Weave Cloud:</p>

--- a/users/templates/invite_email.text
+++ b/users/templates/invite_email.text
@@ -1,4 +1,4 @@
-You've been invited to join the "{{.OrganizationName}}" on Weave Cloud.
+You've been invited to join the "{{.OrganizationID}}" on Weave Cloud.
 
 Click here to login to Weave Cloud:
 

--- a/users/user.go
+++ b/users/user.go
@@ -60,9 +60,9 @@ func (u *user) CompareToken(other string) bool {
 	return time.Now().UTC().Sub(tokenCreatedAt) <= 72*time.Hour
 }
 
-func (u *user) HasOrganization(name string) bool {
+func (u *user) HasOrganization(externalID string) bool {
 	for _, o := range u.Organizations {
-		if strings.ToLower(o.Name) == strings.ToLower(name) {
+		if strings.ToLower(o.ExternalID) == strings.ToLower(externalID) {
 			return true
 		}
 	}
@@ -72,7 +72,7 @@ func (u *user) HasOrganization(name string) bool {
 func newUsersOrganizationFilter(s []string) filter {
 	return and{
 		inFilter{
-			SQLField: "organizations.name",
+			SQLField: "organizations.external_id",
 			SQLJoins: []string{
 				"memberships on (memberships.user_id = users.id)",
 				"organizations on (memberships.organization_id = organizations.id)",
@@ -81,8 +81,8 @@ func newUsersOrganizationFilter(s []string) filter {
 			Allowed: func(i interface{}) bool {
 				if u, ok := i.(*user); ok {
 					for _, org := range u.Organizations {
-						for _, name := range s {
-							if org.Name == name {
+						for _, externalID := range s {
+							if org.ExternalID == externalID {
 								return true
 							}
 						}


### PR DESCRIPTION
Currently: orgs have name, and label.
Goal: orgs have id, and name.

Steps:
1) Add an external id field, which is the same as name.
2) Update clients (js, emails, authenticator clients), to use "id", and display "label" as the friendly UI name.
3) Update the API to duplicate label into name
4) Update JS to use name field, not label for nice name-display, and instance creation.
5) Drop the label column from the db and api

This is step 1.
