### PR TITLE
Run users postgres tests in transactions, instead of truncating, for better isolation

### DIFF
--- a/users/db/db.go
+++ b/users/db/db.go
@@ -94,11 +94,6 @@ type DB interface {
 	Close() error
 }
 
-// Truncater is used in testing, but is not part of the normal db interface
-type Truncater interface {
-	Truncate() error
-}
-
 // MustNew creates a new database from the URI, or panics.
 func MustNew(databaseURI, migrationsDir string) DB {
 	u, err := url.Parse(databaseURI)

--- a/users/db/dbtest/helpers.go
+++ b/users/db/dbtest/helpers.go
@@ -5,29 +5,12 @@ import (
 	"math/rand"
 	"testing"
 
-	"golang.org/x/crypto/bcrypt"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/weaveworks/service/common/logging"
 	"github.com/weaveworks/service/users"
 	"github.com/weaveworks/service/users/db"
 )
-
-// Setup sets up stuff for testing, creating a new database
-func Setup(t *testing.T) db.DB {
-	require.NoError(t, logging.Setup("debug"))
-	db.PasswordHashingCost = bcrypt.MinCost
-	database := db.MustNew(*databaseURI, *databaseMigrations)
-	require.NoError(t, database.(db.Truncater).Truncate())
-	return database
-}
-
-// Cleanup cleans up after a test
-func Cleanup(t *testing.T, database db.DB) {
-	require.NoError(t, database.Close())
-}
 
 // GetUser makes a randomly named user
 func GetUser(t *testing.T, db db.DB) *users.User {

--- a/users/db/dbtest/integration.go
+++ b/users/db/dbtest/integration.go
@@ -2,9 +2,55 @@
 
 package dbtest
 
-import "flag"
+import (
+	"flag"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/weaveworks/service/common/logging"
+	"github.com/weaveworks/service/users/db"
+	"github.com/weaveworks/service/users/db/postgres"
+)
 
 var (
 	databaseURI        = flag.String("database-uri", "postgres://postgres@users-db.weave.local/users_test?sslmode=disable", "Uri of a test database")
 	databaseMigrations = flag.String("database-migrations", "/migrations", "Path where the database migration files can be found")
+
+	done        chan error
+	errRollback = fmt.Errorf("Rolling back test data")
 )
+
+// Setup sets up stuff for testing, creating a new database
+func Setup(t *testing.T) db.DB {
+	require.NoError(t, logging.Setup("debug"))
+	db.PasswordHashingCost = bcrypt.MinCost
+	// Don't use db.MustNew, here so we can do a transaction around the whole test, to rollback.
+	pg, err := postgres.New(*databaseURI, *databaseMigrations, bcrypt.MinCost)
+	require.NoError(t, err)
+
+	newDB := make(chan db.DB)
+	done = make(chan error)
+	go func() {
+		done <- pg.Transaction(func(tx postgres.DB) error {
+			// Pass out the tx so we can run the test
+			newDB <- tx
+			// Wait for the test to finish
+			return <-done
+		})
+	}()
+	// Get the new database
+	return <-newDB
+}
+
+// Cleanup cleans up after a test
+func Cleanup(t *testing.T, database db.DB) {
+	if done != nil {
+		done <- errRollback
+		require.Equal(t, errRollback, <-done)
+		done = nil
+	}
+	require.NoError(t, database.Close())
+}

--- a/users/db/dbtest/unit.go
+++ b/users/db/dbtest/unit.go
@@ -2,9 +2,31 @@
 
 package dbtest
 
-import "flag"
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/weaveworks/service/common/logging"
+	"github.com/weaveworks/service/users/db"
+)
 
 var (
 	databaseURI        = flag.String("database-uri", "memory://", "Uri of a test database")
 	databaseMigrations = flag.String("database-migrations", "", "Path where the database migration files can be found")
 )
+
+// Setup sets up stuff for testing, creating a new database
+func Setup(t *testing.T) db.DB {
+	require.NoError(t, logging.Setup("debug"))
+	db.PasswordHashingCost = bcrypt.MinCost
+	database := db.MustNew(*databaseURI, *databaseMigrations)
+	return database
+}
+
+// Cleanup cleans up after a test
+func Cleanup(t *testing.T, database db.DB) {
+	require.NoError(t, database.Close())
+}

--- a/users/db/memory/memory.go
+++ b/users/db/memory/memory.go
@@ -30,19 +30,6 @@ func New(_, _ string, passwordHashingCost int) (*DB, error) {
 	}, nil
 }
 
-// Truncate clears all the data. Should only be used in tests!
-func (d *DB) Truncate() error {
-	*d = DB{
-		users:               make(map[string]*users.User),
-		organizations:       make(map[string]*users.Organization),
-		memberships:         make(map[string][]string),
-		logins:              make(map[string]*login.Login),
-		apiTokens:           make(map[string]*users.APIToken),
-		passwordHashingCost: d.passwordHashingCost,
-	}
-	return nil
-}
-
 // Close finishes using the db. Noop.
 func (d *DB) Close() error {
 	return nil

--- a/users/db/postgres/api_token.go
+++ b/users/db/postgres/api_token.go
@@ -17,7 +17,7 @@ func (d DB) CreateAPIToken(userID, description string) (*users.APIToken, error) 
 		CreatedAt:   d.Now(),
 	}
 
-	err := d.Transaction(func(tx *sql.Tx) error {
+	err := d.Transaction(func(tx DB) error {
 		for exists := t.Token == ""; exists; {
 			if err := t.RegenerateToken(); err != nil {
 				return err

--- a/users/db/timed.go
+++ b/users/db/timed.go
@@ -252,7 +252,3 @@ func (t timed) Close() error {
 		return t.d.Close()
 	})
 }
-
-func (t timed) Truncate() error {
-	return t.d.(Truncater).Truncate()
-}

--- a/users/db/traced.go
+++ b/users/db/traced.go
@@ -166,8 +166,3 @@ func (t traced) Close() (err error) {
 	defer func() { t.trace("Close", err) }()
 	return t.d.Close()
 }
-
-func (t traced) Truncate() (err error) {
-	defer func() { t.trace("Truncate", err) }()
-	return t.d.(Truncater).Truncate()
-}


### PR DESCRIPTION
The issue with the race condition is 

Added support for the `postgres.DB.Transaction` method to be used recursively. If it is already in a transaction, then it is a noop.

Then, added a bit of a kludge to run each test in a db transaction. It's a bit hairy converting from a callback-style txn, to a defer-stype setup/cleanup. There are way around it (adding `postgres.DB.(Begin|Commit|Rollback)`, but that is a bit awkward, and this works for now.

Side effects:
- Should make integration tests slightly faster
- Should eventually make it possible to parallelize tests

Fixes #816
