### PR TITLE
Revert "Revert "Revert "Merge pull request #887 from weaveworks/mike/authfe/required-host-flags/dryer"""

### DIFF
--- a/authfe/main.go
+++ b/authfe/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"net/http"
 	"regexp"
 	"time"
@@ -103,30 +102,23 @@ func main() {
 	flag.DurationVar(&authCacheExpiration, "auth.cache.expiration", 30*time.Second, "How long to keep entries in the auth client.")
 	flag.StringVar(&fluentHost, "fluent", "", "Hostname & port for fluent")
 	flag.StringVar(&c.outputHeader, "output.header", "X-Scope-OrgID", "Name of header containing org id on forwarded requests")
+	flag.StringVar(&c.deployHost, "deploy", "api.deploy.svc.cluster.local:80", "Hostname & port for deploy service")
+	flag.StringVar(&c.promHost, "prom", "distributor.prism.svc.cluster.local:80", "Hostname & port for prom service")
+	// Required args
+	flag.StringVar(&c.collectionHost, "collection", "", "Hostname & port for collection service (required)")
+	flag.StringVar(&c.queryHost, "query", "", "Hostname & port for query service (required)")
+	flag.StringVar(&c.controlHost, "control", "", "Hostname & port for control service (required)")
+	flag.StringVar(&c.pipeHost, "pipe", "", "Hostname & port for pipe service (required)")
 
-	hostFlags := []struct {
-		dest *string
-		name string
-	}{
-		{&c.promHost, "prom"},
-		{&c.collectionHost, "collection"},
-		{&c.queryHost, "query"},
-		{&c.controlHost, "control"},
-		{&c.pipeHost, "pipe"},
-		// For Admin routers
-		{&c.grafanaHost, "grafana"},
-		{&c.scopeHost, "scope"},
-		{&c.usersHost, "users"},
-		{&c.kubediffHost, "kubediff"},
-		{&c.terradiffHost, "terradiff"},
-		{&c.alertmanagerHost, "alertmanager"},
-		{&c.prometheusHost, "prometheus"},
-	}
-
-	for _, hostFlag := range hostFlags {
-		flag.StringVar(hostFlag.dest, hostFlag.name, "", fmt.Sprintf("Hostname & port for %s service (required)", hostFlag.name))
-	}
-
+	// For Admin routers
+	flag.StringVar(&c.grafanaHost, "grafana", "grafana.monitoring.svc.cluster.local:80", "Hostname & port for grafana")
+	flag.StringVar(&c.scopeHost, "scope", "scope.kube-system.svc.cluster.local:80", "Hostname & port for scope")
+	flag.StringVar(&c.usersHost, "users", "users.default.svc.cluster.local", "Hostname & port for users")
+	flag.StringVar(&c.kubediffHost, "kubediff", "kubediff.monitoring.svc.cluster.local", "Hostname & port for kubediff")
+	flag.StringVar(&c.terradiffHost, "terradiff", "terradiff.monitoring.svc.cluster.local", "Hostname & port for terradiff")
+	flag.StringVar(&c.alertmanagerHost, "alertmanager", "alertmanager.monitoring.svc.cluster.local", "Hostname & port for alertmanager")
+	flag.StringVar(&c.prometheusHost, "prometheus", "prometheus.monitoring.svc.cluster.local", "Hostname & port for prometheus")
+	flag.StringVar(&c.kubedashHost, "kubedash", "kubernetes-dashboard.kube-system.svc.cluster.local", "Hostname & port for kubedash")
 	flag.Parse()
 
 	if err := logging.Setup(logLevel); err != nil {
@@ -134,10 +126,24 @@ func main() {
 		return
 	}
 
-	for _, hostFlag := range hostFlags {
-		if *hostFlag.dest == "" {
-			log.Fatalf("Must specify a %s host", hostFlag.name)
-		}
+	if c.collectionHost == "" {
+		log.Fatal("Must specify a collection host")
+		return
+	}
+
+	if c.queryHost == "" {
+		log.Fatal("Must specify a query host")
+		return
+	}
+
+	if c.controlHost == "" {
+		log.Fatal("Must specify a control host")
+		return
+	}
+
+	if c.pipeHost == "" {
+		log.Fatal("Must specify a pipe host")
+		return
 	}
 
 	authOptions := users.AuthenticatorOptions{}


### PR DESCRIPTION
Reverts weaveworks/service#900—caused authfe failure on dev.

```
$ kubectl get po --selector=name=authfe
NAME                                READY     STATUS             RESTARTS   AGE
authfe-1466791494-dtu4v             1/2       CrashLoopBackOff   10         27m
authfe-1466791494-ilcru             1/2       CrashLoopBackOff   10         27m
```

```
$ kubectl logs -f authfe-1466791494-dtu4v authfe
flag provided but not defined: -deploy
Usage of /authfe:
  -alertmanager string
        Hostname & port for alertmanager service (required)
  -auth.cache.expiration duration
        How long to keep entries in the auth client. (default 30s)
  -auth.cache.size int
        How many entries to cache in the auth client.
  -authenticator string
        What authenticator to use: web | mock (default "web")
  -authenticator.url string
        Where to find web the authenticator service (default "http://users:80")
  -collection string
        Hostname & port for collection service (required)
  -control string
        Hostname & port for control service (required)
  -fluent string
        Hostname & port for fluent
  -grafana string
        Hostname & port for grafana service (required)
  -kubediff string
        Hostname & port for kubediff service (required)
  -listen string
        HTTP server listen address (default ":80")
  -log.level string
        Logging level to use: debug | info | warn | error (default "info")
  -output.header string
        Name of header containing org id on forwarded requests (default "X-Scope-OrgID")
  -pipe string
        Hostname & port for pipe service (required)
  -prom string
        Hostname & port for prom service (required)
  -prometheus string
        Hostname & port for prometheus service (required)
  -query string
        Hostname & port for query service (required)
  -scope string
        Hostname & port for scope service (required)
  -stop.timeout duration
        How long to wait for remaining requests to finish during shutdown (default 5s)
  -terradiff string
        Hostname & port for terradiff service (required)
  -users string
        Hostname & port for users service (required)
```
