### PR TITLE
[API-Only] Already attached interstitial

### DIFF
--- a/ui-server/client/src/pages/landing/login.jsx
+++ b/ui-server/client/src/pages/landing/login.jsx
@@ -47,12 +47,13 @@ export default class Login extends React.Component {
     }
 
     let url = '/api/users/login';
+    const params = Object.assign({}, this.props.params, this.props.location.query);
     if (this.props.params.provider) {
       url = `/api/users/logins/${this.props.params.provider}/attach`;
+      params.force = true;
     }
 
-    getData(url, Object.assign({}, this.props.params, this.props.location.query))
-      .then(this._handleLoginSuccess, this._handleLoginError);
+    getData(url, params).then(this._handleLoginSuccess, this._handleLoginError);
   }
 
   _handleLoginSuccess(resp) {

--- a/users/errors.go
+++ b/users/errors.go
@@ -16,6 +16,27 @@ func ValidationErrorf(format string, args ...interface{}) ValidationError {
 	return ValidationError(fmt.Errorf(format, args...))
 }
 
+// AlreadyAttachedError is when an oauth login is already attached to some other account
+type AlreadyAttachedError struct {
+	ID    string
+	Email string
+}
+
+func (err AlreadyAttachedError) Error() string {
+	return fmt.Sprintf("Login is already attached to %q", err.Email)
+}
+
+// Metadata implements WithMetadata
+func (err AlreadyAttachedError) Metadata() map[string]interface{} {
+	return map[string]interface{}{"email": err.Email}
+}
+
+// WithMetadata is the interface errors should implement if they want to
+// include other information when rendered via the API.
+type WithMetadata interface {
+	Metadata() map[string]interface{}
+}
+
 // These are specific instances of errors the users application deals with.
 var (
 	ErrForbidden                  = errors.New("Forbidden found")

--- a/users/render/errors.go
+++ b/users/render/errors.go
@@ -19,7 +19,7 @@ func errorStatusCode(err error) int {
 	}
 
 	switch err.(type) {
-	case users.MalformedInputError, users.ValidationError:
+	case users.MalformedInputError, users.ValidationError, users.AlreadyAttachedError:
 		return http.StatusBadRequest
 	}
 
@@ -34,10 +34,13 @@ func Error(w http.ResponseWriter, r *http.Request, err error) {
 	if code == http.StatusInternalServerError {
 		http.Error(w, `{"errors":[{"message":"An internal server error occurred"}]}`, http.StatusInternalServerError)
 	} else {
+		m := map[string]interface{}{}
+		if err, ok := err.(users.WithMetadata); ok {
+			m = err.Metadata()
+		}
+		m["message"] = err.Error()
 		JSON(w, code, map[string][]map[string]interface{}{
-			"errors": {
-				{"message": err.Error()},
-			},
+			"errors": {m},
 		})
 	}
 }


### PR DESCRIPTION
Should fix #503, and #513 

This currently the API support (and my attempt at the react) for showing an interstitial page when re-assigning an oauth account.

The flow is you would click "Attach", go do github/google, then be shows the AttachPage (which asks if you want to re-assign the account from otheruser@gmail.com, or not). Then if you say "Do it", it should call the `.../attach?force=true` endpoint.

With this, if you call the `.../attach` endpoint, when it is already attached it will return a `400 Bad Request`, with a body of:

``` json
{
  "errors": [
    {
      "message": "Login is already attached to otherUser@gmail.com",
      "email":"otherUser@gmail.com"
    }
  ]
}
```

To re-assign it you then call the same endpoint with `?force=true` query param added.

@davkal, or @foot, I could use some help with the JS. I have no idea what's wrong. it keeps throwing some obscure minified error... Also, please let me know if the api will work, or if I should set it up differently...
