### PR TITLE
authfe: Make host flags required explicitly (trying again)

### DIFF
--- a/authfe/main.go
+++ b/authfe/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"net/http"
 	"regexp"
 	"time"
@@ -103,25 +104,32 @@ func main() {
 	flag.DurationVar(&authCacheExpiration, "auth.cache.expiration", 30*time.Second, "How long to keep entries in the auth client.")
 	flag.StringVar(&fluentHost, "fluent", "", "Hostname & port for fluent")
 	flag.StringVar(&c.outputHeader, "output.header", "X-Scope-OrgID", "Name of header containing org id on forwarded requests")
-	flag.StringVar(&c.deployHost, "deploy", "api.deploy.svc.cluster.local:80", "Hostname & port for deploy service")
-	flag.StringVar(&c.promHost, "prom", "distributor.prism.svc.cluster.local:80", "Hostname & port for prom service")
 
-	// Required args
-	flag.StringVar(&c.collectionHost, "collection", "", "Hostname & port for collection service (required)")
-	flag.StringVar(&c.queryHost, "query", "", "Hostname & port for query service (required)")
-	flag.StringVar(&c.controlHost, "control", "", "Hostname & port for control service (required)")
-	flag.StringVar(&c.pipeHost, "pipe", "", "Hostname & port for pipe service (required)")
+	hostFlags := []struct {
+		dest *string
+		name string
+	}{
+		{&c.deployHost, "deploy"},
+		{&c.promHost, "prom"},
+		{&c.collectionHost, "collection"},
+		{&c.queryHost, "query"},
+		{&c.controlHost, "control"},
+		{&c.pipeHost, "pipe"},
+		// For Admin routers
+		{&c.grafanaHost, "grafana"},
+		{&c.scopeHost, "scope"},
+		{&c.usersHost, "users"},
+		{&c.kubediffHost, "kubediff"},
+		{&c.terradiffHost, "terradiff"},
+		{&c.alertmanagerHost, "alertmanager"},
+		{&c.prometheusHost, "prometheus"},
+		{&c.compareImagesHost, "compare-images"},
+	}
 
-	// For Admin routers
-	flag.StringVar(&c.grafanaHost, "grafana", "grafana.monitoring.svc.cluster.local:80", "Hostname & port for grafana")
-	flag.StringVar(&c.scopeHost, "scope", "scope.kube-system.svc.cluster.local:80", "Hostname & port for scope")
-	flag.StringVar(&c.usersHost, "users", "users.default.svc.cluster.local", "Hostname & port for users")
-	flag.StringVar(&c.kubediffHost, "kubediff", "kubediff.monitoring.svc.cluster.local", "Hostname & port for kubediff")
-	flag.StringVar(&c.terradiffHost, "terradiff", "terradiff.monitoring.svc.cluster.local", "Hostname & port for terradiff")
-	flag.StringVar(&c.alertmanagerHost, "alertmanager", "alertmanager.monitoring.svc.cluster.local", "Hostname & port for alertmanager")
-	flag.StringVar(&c.prometheusHost, "prometheus", "prometheus.monitoring.svc.cluster.local", "Hostname & port for prometheus")
-	flag.StringVar(&c.kubedashHost, "kubedash", "kubernetes-dashboard.kube-system.svc.cluster.local", "Hostname & port for kubedash")
-	flag.StringVar(&c.compareImagesHost, "compare-images", "compare-images.monitoring.svc.cluster.local", "Hostname & port for compare-images")
+	for _, hostFlag := range hostFlags {
+		flag.StringVar(hostFlag.dest, hostFlag.name, "", fmt.Sprintf("Hostname & port for %s service (required)", hostFlag.name))
+	}
+
 	flag.Parse()
 
 	if err := logging.Setup(logLevel); err != nil {
@@ -129,24 +137,10 @@ func main() {
 		return
 	}
 
-	if c.collectionHost == "" {
-		log.Fatal("Must specify a collection host")
-		return
-	}
-
-	if c.queryHost == "" {
-		log.Fatal("Must specify a query host")
-		return
-	}
-
-	if c.controlHost == "" {
-		log.Fatal("Must specify a control host")
-		return
-	}
-
-	if c.pipeHost == "" {
-		log.Fatal("Must specify a pipe host")
-		return
+	for _, hostFlag := range hostFlags {
+		if *hostFlag.dest == "" {
+			log.Fatalf("Must specify a %s host", hostFlag.name)
+		}
 	}
 
 	authOptions := users.AuthenticatorOptions{}


### PR DESCRIPTION
Revert^4 (re-applies) "Merge pull request #887 from weaveworks/mike/authfe/required-host-flags/dryer"
This reverts commit ca55124d3a35dd007e9baa8e8dc23607cd616b1e, reintroducing #887

It fixes the problem with the original commit (a missing -deploy arg)
as well as resolves a conflict with a new host arg added since the original commit.

This change relies on https://github.com/weaveworks/service-conf/pull/247 being merged first.
