### PR TITLE
Unauthenticated users routes go via authfe

### DIFF
--- a/authfe/main.go
+++ b/authfe/main.go
@@ -60,17 +60,6 @@ func newProbeRequestLogger(orgIDHeader string) logging.HTTPEventExtractor {
 	}
 }
 
-func newUsersRequestLogger() logging.HTTPEventExtractor {
-	return func(r *http.Request) (logging.Event, bool) {
-		event := logging.Event{
-			ID:        r.URL.Path,
-			Product:   "scope-ui",
-			UserAgent: r.UserAgent(),
-		}
-		return event, true
-	}
-}
-
 func newUIRequestLogger(orgIDHeader, userIDHeader string) logging.HTTPEventExtractor {
 	return func(r *http.Request) (logging.Event, bool) {
 		sessionCookie, err := r.Cookie(sessionCookieKey)

--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -38,7 +38,6 @@ type Config struct {
 func routes(c Config) (http.Handler, error) {
 	probeHTTPlogger := middleware.Identity
 	uiHTTPlogger := middleware.Identity
-	usersHTTPlogger := middleware.Identity
 	if c.eventLogger != nil {
 		probeHTTPlogger = logging.HTTPEventLogger{
 			Extractor: newProbeRequestLogger(c.outputHeader),
@@ -46,10 +45,6 @@ func routes(c Config) (http.Handler, error) {
 		}
 		uiHTTPlogger = logging.HTTPEventLogger{
 			Extractor: newUIRequestLogger(c.outputHeader, userIDHeader),
-			Logger:    c.eventLogger,
-		}
-		usersHTTPlogger = logging.HTTPEventLogger{
-			Extractor: newUsersRequestLogger(),
 			Logger:    c.eventLogger,
 		}
 	}
@@ -64,7 +59,7 @@ func routes(c Config) (http.Handler, error) {
 			[]path{
 				{"/", newProxy(c.usersHost)},
 			},
-			usersHTTPlogger,
+			uiHTTPlogger,
 		},
 
 		// For all ui <-> app communication, authenticated using cookie credentials


### PR DESCRIPTION
This fixes https://github.com/weaveworks/service/issues/673,
and is relevant to https://github.com/weaveworks/service/issues/38.

It is one step in reducing the responsibilities and complexity of frontend
in favor of authfe.
