### PR TITLE
Remove vestigial approval code

### DIFF
--- a/users/api/account_test.go
+++ b/users/api/account_test.go
@@ -17,7 +17,7 @@ func Test_Account_AttachOauthAccount(t *testing.T) {
 	setup(t)
 	defer cleanup(t)
 
-	user := getApprovedUser(t)
+	user := getUser(t)
 
 	remoteEmail := "fran@example.com"
 	logins.Register("mock", MockLoginProvider{
@@ -58,8 +58,8 @@ func Test_Account_AttachOauthAccount_AlreadyAttachedToAnotherAccount(t *testing.
 	setup(t)
 	defer cleanup(t)
 
-	user := getApprovedUser(t)
-	fran := getApprovedUser(t)
+	user := getUser(t)
+	fran := getUser(t)
 	require.NoError(t, database.AddLoginToUser(fran.ID, "mock", "fran", nil))
 	fran, err := database.FindUserByID(fran.ID)
 	require.NoError(t, err)
@@ -129,7 +129,7 @@ func Test_Account_AttachOauthAccount_AlreadyAttachedToSameAccount(t *testing.T) 
 	setup(t)
 	defer cleanup(t)
 
-	user := getApprovedUser(t)
+	user := getUser(t)
 
 	// Should be associated to same user
 	assert.NoError(t, database.AddLoginToUser(user.ID, "mock", "joe", nil))
@@ -178,7 +178,7 @@ func Test_Account_ListAttachedLoginProviders(t *testing.T) {
 	setup(t)
 	defer cleanup(t)
 
-	user := getApprovedUser(t)
+	user := getUser(t)
 
 	logins.Register("mock", MockLoginProvider{
 		// Different remote email, to prevent auto-matching
@@ -235,7 +235,7 @@ func Test_Account_DetachOauthAccount(t *testing.T) {
 	setup(t)
 	defer cleanup(t)
 
-	user := getApprovedUser(t)
+	user := getUser(t)
 
 	mockLoginProvider := MockLoginProvider{"joe": {ID: "joe", Email: user.Email}}
 	logins.Register("mock", mockLoginProvider)

--- a/users/api/admin.go
+++ b/users/api/admin.go
@@ -80,9 +80,6 @@ func (a *API) pardotRefresh(w http.ResponseWriter, r *http.Request) {
 	for _, user := range users {
 		// tell pardot about the users
 		a.pardotClient.UserCreated(user.Email, user.CreatedAt)
-		if !user.ApprovedAt.IsZero() {
-			a.pardotClient.UserApproved(user.Email, user.ApprovedAt)
-		}
 	}
 }
 

--- a/users/api/api_tokens_test.go
+++ b/users/api/api_tokens_test.go
@@ -17,7 +17,7 @@ func Test_APITokens_CreateAndUseAPIToken(t *testing.T) {
 	setup(t)
 	defer cleanup(t)
 
-	user := getApprovedUser(t)
+	user := getUser(t)
 	org1 := createOrgForUser(t, user)
 	org2 := createOrgForUser(t, user)
 

--- a/users/api/helpers_test.go
+++ b/users/api/helpers_test.go
@@ -75,8 +75,8 @@ func requestAs(t *testing.T, u *users.User, method, endpoint string, body io.Rea
 	return r
 }
 
-func getApprovedUser(t *testing.T) *users.User {
-	return dbtest.GetApprovedUser(t, database)
+func getUser(t *testing.T) *users.User {
+	return dbtest.GetUser(t, database)
 }
 
 func createOrgForUser(t *testing.T, u *users.User) *users.Organization {

--- a/users/api/invite_test.go
+++ b/users/api/invite_test.go
@@ -75,7 +75,7 @@ func Test_InviteExistingUser(t *testing.T) {
 	defer cleanup(t)
 
 	user, org := getOrg(t)
-	fran := getApprovedUser(t)
+	fran := getUser(t)
 
 	body := requestInvite(t, user, org, fran.Email, http.StatusOK)
 	assert.Equal(t, map[string]interface{}{
@@ -149,8 +149,8 @@ func Test_Invite_UserToAnOrgIDontOwn(t *testing.T) {
 	setup(t)
 	defer cleanup(t)
 
-	user := getApprovedUser(t)
-	otherUser := getApprovedUser(t)
+	user := getUser(t)
+	otherUser := getUser(t)
 	_, otherOrg := getOrg(t)
 
 	requestInvite(t, user, otherOrg, otherUser.Email, http.StatusForbidden)
@@ -159,25 +159,6 @@ func Test_Invite_UserToAnOrgIDontOwn(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, organizations, 0)
 	assert.Len(t, sentEmails, 0)
-}
-
-func Test_Invite_UserNotApproved(t *testing.T) {
-	setup(t)
-	defer cleanup(t)
-
-	user, org := getOrg(t)
-
-	fran, err := database.CreateUser("fran@weave.works")
-	require.NoError(t, err)
-
-	requestInvite(t, user, org, fran.Email, http.StatusOK)
-
-	organizations, err := database.ListOrganizationsForUserIDs(fran.ID)
-	require.NoError(t, err)
-	require.Len(t, organizations, 1)
-	assert.Equal(t, org.ID, organizations[0].ID)
-
-	assertEmailSent(t, fran.Email, "has granted you access")
 }
 
 func Test_Invite_UserInDifferentOrganization(t *testing.T) {
@@ -203,7 +184,7 @@ func Test_Invite_RemoveOtherUsersAccess(t *testing.T) {
 	defer cleanup(t)
 
 	user, org := getOrg(t)
-	otherUser := getApprovedUser(t)
+	otherUser := getUser(t)
 	otherUser, _, err := database.InviteUser(otherUser.Email, org.ExternalID)
 	require.NoError(t, err)
 	organizations, err := database.ListOrganizationsForUserIDs(otherUser.ID)

--- a/users/api/lookup_test.go
+++ b/users/api/lookup_test.go
@@ -114,7 +114,7 @@ func Test_Lookup_Admin(t *testing.T) {
 	setup(t)
 	defer cleanup(t)
 
-	user := getApprovedUser(t)
+	user := getUser(t)
 	require.NoError(t, database.SetUserAdmin(user.ID, true))
 
 	w := httptest.NewRecorder()
@@ -131,7 +131,7 @@ func Test_Lookup_Admin_Unauthorized(t *testing.T) {
 	setup(t)
 	defer cleanup(t)
 
-	user := getApprovedUser(t)
+	user := getUser(t)
 
 	w := httptest.NewRecorder()
 	r := requestAs(t, user, "GET", "/private/api/users/admin", nil)

--- a/users/api/org.go
+++ b/users/api/org.go
@@ -185,12 +185,6 @@ func (a *API) inviteUser(currentUser *users.User, w http.ResponseWriter, r *http
 		render.Error(w, r, err)
 		return
 	}
-	// Auto-approve all invited users
-	invitee, err = a.db.ApproveUser(invitee.ID)
-	if err != nil {
-		render.Error(w, r, err)
-		return
-	}
 	// We always do this so that the timing difference can't be used to infer a user's existence.
 	token, err := a.generateUserToken(invitee)
 	if err != nil {

--- a/users/api/org_test.go
+++ b/users/api/org_test.go
@@ -73,7 +73,7 @@ func Test_ListOrganizationUsers(t *testing.T) {
 
 	user, org := getOrg(t)
 
-	fran := getApprovedUser(t)
+	fran := getUser(t)
 	fran, _, err := database.InviteUser(fran.Email, org.ExternalID)
 	require.NoError(t, err)
 
@@ -90,7 +90,7 @@ func Test_RenameOrganization(t *testing.T) {
 	defer cleanup(t)
 
 	user, org := getOrg(t)
-	otherUser := getApprovedUser(t)
+	otherUser := getUser(t)
 	body := map[string]interface{}{"name": "my-organization"}
 
 	{
@@ -185,7 +185,7 @@ func Test_CustomExternalIDOrganization(t *testing.T) {
 	setup(t)
 	defer cleanup(t)
 
-	user := getApprovedUser(t)
+	user := getUser(t)
 
 	w := httptest.NewRecorder()
 	r := requestAs(t, user, "POST", "/api/users/org", jsonBody{
@@ -239,7 +239,7 @@ func Test_Organization_GenerateOrgExternalID(t *testing.T) {
 	setup(t)
 	defer cleanup(t)
 
-	user := getApprovedUser(t)
+	user := getUser(t)
 
 	// Generate a new org id
 	r := requestAs(t, user, "GET", "/api/users/generateOrgID", nil)
@@ -260,8 +260,8 @@ func Test_Organization_CheckIfExternalIDExists(t *testing.T) {
 	setup(t)
 	defer cleanup(t)
 
-	user := getApprovedUser(t)
-	otherUser := getApprovedUser(t)
+	user := getUser(t)
+	otherUser := getUser(t)
 
 	id, err := database.GenerateOrganizationExternalID()
 	require.NoError(t, err)
@@ -289,7 +289,7 @@ func Test_Organization_CreateMultiple(t *testing.T) {
 	setup(t)
 	defer cleanup(t)
 
-	user := getApprovedUser(t)
+	user := getUser(t)
 
 	r1 := requestAs(t, user, "POST", "/api/users/org", jsonBody{"id": "my-first-org", "name": "my first org"}.Reader(t))
 
@@ -319,8 +319,8 @@ func Test_Organization_Delete(t *testing.T) {
 	setup(t)
 	defer cleanup(t)
 
-	user := getApprovedUser(t)
-	otherUser := getApprovedUser(t)
+	user := getUser(t)
+	otherUser := getUser(t)
 
 	externalID, err := database.GenerateOrganizationExternalID()
 	require.NoError(t, err)
@@ -369,7 +369,7 @@ func Test_Organization_Name(t *testing.T) {
 	setup(t)
 	defer cleanup(t)
 
-	user := getApprovedUser(t)
+	user := getUser(t)
 	externalID, err := database.GenerateOrganizationExternalID()
 	name := "arbitrary name"
 	require.NoError(t, err)

--- a/users/api/sessions_test.go
+++ b/users/api/sessions_test.go
@@ -14,7 +14,7 @@ func Test_Sessions_EncodeDecode(t *testing.T) {
 	setup(t)
 	defer cleanup(t)
 
-	user := getApprovedUser(t)
+	user := getUser(t)
 
 	encoded, err := sessionStore.Encode(user.ID)
 	require.NoError(t, err)

--- a/users/api/signup_test.go
+++ b/users/api/signup_test.go
@@ -78,9 +78,6 @@ func Test_Signup(t *testing.T) {
 	loginLink, emailToken := findLoginLink(t, sentEmails[0])
 	assert.Contains(t, string(sentEmails[0].HTML), loginLink)
 
-	// Check they were immediately approved
-	assert.False(t, user.ApprovedAt.IsZero(), "user should be approved")
-
 	// Check the db one was hashed
 	assert.NotEqual(t, "", user.Token, "user should have a token set")
 	assert.NotEqual(t, user.Token, emailToken, "stored token should have been hashed")
@@ -206,7 +203,6 @@ func Test_Signup_ViaOAuth(t *testing.T) {
 	user, err := database.FindUserByEmail(email)
 	require.NoError(t, err)
 
-	assert.False(t, user.ApprovedAt.IsZero(), "user should be approved")
 	assert.Equal(t, "", user.Token, "user should not have a token set")
 	assert.False(t, user.FirstLoginAt.IsZero(), "Login should have set user's FirstLoginAt")
 
@@ -224,7 +220,7 @@ func Test_Signup_ViaOAuth_MatchesByEmail(t *testing.T) {
 	setup(t)
 	defer cleanup(t)
 
-	user := getApprovedUser(t)
+	user := getUser(t)
 	logins.Register("mock", MockLoginProvider{
 		"joe": {ID: "joe", Email: user.Email},
 	})
@@ -250,7 +246,6 @@ func Test_Signup_ViaOAuth_MatchesByEmail(t *testing.T) {
 	}, body)
 
 	assert.Equal(t, user.ID, found.ID, "user id should match the existing")
-	assert.False(t, found.ApprovedAt.IsZero(), "user should be approved")
 	assert.Equal(t, user.Token, found.Token, "user should still have same token set")
 	assert.False(t, found.FirstLoginAt.IsZero(), "Login should have set user's FirstLoginAt")
 
@@ -268,7 +263,7 @@ func Test_Signup_ViaOAuth_EmailChanged(t *testing.T) {
 	// When a user has changed their remote email, but the remote user ID is the same.
 	setup(t)
 	defer cleanup(t)
-	user := getApprovedUser(t)
+	user := getUser(t)
 	provider := MockLoginProvider{
 		"joe": {ID: "joe", Email: user.Email},
 	}

--- a/users/cmd/users/main.go
+++ b/users/cmd/users/main.go
@@ -33,7 +33,7 @@ func main() {
 		databaseMigrations = flag.String("database-migrations", "", "Path where the database migration files can be found")
 		emailURI           = flag.String("email-uri", "", "uri of smtp server to send email through, of the format: smtp://username:password@hostname:port.  Either email-uri or sendgrid-api-key must be provided. For local development, you can set this to: log://, which will log all emails.")
 		sessionSecret      = flag.String("session-secret", "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "Secret used validate sessions")
-		directLogin        = flag.Bool("direct-login", false, "Approve user and send login token in the signup response (DEV only)")
+		directLogin        = flag.Bool("direct-login", false, "Send login token in the signup response (DEV only)")
 
 		pardotEmail    = flag.String("pardot-email", "", "Email of Pardot account.  If not supplied pardot integration will be disabled.")
 		pardotPassword = flag.String("pardot-password", "", "Password of Pardot account.")

--- a/users/db/db.go
+++ b/users/db/db.go
@@ -68,9 +68,6 @@ type DB interface {
 	// users
 	ListAPITokensForUserIDs(userIDs ...string) ([]*users.APIToken, error)
 
-	// Approve the user for access. Should generate them a new organization.
-	ApproveUser(id string) (*users.User, error)
-
 	// Set the admin flag of a user
 	SetUserAdmin(id string, value bool) error
 

--- a/users/db/db_test.go
+++ b/users/db/db_test.go
@@ -13,7 +13,7 @@ func Test_DB_RemoveOtherUsersAccess(t *testing.T) {
 	defer dbtest.Cleanup(t, db)
 
 	_, org := dbtest.GetOrg(t, db)
-	otherUser := dbtest.GetApprovedUser(t, db)
+	otherUser := dbtest.GetUser(t, db)
 	otherUser, _, err := db.InviteUser(otherUser.Email, org.ExternalID)
 	require.NoError(t, err)
 	otherUserOrganizations, err := db.ListOrganizationsForUserIDs(otherUser.ID)

--- a/users/db/dbtest/helpers.go
+++ b/users/db/dbtest/helpers.go
@@ -29,13 +29,10 @@ func Cleanup(t *testing.T, database db.DB) {
 	require.NoError(t, database.Close())
 }
 
-// GetApprovedUser makes a randomly named, approved user
-func GetApprovedUser(t *testing.T, db db.DB) *users.User {
+// GetUser makes a randomly named user
+func GetUser(t *testing.T, db db.DB) *users.User {
 	email := fmt.Sprintf("%d@weave.works", rand.Int63())
 	user, err := db.CreateUser(email)
-	require.NoError(t, err)
-
-	user, err = db.ApproveUser(user.ID)
 	require.NoError(t, err)
 
 	return user
@@ -58,7 +55,7 @@ func CreateOrgForUser(t *testing.T, db db.DB, u *users.User) *users.Organization
 
 // GetOrg makes org with a random ExternalID and user for testing
 func GetOrg(t *testing.T, db db.DB) (*users.User, *users.Organization) {
-	user := GetApprovedUser(t, db)
+	user := GetUser(t, db)
 	org := CreateOrgForUser(t, db, user)
 	return user, org
 }

--- a/users/db/memory/user.go
+++ b/users/db/memory/user.go
@@ -188,24 +188,6 @@ func (d *DB) ListLoginsForUserIDs(userIDs ...string) ([]*login.Login, error) {
 	return logins, nil
 }
 
-// ApproveUser approves a user. Sort of deprecated, as all users are
-// auto-approved now.
-func (d *DB) ApproveUser(id string) (*users.User, error) {
-	d.mtx.Lock()
-	defer d.mtx.Unlock()
-	user, err := d.findUserByID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	if !user.ApprovedAt.IsZero() {
-		return user, nil
-	}
-
-	user.ApprovedAt = time.Now().UTC()
-	return user, err
-}
-
 // SetUserAdmin sets the admin flag of a user
 func (d *DB) SetUserAdmin(id string, value bool) error {
 	d.mtx.Lock()

--- a/users/db/timed.go
+++ b/users/db/timed.go
@@ -171,14 +171,6 @@ func (t timed) ListAPITokensForUserIDs(userIDs ...string) (ts []*users.APIToken,
 	return
 }
 
-func (t timed) ApproveUser(id string) (u *users.User, err error) {
-	t.timeRequest("ApproveUser", func() error {
-		u, err = t.d.ApproveUser(id)
-		return err
-	})
-	return
-}
-
 func (t timed) SetUserAdmin(id string, value bool) error {
 	return t.timeRequest("SetUserAdmin", func() error {
 		return t.d.SetUserAdmin(id, value)

--- a/users/db/traced.go
+++ b/users/db/traced.go
@@ -107,11 +107,6 @@ func (t traced) ListAPITokensForUserIDs(userIDs ...string) (ts []*users.APIToken
 	return t.d.ListAPITokensForUserIDs(userIDs...)
 }
 
-func (t traced) ApproveUser(id string) (u *users.User, err error) {
-	defer func() { t.trace("ApproveUser", id, u, err) }()
-	return t.d.ApproveUser(id)
-}
-
 func (t traced) SetUserAdmin(id string, value bool) (err error) {
 	defer func() { t.trace("SetUserAdmin", id, value, err) }()
 	return t.d.SetUserAdmin(id, value)

--- a/users/pardot/pardot.go
+++ b/users/pardot/pardot.go
@@ -32,7 +32,6 @@ type apiResponse struct {
 type prospect struct {
 	Email             string
 	ServiceCreatedAt  time.Time
-	ServiceApprovedAt time.Time
 	ServiceLastAccess time.Time
 }
 
@@ -46,7 +45,6 @@ func (p1 prospect) merge(p2 prospect) prospect {
 
 	return prospect{
 		ServiceCreatedAt:  latest(p1.ServiceCreatedAt, p2.ServiceCreatedAt),
-		ServiceApprovedAt: latest(p1.ServiceApprovedAt, p2.ServiceApprovedAt),
 		ServiceLastAccess: latest(p1.ServiceLastAccess, p2.ServiceLastAccess),
 	}
 }
@@ -61,11 +59,9 @@ func (p1 prospect) MarshalJSON() ([]byte, error) {
 
 	encoded := struct {
 		ServiceCreatedAt  string `json:",omitempty"`
-		ServiceApprovedAt string `json:",omitempty"`
 		ServiceLastAccess string `json:",omitempty"`
 	}{
 		ServiceCreatedAt:  encode(p1.ServiceCreatedAt),
-		ServiceApprovedAt: encode(p1.ServiceApprovedAt),
 		ServiceLastAccess: encode(p1.ServiceLastAccess),
 	}
 	return json.Marshal(encoded)
@@ -207,22 +203,6 @@ func (c *Client) UserCreated(email string, createdAt time.Time) {
 	c.prospects = append(c.prospects, prospect{
 		Email:            email,
 		ServiceCreatedAt: createdAt,
-	})
-	c.cond.Broadcast()
-}
-
-// UserApproved should be called when users are approved.
-// This will trigger an immediate 'upload' to pardot, although
-// that upload will still happen in the background.
-func (c *Client) UserApproved(email string, approvedAt time.Time) {
-	if c == nil {
-		return
-	}
-	c.Lock()
-	defer c.Unlock()
-	c.prospects = append(c.prospects, prospect{
-		Email:             email,
-		ServiceApprovedAt: approvedAt,
 	})
 	c.cond.Broadcast()
 }

--- a/users/pardot/pardot_internal_test.go
+++ b/users/pardot/pardot_internal_test.go
@@ -24,7 +24,6 @@ const (
 
 type pardotProspect struct {
 	ServiceCreatedAt  string
-	ServiceApprovedAt string
 	ServiceLastAccess string
 }
 
@@ -99,15 +98,12 @@ func TestPardotClient(t *testing.T) {
 	defer client.Stop()
 
 	createdAt := time.Now()
-	approvedAt := createdAt.Add(48 * time.Hour)
 	client.UserCreated(userEmail, createdAt)
-	client.UserApproved(userEmail, approvedAt)
 	select {
 	case ps := <-prospects:
 		if !reflect.DeepEqual(ps, map[string]pardotProspect{
 			userEmail: {
-				ServiceCreatedAt:  strftime.Format("%Y-%m-%d", createdAt),
-				ServiceApprovedAt: strftime.Format("%Y-%m-%d", approvedAt),
+				ServiceCreatedAt: strftime.Format("%Y-%m-%d", createdAt),
 			},
 		}) {
 			t.Fatal("Wrong data: ", ps)

--- a/users/user.go
+++ b/users/user.go
@@ -18,7 +18,6 @@ type User struct {
 	Email          string    `json:"email"`
 	Token          string    `json:"-"`
 	TokenCreatedAt time.Time `json:"-"`
-	ApprovedAt     time.Time `json:"-"`
 	FirstLoginAt   time.Time `json:"-"`
 	CreatedAt      time.Time `json:"-"`
 	Admin          bool      `json:"-"`
@@ -36,19 +35,9 @@ func (u *User) FormatCreatedAt() string {
 	return formatTimestamp(u.CreatedAt)
 }
 
-// FormatApprovedAt formats the user's approved at timestamp
-func (u *User) FormatApprovedAt() string {
-	return formatTimestamp(u.ApprovedAt)
-}
-
 // FormatFirstLoginAt formats the user's first login timestamp
 func (u *User) FormatFirstLoginAt() string {
 	return formatTimestamp(u.FirstLoginAt)
-}
-
-// IsApproved checks if a user has been approved
-func (u *User) IsApproved() bool {
-	return !u.ApprovedAt.IsZero()
 }
 
 // CompareToken does a cryptographically-secure comparison of the user's login token


### PR DESCRIPTION
Based on #860, so will be a smaller diff after that.

Are we relying on this data being pushed to pardot? Because this stops that happening.
