### PR TITLE
Don't do any rate limiting in nginx

### DIFF
--- a/frontend-mt/default.conf
+++ b/frontend-mt/default.conf
@@ -1,10 +1,3 @@
-# Each $binary_remote_addr occupies 64 bytes.
-# So, 64 MB should allow tracking roughly 1 million clients
-# (64*2^20/64 = 2^20 = 1048576), limit after which nginx will start
-# returning 503s for the rate-limited locations.
-limit_req_zone $binary_remote_addr zone=antibf:64m rate=1r/s;
-limit_req_zone $binary_remote_addr zone=antidos:64m rate=10r/s;
-
 # Prometheus instrumentation
 lua_shared_dict prometheus_metrics 10M;
 lua_package_path "/lua/?.lua";

--- a/frontend-mt/routes.conf
+++ b/frontend-mt/routes.conf
@@ -1,16 +1,7 @@
 # Users service
 location = /api/users/login {
-  # Apply anti-bruteforce rate-limitting to login.
-  # Any additional requests coming from clients exceeding the
-  # rate-limit are put into a shared queue of 5 requests (which
-  # will start discarding requests with 503s when full)
-  limit_req zone=antibf burst=5;
   proxy_pass http://users.default.svc.cluster.local$request_uri;
 }
-
-# Apply a more relaxed anti-DoS rate-limiting to all
-# authentication-unrelated endpoints
-limit_req zone=antidos burst=10;
 
 location /api/users/ {
   proxy_pass http://users.default.svc.cluster.local$request_uri;


### PR DESCRIPTION
All the requests come from a small set of IPs (the ELBs).

Should reenable this when we do #38 (and use the ELBs for SSL)
