### PR TITLE
circle.yml: Roll up-upload step into the push deployment section

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -59,7 +59,4 @@ deployment:
           export LAST_BUILD_COMMIT=$(curl -sS 'https://circleci.com/api/v1/project/weaveworks/service/tree/'$CIRCLE_BRANCH'?circle-token='$CIRCLE_TOKEN'&filter=successful&limit=1' | jq -r '.[0].vcs_revision')
           echo Last successful build was commit $LAST_BUILD_COMMIT
           ./push-images --and-deploy --if-changed-since $LAST_BUILD_COMMIT
-  ui_upload:
-    branch: master
-    commands:
       - make ui-upload


### PR DESCRIPTION
circle-ci doesn't like having multiple deploy sections,
so we have to just pile everything into one.

Until this PR goes in, new UI changes will break master unless they are manually deployed to S3
