### PR TITLE
Use the alert summary as the slack message.

### DIFF
--- a/monitoring/alertmanager/alertmanager-dev.yml
+++ b/monitoring/alertmanager/alertmanager-dev.yml
@@ -16,3 +16,4 @@ receivers:
     channel: cloud
     send_resolved: true
     username: dev-alert
+    text: "<!channel> {{ .CommonLabels.alertname }}: {{ .CommonAnnotations.summary }}"

--- a/monitoring/alertmanager/alertmanager-prod.yml
+++ b/monitoring/alertmanager/alertmanager-prod.yml
@@ -62,6 +62,7 @@ receivers:
     channel: cloud
     send_resolved: true
     username: prod-alert
+    text: "<!channel> {{ .CommonLabels.alertname }}: {{ .CommonAnnotations.summary }}"
 
 - name: 'service-alerts-critical'
   email_configs:


### PR DESCRIPTION
We got an alert like this:

<img width="456" alt="screen shot 2016-09-15 at 11 58 40" src="https://cloud.githubusercontent.com/assets/444037/18547526/c4a7a022-7b3b-11e6-857e-480464699811.png">

Which was misleading, as the job which failed to deploy was in frankenstein (the retrievers).

This should fix it.
