### PR TITLE
Fix spelling of version info on /api

### DIFF
--- a/frontend-mt/api.json
+++ b/frontend-mt/api.json
@@ -1,1 +1,1 @@
-{"id": "sccopeservice", "version": "0.1"}
+{"id": "scopeservice","version": "0.1"}


### PR DESCRIPTION
```
$ curl cloud.weave.works/api
{"id": "sccopeservice", "version": "0.1"}
```

oddly, dev was not affected:

```
$ curl frontend.dev.weave.works/api
{"id":"scopeservice-dev","version":"0.1"}
```

Anyone know how ^ is written on dev?
