### PR TITLE
authfe: Make all host flags required (DRYer edition)

### DIFF
--- a/authfe/main.go
+++ b/authfe/main.go
@@ -16,11 +16,6 @@ import (
 	users "github.com/weaveworks/service/users/client"
 )
 
-type hostFlag struct {
-	dest *string
-	name string
-}
-
 const (
 	sessionCookieKey = "_weaveclientid"
 	userIDHeader     = "X-Scope-UserID"
@@ -109,7 +104,10 @@ func main() {
 	flag.StringVar(&fluentHost, "fluent", "", "Hostname & port for fluent")
 	flag.StringVar(&c.outputHeader, "output.header", "X-Scope-OrgID", "Name of header containing org id on forwarded requests")
 
-	hostFlags := []hostFlag{
+	hostFlags := []struct {
+		dest *string
+		name string
+	}{
 		{&c.promHost, "prom"},
 		{&c.collectionHost, "collection"},
 		{&c.queryHost, "query"},


### PR DESCRIPTION
Uses an intermediate list to avoid repetition when delcaring and checking flags.

I've also uploaded https://github.com/weaveworks/service/pull/886, which is a little
simpler but at the cost of needing to repeat help strings and flag names in multiple places,
which could concievibly get out of sync.

I've uploaded both so people who know Go better can decide which is better.
