### PR TITLE
authfe: Make host flags required explicitly (trying again 2)

### DIFF
--- a/authfe/main.go
+++ b/authfe/main.go
@@ -123,6 +123,7 @@ func main() {
 		{&c.terradiffHost, "terradiff"},
 		{&c.alertmanagerHost, "alertmanager"},
 		{&c.prometheusHost, "prometheus"},
+		{&c.kubedashHost, "kubedash"},
 		{&c.compareImagesHost, "compare-images"},
 	}
 


### PR DESCRIPTION
This is a repeat of #913, but with the issue fixed (I was _still_ somehow missing an arg,
probably missed it during a rebase).
