### PR TITLE
Add view analytics

### DIFF
--- a/ui-server/client/src/pages/onboarding/instances-deleted.jsx
+++ b/ui-server/client/src/pages/onboarding/instances-deleted.jsx
@@ -7,7 +7,7 @@ import InstancesList from '../instances/instances-list';
 export default class IntancesPicker extends React.Component {
 
   componentDidMount() {
-    trackView('InstancePicker');
+    trackView('InstanceDeleted');
   }
 
   render() {

--- a/ui-server/client/src/pages/onboarding/instances-select.jsx
+++ b/ui-server/client/src/pages/onboarding/instances-select.jsx
@@ -6,7 +6,7 @@ import { browserHistory } from 'react-router';
 
 import { encodeURIs } from '../../common/request';
 import { getProbes } from '../../common/api';
-import { trackException } from '../../common/tracking';
+import { trackException, trackView } from '../../common/tracking';
 
 export default class InstancesSelect extends React.Component {
 
@@ -24,6 +24,7 @@ export default class InstancesSelect extends React.Component {
 
   componentDidMount() {
     this.checkProbes();
+    trackView('InstanceSelect');
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
- react components that call `trackView()` will issue a request to the
  analytics API
- URL has shape: `/api/analytics/view/<fromView>/<toView>/<timeSpentOnFromInMs>`, e.g., `/api/analytics/view/organization/wrapper/12000` means the user spent 12 seconds on the org page before going to the Scope wrapper
- if `toView` is `null`, it means the user landed on that page and the
  time value was the time to render

Related to #759
