### PR TITLE
Alert then deployments have no availible replicas

### DIFF
--- a/monitoring/prometheus/alert.rules
+++ b/monitoring/prometheus/alert.rules
@@ -149,7 +149,7 @@ ALERT DeploymentGenerationMismatch
   }
 
 ALERT DeploymentReplicasMismatch
-  IF          k8s_deployment_spec_replicas{job="kube-api-exporter"} != k8s_deployment_status_availableReplicas{job="kube-api-exporter"}
+  IF          (k8s_deployment_spec_replicas{job="kube-api-exporter"} != k8s_deployment_status_availableReplicas{job="kube-api-exporter"}) or (k8s_deployment_spec_replicas{job="kube-api-exporter"} unless k8s_deployment_status_availableReplicas{job="kube-api-exporter"})
   FOR         5m
   LABELS      { severity="critical" }
   ANNOTATIONS {


### PR DESCRIPTION
This was a missed case; currently the users-db-exporter is failing to deploy and we weren't alerted.
