### PR TITLE
frontend: Simplify routing rules

### DIFF
--- a/frontend-mt/routes.conf
+++ b/frontend-mt/routes.conf
@@ -1,43 +1,3 @@
-# Users service
-location = /api/users/login {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-}
-
-location /api/users/ {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-  proxy_connect_timeout 5s;
-  proxy_read_timeout 5s;
-  proxy_send_timeout 5s;
-}
-
-# Serve scope index.html with no caching
-location ~ ^/api/app/[^/]+/$ {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-}
-
-location /api/app/ {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-}
-
-location /api/org/ {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-}
-
-location /api/deploy {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-}
-
-location /api/config {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-}
-
-location /api/prom {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-}
-
-location = /api/report {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-}
 
 location /admin/ {
   proxy_pass http://authfe.default.svc.cluster.local$request_uri;
@@ -55,11 +15,6 @@ location @401 {
   return 302 $scheme://$host/login;
 }
 
-# pipe delete requests from probe
-location ~ ^/api/pipe/pipe-[^/]+$ {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-}
-
 # topology (from UI), pipe (from both UI and probe) and control (from probe) websockets
 location ~ ^/api/(app/[^/]+/api/(topology/[^/]+/ws|pipe/pipe-[^/]+)|pipe/pipe-[^/]+/probe|control/ws)$ {
   proxy_pass http://authfe.default.svc.cluster.local$request_uri;
@@ -73,10 +28,6 @@ location = /api {
   alias /home/weave/api.json;
 }
 
-location /launch/k8s/ {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-}
-
 location ~ ^/demo/?((?<=/).*)?$ {
   proxy_pass http://authfe.default.svc.cluster.local$request_uri;
 
@@ -86,12 +37,7 @@ location ~ ^/demo/?((?<=/).*)?$ {
   proxy_set_header Connection Upgrade;
 }
 
-# Serve service index.html with no-caching.
-location = / {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-}
-
-# The rest will be served by the ui-server
+# The rest will be routed by authfe without further modification
 location / {
   proxy_pass http://authfe.default.svc.cluster.local$request_uri;
 }


### PR DESCRIPTION
Since so many of these now just go to authfe without doing anything special,
remove the long list of special cases which all do the same thing
and instead let it fall back to the generic last route.

This will conflict with https://github.com/weaveworks/service/pull/927,
which should be merged first.
