### PR TITLE
Don't scrap cluster add ons

### DIFF
--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -20,6 +20,9 @@ scrape_configs:
   #   prometheus.io.port - scrape this port
   #   prometheus.io.path - scrape this path
   relabel_configs:
+  - source_labels: [__meta_kubernetes_service_label_kubernetes_io_cluster_service]
+    action: drop
+    regex: true
   - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
     action: drop
     regex: false


### PR DESCRIPTION
They are not instrumented, and we can annotate them with the "no scrape" flag.
