### PR TITLE
Report memcache is in default namespace

### DIFF
--- a/monitoring/grafana/reports.json
+++ b/monitoring/grafana/reports.json
@@ -827,7 +827,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(memcached_current_bytes) by (instance) / sum(memcached_limit_bytes) by (instance)",
+              "expr": "sum(memcached_current_bytes{namespace=\"default\"}) by (instance) / sum(memcached_limit_bytes{namespace=\"default\"}) by (instance)",
               "interval": "",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",


### PR DESCRIPTION
... there is another in the frankenstein namespace, and they shouldn't be confused.
