### PR TITLE
Don't list revoked users in organizations

### DIFF
--- a/users/filters.go
+++ b/users/filters.go
@@ -45,3 +45,21 @@ func (f inFilter) Select(q squirrel.SelectBuilder) squirrel.SelectBuilder {
 	}
 	return q
 }
+
+type and []filter
+
+func (a and) Item(item interface{}) bool {
+	for _, f := range a {
+		if !f.Item(item) {
+			return false
+		}
+	}
+	return true
+}
+
+func (a and) Select(q squirrel.SelectBuilder) squirrel.SelectBuilder {
+	for _, f := range a {
+		q = f.Select(q)
+	}
+	return q
+}

--- a/users/storage_test.go
+++ b/users/storage_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Storage_RemoveOtherUsersAccess(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	_, org := getOrg(t)
+	otherUser := getApprovedUser(t)
+	otherUser, err := storage.InviteUser(otherUser.Email, org.Name)
+	require.NoError(t, err)
+	require.Len(t, otherUser.Organizations, 1)
+
+	orgUsers, err := storage.ListOrganizationUsers(org.Name)
+	require.NoError(t, err)
+	require.Len(t, orgUsers, 2)
+
+	err = storage.RemoveUserFromOrganization(org.Name, otherUser.Email)
+	require.NoError(t, err)
+
+	orgUsers, err = storage.ListOrganizationUsers(org.Name)
+	require.NoError(t, err)
+	require.Len(t, orgUsers, 1)
+}


### PR DESCRIPTION
Turns out we were correctly setting `deleted_at` in the postgresql code but not honouring that when we listed users in an organization.

Thanks to @paulbellamy for doing the Squirrel stuff.

Also adds a `storage_test` file for direct tests of the storage interface.

Last remaining component of #581. Fixes issue introduced in #661. 
