### PR TITLE
Remove @channel mention for alerts in Slack

### DIFF
--- a/monitoring/alertmanager/alertmanager-dev.yml
+++ b/monitoring/alertmanager/alertmanager-dev.yml
@@ -16,4 +16,4 @@ receivers:
     channel: cloud
     send_resolved: true
     username: dev-alert
-    text: "<!channel> {{ .CommonLabels.alertname }}: {{ .CommonAnnotations.summary }}"
+    text: "{{ .CommonLabels.alertname }}: {{ .CommonAnnotations.summary }}"

--- a/monitoring/alertmanager/alertmanager-prod.yml
+++ b/monitoring/alertmanager/alertmanager-prod.yml
@@ -62,7 +62,7 @@ receivers:
     channel: cloud
     send_resolved: true
     username: prod-alert
-    text: "<!channel> {{ .CommonLabels.alertname }}: {{ .CommonAnnotations.summary }}"
+    text: "{{ .CommonLabels.alertname }}: {{ .CommonAnnotations.summary }}"
 
 - name: 'service-alerts-critical'
   email_configs:


### PR DESCRIPTION
#855 introduced the `<!channel>` prefix in Slack alert messages, which does a **@channel** mention/alert like so:

![screen shot 2016-09-22 at 15 21 22](https://cloud.githubusercontent.com/assets/114509/18749672/45025df6-80d8-11e6-988b-24fdeb28df44.png)

This has the un-opt-out-able effect of red-dotting the channel to everyone who is joined. Red dots normally signify direct messages, and I've therefore developed a Pavlovian response to treat them as work interrupts. But this is rather disruptive, especially as we nominally have someone on-call whose principle responsibility is to respond to these events.

Thoughts? Everyone OK with this?
