### PR TITLE
Don't wrap edit button w/ long instance names

### DIFF
--- a/ui-server/client/src/components/toolbar.jsx
+++ b/ui-server/client/src/components/toolbar.jsx
@@ -85,7 +85,12 @@ export default class Toolbar extends React.Component {
         top: 2
       },
       toolbarCenter: {
-        padding: 8
+        padding: 8,
+        position: 'relative',
+        display: 'flex',
+        // gotta set w/ overflowing things otherwise minWidth is something complicated like the
+        // size of the overflowing stuff.
+        minWidth: 0,
       },
       toolbarLeft: {
         top: 2,
@@ -101,6 +106,14 @@ export default class Toolbar extends React.Component {
         backgroundColor: '#e4e4ed',
         position: 'absolute',
         width: '100%'
+      },
+      buttonLabelStyle: {
+        // width fit the container
+        display: 'block',
+        // ellipsis!
+        textOverflow: 'ellipsis',
+        overflow: 'hidden',
+        whiteSpace: 'nowrap',
       }
     };
 
@@ -127,39 +140,39 @@ export default class Toolbar extends React.Component {
               <Logo />
             </div>
             <div style={styles.toolbarCenter}>
-              <div style={{position: 'relative', display: 'flex'}}>
-                <IconMenu
-                  // don't animate onClose
-                  animated={false}
-                  // close immediately don't wait for 200ms.
-                  touchTapCloseDelay={1}
-                  open={instancesMenuOpen}
-                  onRequestChange={instancesMenuRequestChange}
-                  iconButtonElement={viewSelectorButton}
-                  anchorOrigin={{horizontal: 'left', vertical: 'top'}}
-                  targetOrigin={{horizontal: 'left', vertical: 'top'}}>
-                    {this.props.instances.map(ins => <InstanceItem key={ins.id} {...ins} />)}
-                    <Divider />
-                    <MenuItem
-                      style={{lineHeight: '24px', fontSize: 13, cursor: 'pointer'}}
-                      primaryText="Create new instance"
-                      onClick={this.handleClickCreateInstance} />
-                </IconMenu>
-                <FlatButton
-                  style={{color: viewColor}}
-                  onClick={this.handleClickInstance}
-                  label={viewText} />
-                {hasProm && <FlatButton style={styles.toolbarButton}
-                  onClick={this.handleClickProm}>
-                    <FontIcon className="fa fa-area-chart" color={promColor}
-                      style={styles.toolbarButtonIcon} />
-                  </FlatButton>
-                }
-                <FlatButton style={styles.toolbarButton} onClick={this.handleClickSettings}>
-                  <FontIcon className="fa fa-cog" color={settingsColor}
+              <IconMenu
+                // don't animate onClose
+                animated={false}
+                // close immediately don't wait for 200ms.
+                touchTapCloseDelay={1}
+                open={instancesMenuOpen}
+                onRequestChange={instancesMenuRequestChange}
+                iconButtonElement={viewSelectorButton}
+                anchorOrigin={{horizontal: 'left', vertical: 'top'}}
+                targetOrigin={{horizontal: 'left', vertical: 'top'}}>
+                  {this.props.instances.map(ins => <InstanceItem key={ins.id} {...ins} />)}
+                  <Divider />
+                  <MenuItem
+                    style={{lineHeight: '24px', fontSize: 13, cursor: 'pointer'}}
+                    primaryText="Create new instance"
+                    onClick={this.handleClickCreateInstance} />
+              </IconMenu>
+              <FlatButton
+                style={{color: viewColor}}
+                title={viewText}
+                labelStyle={styles.buttonLabelStyle}
+                onClick={this.handleClickInstance}
+                label={viewText} />
+              {hasProm && <FlatButton style={styles.toolbarButton}
+                onClick={this.handleClickProm}>
+                  <FontIcon className="fa fa-area-chart" color={promColor}
                     style={styles.toolbarButtonIcon} />
                 </FlatButton>
-              </div>
+              }
+              <FlatButton style={styles.toolbarButton} onClick={this.handleClickSettings}>
+                <FontIcon className="fa fa-cog" color={settingsColor}
+                  style={styles.toolbarButtonIcon} />
+              </FlatButton>
             </div>
             <div style={styles.toolbarRight}>
             <FlatButton style={styles.toolbarButton} labelStyle={{color: accountColor}}

--- a/ui-server/client/src/pages/instances/instances-delete.jsx
+++ b/ui-server/client/src/pages/instances/instances-delete.jsx
@@ -82,6 +82,10 @@ export default class InstancesDelete extends React.Component {
 
   render() {
     const styles = {
+      label: {
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+      },
       deleteError: {
         display: this.state.deleteErrorText ? 'block' : 'none'
       },
@@ -109,9 +113,11 @@ export default class InstancesDelete extends React.Component {
     ];
 
     return (
-      <div style={this.props.style}>
+      <div>
         <div style={styles.heading}>Delete this instance</div>
-        <p>You can delete this Weave Cloud instance for your cluster {instanceName}</p>
+        <p style={styles.label}>
+          You can delete this Weave Cloud instance for your cluster {instanceName}
+        </p>
         <div style={styles.deleteError}>
           <p style={styles.errorLabel}>
             {this.state.deleteErrorText}

--- a/ui-server/client/src/pages/instances/instances-list.jsx
+++ b/ui-server/client/src/pages/instances/instances-list.jsx
@@ -56,7 +56,8 @@ export default class IntancesList extends React.Component {
     return (
       <ListItem
         onClick={selectInstance}
-        style={{paddingRight: 64}}
+        title={instance.name}
+        style={{paddingRight: 64, maxWidth: '90vw', overflow: 'hidden'}}
         key={instance.id}
         primaryText={instance.name}
         secondaryText={instance.id}

--- a/ui-server/client/src/pages/organization/name.jsx
+++ b/ui-server/client/src/pages/organization/name.jsx
@@ -90,18 +90,26 @@ export default class Users extends React.Component {
 
     const styles = {
       button: {
+        //
+        // We're in an h2 w/ fontSize: 36px which seems to muck up the vertical alignment of the
+        // button label. Theory: The nested div matui uses for the ripple layed inherits
+        // "-webkit-margin-before: 0.83em" from the h2.
+        //
+        fontSize: '14px',
         marginLeft: '0.5em'
       },
       labelContainer: {
         display: 'flex'
       },
       label: {
-        flex: 1
+        flex: 1,
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
       }
     };
-
+    const name = this.state.editingName || this.props.name;
     return (
-      <span>
+      <div>
         <Snackbar
           action="ok"
           open={Boolean(this.state.notices)}
@@ -109,7 +117,7 @@ export default class Users extends React.Component {
           onActionTouchTap={this.clearErrors}
           onRequestClose={this.clearErrors}
         />
-        {editing && <span>
+        {editing && <div>
           <TextField
             onChange={this.handleChangeNameInput}
             value={this.state.editingName}
@@ -128,10 +136,10 @@ export default class Users extends React.Component {
             style={styles.button}
             onClick={this.handleClickCancel}
             />
-          </span>}
+          </div>}
         {!editing && <div style={styles.labelContainer}>
-          <div style={styles.label}>
-            {this.props.prefix} {this.state.editingName || this.props.name}
+          <div style={styles.label} title={name}>
+            {this.props.prefix} {name}
           </div>
           <FlatButton
             label="Edit"
@@ -139,7 +147,7 @@ export default class Users extends React.Component {
             onClick={this.handleClickEdit}
             />
           </div>}
-      </span>
+      </div>
     );
   }
 


### PR DESCRIPTION
- keep everything on one line in the toolbar w/ really long instance
  names
- Fixes small bug where the instance selector would re-open when used
  from the settings page.

Fixes #830 
