### PR TITLE
Default to prism namespace

### DIFF
--- a/authfe/main.go
+++ b/authfe/main.go
@@ -107,7 +107,7 @@ func main() {
 	flag.StringVar(&c.controlHost, "control", "control.default.svc.cluster.local:80", "Hostname & port for control service")
 	flag.StringVar(&c.pipeHost, "pipe", "pipe.default.svc.cluster.local:80", "Hostname & port for pipe service")
 	flag.StringVar(&c.deployHost, "deploy", "api.deploy.svc.cluster.local:80", "Hostname & port for deploy service")
-	flag.StringVar(&c.promHost, "prom", "distributor.frankenstein.svc.cluster.local:80", "Hostname & port for prom service")
+	flag.StringVar(&c.promHost, "prom", "distributor.prism.svc.cluster.local:80", "Hostname & port for prom service")
 
 	// For Admin routers
 	flag.StringVar(&c.grafanaHost, "grafana", "grafana.monitoring.svc.cluster.local:80", "Hostname & port for grafana")


### PR DESCRIPTION
authfe routes prometheus traffic to frankenstein namespace, but https://github.com/weaveworks/service-conf/pull/196/ renames that to prism. 

Do **not** merge this until https://github.com/weaveworks/service-conf/pull/196/ has been merged and deployed.

Part of https://github.com/weaveworks/prism/issues/28
