### PR TITLE
New image ui-server-local: ui-server which doesn't use S3, for local dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,9 @@ authfe/authfe
 kubediff/vendor/github.com/tomwilkie/prom-run/prom-run
 pr-assigner/pr-assigner
 client/build/*
+ui-server/client/build-local/*
 ui-server/build/*
+ui-server/ui-server-local/build-local/*
 
 Vagrantfile.local
 .dir-locals.el

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ frontend-mt/$(UPTODATE): frontend-mt/default.conf frontend-mt/routes.conf fronte
 logging/$(UPTODATE): logging/fluent.conf logging/fluent-dev.conf logging/schema_service_events.json
 ui-server/client/$(UPTODATE): ui-server/client/package.json ui-server/client/webpack.* ui-server/client/server.js ui-server/client/.eslintrc ui-server/client/.eslintignore ui-server/client/.babelrc
 ui-server/$(UPTODATE): ui-server/client/build/index.html
+ui-server/ui-server-local/$(UPTODATE): ui-server/ui-server-local/build-local
 build/$(UPTODATE): build/build.sh
 monitoring/grafana/$(UPTODATE): monitoring/grafana/*
 monitoring/gfdatasource/$(UPTODATE): monitoring/gfdatasource/*
@@ -111,6 +112,18 @@ ui-server/client/build/index.html: ui-server/client/$(UPTODATE) $(JS_FILES) ui-s
 		-v $(shell pwd)/ui-server/client/build:/home/weave/build \
 		$(IMAGE_PREFIX)/client npm run build
 	cp -p ui-server/client/src/images/* ui-server/client/build
+
+ui-server/client/build-local/index.html: ui-server/client/$(UPTODATE) $(JS_FILES) ui-server/client/src/html/index.html
+	mkdir -p ui-server/client/build-local
+	$(SUDO) docker run $(RM) -ti \
+		-v $(shell pwd)/ui-server/client/src:/home/weave/src \
+		-v $(shell pwd)/ui-server/client/build-local:/home/weave/build-local \
+		$(IMAGE_PREFIX)/client npm run build-local
+	cp -p ui-server/client/src/images/* ui-server/client/build-local
+
+ui-server/ui-server-local/build-local: ui-server/client/build-local/index.html
+	# copy the results into the docker build context
+	cp -r ui-server/client/build-local ui-server/ui-server-local/
 
 # Test and misc stuff
 users-integration-test: $(USERS_UPTODATE)

--- a/ui-server/client/Dockerfile
+++ b/ui-server/client/Dockerfile
@@ -4,4 +4,4 @@ COPY package.json /home/weave/
 ENV NPM_CONFIG_LOGLEVEL=warn NPM_CONFIG_PROGRESS=false
 # Don't install optional developer tools
 RUN npm install --no-optional
-COPY webpack.local.config.js webpack.production.config.js .eslintignore .eslintrc .babelrc /home/weave/
+COPY webpack.local.config.js webpack.localimage.config.js webpack.production.config.js .eslintignore .eslintrc .babelrc /home/weave/

--- a/ui-server/client/package.json
+++ b/ui-server/client/package.json
@@ -9,6 +9,7 @@
     "start-production": "NODE_ENV=production node server.js",
     "lint": "eslint src --ext=jsx --ext=js",
     "build": "webpack --bail --config webpack.production.config.js",
+    "build-local": "webpack --bail --config webpack.localimage.config.js",
     "test": "jest --coverage",
     "coveralls": "cat coverage/lcov.info | coveralls",
     "clean": "rm build/app.js"

--- a/ui-server/client/webpack.localimage.config.js
+++ b/ui-server/client/webpack.localimage.config.js
@@ -1,0 +1,63 @@
+var webpack = require('webpack');
+var CleanWebpackPlugin = require('clean-webpack-plugin');
+var HtmlWebpackPlugin = require('html-webpack-plugin');
+
+/**
+ * This is the Webpack configuration file for building a static image to be used in a local env.
+ * It is identical to the production config, except paths are relative to the current host,
+ * instead of pointing to S3. It outputs to ./build-local
+ */
+module.exports = {
+  entry: {
+    app: './src/main',
+    // keep only some in here, to make vendors and app bundles roughly same size
+    vendors: ['babel-polyfill', 'debug', 'react', 'react-dom', 'react-router',
+      'redux', 'react-redux', 'redux-thunk']
+  },
+
+  output: {
+    // absolute path for bundle
+    publicPath: '/',
+    path: __dirname + '/build-local/',
+    filename: '[chunkhash].js'
+  },
+
+  module: {
+    loaders: [
+      {
+        test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+        loader: 'url-loader?limit=10000&minetype=application/font-woff'
+      },
+      {
+        test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+        loader: 'file-loader'
+      },
+      { test: /\.jsx?$/, exclude: /node_modules/, loader: 'babel' }
+    ]
+  },
+
+  resolve: {
+    extensions: ['', '.js', '.jsx']
+  },
+
+  plugins: [
+    new CleanWebpackPlugin(['build']),
+    new webpack.DefinePlugin({
+      'process.env': {NODE_ENV: '"production"'}
+    }),
+    new webpack.optimize.CommonsChunkPlugin('vendors', '[chunkhash].js'),
+    new webpack.optimize.OccurenceOrderPlugin(true),
+    new webpack.optimize.UglifyJsPlugin({
+      sourceMap: false,
+      compress: {
+        warnings: false
+      }
+    }),
+    new HtmlWebpackPlugin({
+      hash: true,
+      chunks: ['vendors', 'app'],
+      template: 'src/html/index.html',
+      filename: 'index.html'
+    })
+  ]
+};

--- a/ui-server/ui-server-local/Dockerfile
+++ b/ui-server/ui-server-local/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx
+MAINTAINER Weaveworks Inc <help@weave.works>
+# Need try_files directive for single page app with browser history
+COPY default.conf /etc/nginx/conf.d/
+COPY build-local /usr/share/nginx/html/

--- a/ui-server/ui-server-local/default.conf
+++ b/ui-server/ui-server-local/default.conf
@@ -1,0 +1,14 @@
+server {
+    listen       80;
+
+    # Backwards-compatible with hash history
+    location ^/# {
+      rewrite ^/#(.*) $1 redirect;
+      break;
+    }
+
+    location / {
+        root   /usr/share/nginx/html;
+        try_files $uri $uri/ /index.html =404;
+    }
+}


### PR DESCRIPTION
This fixes issues with the s3-based solution not working locally,
as well as removing the external dependency from running the local env

Note this PR only causes the new image to be built.
A change in service-conf to follow will replace use of `ui-server` in `k8s/local` with `ui-server-local`
