### PR TITLE
Set feature flags easier

### DIFF
--- a/users/api/admin.go
+++ b/users/api/admin.go
@@ -3,6 +3,8 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"sort"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
@@ -21,11 +23,24 @@ func (a *API) admin(w http.ResponseWriter, r *http.Request) {
 		<h1>User service</h1>
 		<ul>
 			<li><a href="private/api/users">Users</a></li>
+			<li><a href="private/api/organizations">Organizations</a></li>
 			<li><a href="private/api/pardot">Sync User-Creation with Pardot</a></li>
 		</ul>
 	</body>
 </html>
 `)
+}
+
+type listUsersView struct {
+	Users []privateUserView `json:"organizations"`
+}
+
+type privateUserView struct {
+	ID           string `json:"id"`
+	Email        string `json:"email"`
+	CreatedAt    string `json:"created_at"`
+	FirstLoginAt string `json:"first_login_at"`
+	Admin        bool   `json:"admin"`
 }
 
 func (a *API) listUsers(w http.ResponseWriter, r *http.Request) {
@@ -34,15 +49,30 @@ func (a *API) listUsers(w http.ResponseWriter, r *http.Request) {
 		render.Error(w, r, err)
 		return
 	}
-	b, err := a.templates.Bytes("list_users.html", map[string]interface{}{
-		"Users": users,
-	})
-	if err != nil {
-		render.Error(w, r, err)
-		return
-	}
-	if _, err := w.Write(b); err != nil {
-		logrus.Warn("list users: %v", err)
+	switch render.Format(r) {
+	case render.FormatJSON:
+		view := listUsersView{}
+		for _, user := range users {
+			view.Users = append(view.Users, privateUserView{
+				ID:           user.ID,
+				Email:        user.Email,
+				CreatedAt:    user.FormatCreatedAt(),
+				FirstLoginAt: user.FormatFirstLoginAt(),
+				Admin:        user.Admin,
+			})
+		}
+		render.JSON(w, http.StatusOK, view)
+	default: // render.FormatHTML
+		b, err := a.templates.Bytes("list_users.html", map[string]interface{}{
+			"Users": users,
+		})
+		if err != nil {
+			render.Error(w, r, err)
+			return
+		}
+		if _, err := w.Write(b); err != nil {
+			logrus.Warn("list users: %v", err)
+		}
 	}
 }
 
@@ -51,7 +81,11 @@ type listOrganizationsView struct {
 }
 
 type privateOrgView struct {
-	ID string `json:"id"`
+	ID                 string   `json:"id"`
+	Name               string   `json:"name"`
+	CreatedAt          string   `json:"created_at"`
+	FirstProbeUpdateAt string   `json:"first_probe_update_at,omitempty"`
+	FeatureFlags       []string `json:"feature_flags,omitempty"`
 }
 
 func (a *API) listOrganizations(w http.ResponseWriter, r *http.Request) {
@@ -61,13 +95,71 @@ func (a *API) listOrganizations(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	view := listOrganizationsView{}
-	for _, org := range organizations {
-		view.Organizations = append(view.Organizations, privateOrgView{
-			ID: org.ID,
+	switch render.Format(r) {
+	case render.FormatJSON:
+		view := listOrganizationsView{}
+		for _, org := range organizations {
+			view.Organizations = append(view.Organizations, privateOrgView{
+				ID:                 org.ExternalID,
+				Name:               org.Name,
+				CreatedAt:          org.FormatCreatedAt(),
+				FirstProbeUpdateAt: org.FormatFirstProbeUpdateAt(),
+				FeatureFlags:       org.FeatureFlags,
+			})
+		}
+		render.JSON(w, http.StatusOK, view)
+	default: // render.FormatHTML
+		orgUsers := map[string]int{}
+		for _, org := range organizations {
+			us, err := a.db.ListOrganizationUsers(org.ExternalID)
+			if err != nil {
+				render.Error(w, r, err)
+				return
+			}
+			orgUsers[org.ExternalID] = len(us)
+		}
+
+		b, err := a.templates.Bytes("list_organizations.html", map[string]interface{}{
+			"Organizations":     organizations,
+			"OrganizationUsers": orgUsers,
 		})
+		if err != nil {
+			render.Error(w, r, err)
+			return
+		}
+		if _, err := w.Write(b); err != nil {
+			logrus.Warn("list organizations: %v", err)
+		}
 	}
-	render.JSON(w, http.StatusOK, view)
+}
+
+func (a *API) setOrgFeatureFlags(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	orgExternalID, ok := vars["orgExternalID"]
+	if !ok {
+		render.Error(w, r, users.ErrNotFound)
+		return
+	}
+
+	uniqueFlags := map[string]struct{}{}
+	for _, f := range strings.Fields(r.FormValue("feature_flags")) {
+		uniqueFlags[f] = struct{}{}
+	}
+	var sortedFlags []string
+	for f := range uniqueFlags {
+		sortedFlags = append(sortedFlags, f)
+	}
+	sort.Strings(sortedFlags)
+
+	if err := a.db.SetFeatureFlags(orgExternalID, sortedFlags); err != nil {
+		render.Error(w, r, err)
+		return
+	}
+	redirectTo := r.FormValue("redirect_to")
+	if redirectTo == "" {
+		redirectTo = "/private/api/organizations"
+	}
+	http.Redirect(w, r, redirectTo, http.StatusFound)
 }
 
 func (a *API) pardotRefresh(w http.ResponseWriter, r *http.Request) {

--- a/users/api/routes.go
+++ b/users/api/routes.go
@@ -77,9 +77,10 @@ func (a *API) routes() http.Handler {
 		// Internal stuff for our internal usage, internally.
 		{"loadgen", "GET", "/loadgen", func(w http.ResponseWriter, _ *http.Request) { fmt.Fprintf(w, "OK") }},
 		{"root", "GET", "/", a.admin},
-		{"private_api_users", "GET", "/private/api/users", a.listUsers},
-		{"private_api_instances", "GET", "/private/api/organizations", a.listOrganizations},
+		{"private_api_organizations", "GET", "/private/api/organizations", a.listOrganizations},
+		{"private_api_organizations_orgExternalID_featureFlags", "POST", "/private/api/organizations/{orgExternalID}/featureflags", a.setOrgFeatureFlags},
 		{"private_api_pardot", "GET", "/private/api/pardot", a.pardotRefresh},
+		{"private_api_users", "GET", "/private/api/users", a.listUsers},
 		{"private_api_users_userID_admin", "POST", "/private/api/users/{userID}/admin", a.makeUserAdmin},
 	} {
 		r.Handle(route.path, route.handler).Methods(route.method).Name(route.name)

--- a/users/db/db.go
+++ b/users/db/db.go
@@ -90,6 +90,7 @@ type DB interface {
 	GetOrganizationName(externalID string) (string, error)
 	DeleteOrganization(externalID string) error
 	AddFeatureFlag(externalID string, featureFlag string) error
+	SetFeatureFlags(externalID string, featureFlags []string) error
 
 	Close() error
 }

--- a/users/db/db_test.go
+++ b/users/db/db_test.go
@@ -44,3 +44,21 @@ func Test_DB_AddFeatureFlag(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, org.FeatureFlags, []string{"supercow"})
 }
+
+func Test_DB_SetFeatureFlags(t *testing.T) {
+	db := dbtest.Setup(t)
+	defer dbtest.Cleanup(t, db)
+
+	_, org := dbtest.GetOrg(t, db)
+
+	for _, flags := range [][]string{
+		{"supercow", "superchicken"},
+		{"superchicken"},
+	} {
+		err := db.SetFeatureFlags(org.ExternalID, flags)
+		require.NoError(t, err)
+		org, err = db.FindOrganizationByProbeToken(org.ProbeToken)
+		require.NoError(t, err)
+		require.Equal(t, flags, org.FeatureFlags)
+	}
+}

--- a/users/db/memory/organization.go
+++ b/users/db/memory/organization.go
@@ -280,3 +280,18 @@ func (d *DB) AddFeatureFlag(externalID string, featureFlag string) error {
 	o.FeatureFlags = append(o.FeatureFlags, featureFlag)
 	return nil
 }
+
+// SetFeatureFlags sets all feature flags of an organization.
+func (d *DB) SetFeatureFlags(externalID string, featureFlags []string) error {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+	o, err := d.findOrganizationByExternalID(externalID)
+	if err == users.ErrNotFound {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	o.FeatureFlags = featureFlags
+	return nil
+}

--- a/users/db/postgres/organization.go
+++ b/users/db/postgres/organization.go
@@ -322,3 +322,12 @@ func (d DB) AddFeatureFlag(externalID string, featureFlag string) error {
 	)
 	return err
 }
+
+// SetFeatureFlags sets all feature flags of an organization.
+func (d DB) SetFeatureFlags(externalID string, featureFlags []string) error {
+	_, err := d.Exec(
+		`update organizations set feature_flags = $1 where lower(external_id) = lower($2)`,
+		pq.Array(featureFlags), externalID,
+	)
+	return err
+}

--- a/users/db/timed.go
+++ b/users/db/timed.go
@@ -247,6 +247,12 @@ func (t timed) AddFeatureFlag(externalID string, featureFlag string) error {
 	})
 }
 
+func (t timed) SetFeatureFlags(externalID string, featureFlags []string) error {
+	return t.timeRequest("SetFeatureFlags", func() error {
+		return t.d.SetFeatureFlags(externalID, featureFlags)
+	})
+}
+
 func (t timed) Close() error {
 	return t.timeRequest("Close", func() error {
 		return t.d.Close()

--- a/users/db/traced.go
+++ b/users/db/traced.go
@@ -162,6 +162,11 @@ func (t traced) AddFeatureFlag(externalID string, featureFlag string) (err error
 	return t.d.AddFeatureFlag(externalID, featureFlag)
 }
 
+func (t traced) SetFeatureFlags(externalID string, featureFlags []string) (err error) {
+	defer func() { t.trace("SetFeatureFlags", externalID, featureFlags, err) }()
+	return t.d.SetFeatureFlags(externalID, featureFlags)
+}
+
 func (t traced) Close() (err error) {
 	defer func() { t.trace("Close", err) }()
 	return t.d.Close()

--- a/users/organization.go
+++ b/users/organization.go
@@ -45,3 +45,13 @@ func (o *Organization) Valid() error {
 	}
 	return nil
 }
+
+// FormatCreatedAt formats the org's created at timestamp
+func (o *Organization) FormatCreatedAt() string {
+	return formatTimestamp(o.CreatedAt)
+}
+
+// FormatFirstProbeUpdateAt formats the org's first probe update at timestamp
+func (o *Organization) FormatFirstProbeUpdateAt() string {
+	return formatTimestamp(o.FirstProbeUpdateAt)
+}

--- a/users/render/format.go
+++ b/users/render/format.go
@@ -1,0 +1,31 @@
+package render
+
+import (
+	"net/http"
+	"strings"
+)
+
+// These are the supported response formats
+const (
+	FormatHTML = "text/html"
+	FormatJSON = "application/json"
+	FormatText = "text/plain"
+)
+
+// Format checks the accept header format for a request
+// TODO: Use a better mime-type parser
+func Format(r *http.Request) string {
+	header := r.Header.Get("Accept")
+	for _, f := range []string{
+		FormatHTML,
+		FormatJSON,
+		FormatText,
+	} {
+		if header == f || strings.HasPrefix(header, f) {
+			return f
+		}
+	}
+
+	// HTML is the default
+	return FormatHTML
+}

--- a/users/templates/list_organizations.html
+++ b/users/templates/list_organizations.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Weave Cloud - Organizations</title>
+  </head>
+  <body>
+    <h2>Organizations</h2>
+    {{with .}}
+    <table>
+      <tr>
+        <th>ID</th>
+        <th>Name</th>
+        <th>CreatedAt</th>
+        <th>FirstProbeUpdateAt</th>
+        <th>Users</th>
+        <th>FeatureFlags</th>
+      </tr>
+      {{range .Organizations}}
+      <tr>
+        <td>{{.ExternalID}}</td>
+        <td>{{.Name}}</td>
+        <td>{{.FormatCreatedAt}}</td>
+        <td>{{.FormatFirstProbeUpdateAt}}</td>
+        <td>{{index $.OrganizationUsers .ExternalID}}</td>
+        <td>
+          <form action="organizations/{{.ExternalID}}/featureflags" method="POST">
+            <input type="hidden" name="redirect_to" value="../../organizations" />
+            <input type="text" name="feature_flags" value="{{range .FeatureFlags}}{{.}} {{end}}" />
+            <input type="submit" value="Save" />
+          </form>
+        </td>
+      </tr>
+      {{end}}
+    </table>
+    {{else}}
+    <p>No organizations.</p>
+    {{end}}
+  </body>
+</html>


### PR DESCRIPTION
Adds `Accept: application/json` support to `/private/api/organizations` endpoint, so we can render html for browsers.

Fixes #849

Based on #860, so will be a smaller diff after that.
