### PR TITLE
Revert "Add new optional host flags as part of bootstrapping new requrired args"

### DIFF
--- a/authfe/main.go
+++ b/authfe/main.go
@@ -105,12 +105,6 @@ func main() {
 	flag.StringVar(&fluentHost, "fluent", "", "Hostname & port for fluent")
 	flag.StringVar(&c.outputHeader, "output.header", "X-Scope-OrgID", "Name of header containing org id on forwarded requests")
 
-	// Temporary ignored optional args
-	var ignored string
-	flag.StringVar(&ignored, "ui-server", "", "ignored")
-	flag.StringVar(&ignored, "demo", "", "ignored")
-	flag.StringVar(&ignored, "launch-generator", "", "ignored")
-
 	hostFlags := []struct {
 		dest *string
 		name string


### PR DESCRIPTION
This reverts commit f1038d38c870ee0317bba13ce226f41f57ac0e6f,
as it was a temporary commit which is no longer needed
