### PR TITLE
Frontend only talks to authfe, who forwards things as needed

### DIFF
--- a/authfe/main.go
+++ b/authfe/main.go
@@ -125,6 +125,9 @@ func main() {
 		{&c.prometheusHost, "prometheus"},
 		{&c.kubedashHost, "kubedash"},
 		{&c.compareImagesHost, "compare-images"},
+		{&c.uiServerHost, "ui-server"},
+		{&c.demoHost, "demo"},
+		{&c.launchGeneratorHost, "launch-generator"},
 	}
 
 	for _, hostFlag := range hostFlags {

--- a/frontend-mt/routes.conf
+++ b/frontend-mt/routes.conf
@@ -75,7 +75,7 @@ location = /api {
 }
 
 location /launch/k8s/ {
-  proxy_pass http://launch-generator.extra.svc.cluster.local$request_uri;
+  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
 }
 
 # Demo app served at /demo/
@@ -85,7 +85,7 @@ location = /demo {
 }
 
 location ~ ^/demo/?((?<=/).*)?$ {
-  proxy_pass http://demo.extra.svc.cluster.local/$1$is_args$args;
+  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
 
   proxy_redirect off;
   proxy_pass_request_headers on;
@@ -96,10 +96,10 @@ location ~ ^/demo/?((?<=/).*)?$ {
 # Serve service index.html with no-caching.
 location = / {
   add_header Cache-Control no-cache;
-  proxy_pass http://ui-server.default.svc.cluster.local$request_uri;
+  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
 }
 
 # The rest will be served by the ui-server
 location / {
-  proxy_pass http://ui-server.default.svc.cluster.local$request_uri;
+  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
 }


### PR DESCRIPTION
With this commit, frontend no longer talks to:
- demo
- launch-generator
- ui-server

This continues to move us towards a frontend-less world, or at least one where it's a dumb terminator instead
of a complex router

Works towards https://github.com/weaveworks/service/issues/38

Will conflict with https://github.com/weaveworks/service/pull/913, but i'll fix that later
depending on which makes it in first.

Will require service-conf changes to add values for new args.
