### PR TITLE
Set cache-control headers in authfe, not frontend

### DIFF
--- a/frontend-mt/routes.conf
+++ b/frontend-mt/routes.conf
@@ -12,7 +12,6 @@ location /api/users/ {
 
 # Serve scope index.html with no caching
 location ~ ^/api/app/[^/]+/$ {
-  add_header Cache-Control no-cache;
   proxy_pass http://authfe.default.svc.cluster.local$request_uri;
 }
 
@@ -95,7 +94,6 @@ location ~ ^/demo/?((?<=/).*)?$ {
 
 # Serve service index.html with no-caching.
 location = / {
-  add_header Cache-Control no-cache;
   proxy_pass http://authfe.default.svc.cluster.local$request_uri;
 }
 


### PR DESCRIPTION
This moves all custom response header logic into authfe instead of using frontend.

Note the somewhat awkward "is this '/'?" check in the middleware.
This was easier than re-writing the entire "routable" mess to allow specifying exact
paths as opposed to prefixes.

Related to https://github.com/weaveworks/service/issues/38
