### PR TITLE
Add new optional host flags as part of bootstrapping new requrired args for #921

### DIFF
--- a/authfe/main.go
+++ b/authfe/main.go
@@ -105,6 +105,12 @@ func main() {
 	flag.StringVar(&fluentHost, "fluent", "", "Hostname & port for fluent")
 	flag.StringVar(&c.outputHeader, "output.header", "X-Scope-OrgID", "Name of header containing org id on forwarded requests")
 
+	// Temporary ignored optional args
+	var ignored string
+	flag.StringVar(&ignored, "ui-server", "", "ignored")
+	flag.StringVar(&ignored, "demo", "", "ignored")
+	flag.StringVar(&ignored, "launch-generator", "", "ignored")
+
 	hostFlags := []struct {
 		dest *string
 		name string


### PR DESCRIPTION
These new args will be required when actually used. We are introducing this intermediate
"exists, does nothing, is optional" state to resolve ordering between service and service-conf.
The full plan being:
1. Add this commit to service
2. Add args to service-conf
3. Merge functionality and make it required
