### PR TITLE
Add missing makefile dep for webpack files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,13 +98,14 @@ endif
 
 # All the boiler plate for building the client follows:
 JS_FILES=$(shell find ui-server/client/src -name '*.jsx' -or -name '*.js')
+WEBPACK_DEPS = ui-server/client/$(UPTODATE) $(JS_FILES) ui-server/client/src/html/index.html ui-server/client/.eslintignore ui-server/client/.eslintrc ui-server/client/.babelrc
 
 client-lint: ui-server/client/$(UPTODATE) $(JS_FILES)
 	$(SUDO) docker run $(RM) -ti \
 		-v $(shell pwd)/ui-server/client/src:/home/weave/src \
 		$(IMAGE_PREFIX)/client npm run lint
 
-ui-server/client/build/index.html: ui-server/client/$(UPTODATE) $(JS_FILES) ui-server/client/src/html/index.html ui-server/client/webpack.production.config.js
+ui-server/client/build/index.html: $(WEBPACK_DEPS) ui-server/client/webpack.production.config.js
 	mkdir -p ui-server/client/build
 	$(SUDO) docker run $(RM) -ti \
 		-v $(shell pwd)/ui-server/client/src:/home/weave/src \


### PR DESCRIPTION
Without this dep, edits to the config file which may cause the output to change won't cause the make to be rerun. This shouldn't matter most of the time, since CI starts from a blank slate and builds everything every time.
