### PR TITLE
frontend: Remove special cases for websockets

### DIFF
--- a/frontend-mt/routes.conf
+++ b/frontend-mt/routes.conf
@@ -1,13 +1,10 @@
 
 location /admin/ {
   proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-
-  proxy_redirect off;
-  proxy_pass_request_headers on;
   proxy_set_header Upgrade $http_upgrade;
-  proxy_set_header Connection Upgrade;
-  proxy_intercept_errors on;
+  proxy_set_header Connection $http_connection;
 
+  proxy_intercept_errors on;
   error_page 401 = @401;
 }
 
@@ -15,29 +12,15 @@ location @401 {
   return 302 $scheme://$host/login;
 }
 
-# topology (from UI), pipe (from both UI and probe) and control (from probe) websockets
-location ~ ^/api/(app/[^/]+/api/(topology/[^/]+/ws|pipe/pipe-[^/]+)|pipe/pipe-[^/]+/probe|control/ws)$ {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-  proxy_http_version 1.1;
-  proxy_set_header Upgrade $http_upgrade;
-  proxy_set_header Connection "upgrade";
-}
-
 # Static version file
 location = /api {
   alias /home/weave/api.json;
 }
 
-location ~ ^/demo/?((?<=/).*)?$ {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-
-  proxy_redirect off;
-  proxy_pass_request_headers on;
-  proxy_set_header Upgrade $http_upgrade;
-  proxy_set_header Connection Upgrade;
-}
-
 # The rest will be routed by authfe without further modification
 location / {
   proxy_pass http://authfe.default.svc.cluster.local$request_uri;
+  # nginx doesn't pass these headers to the proxy by default, force it to
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection $http_connection;
 }


### PR DESCRIPTION
Instead, have it automatically determine whether to set the headers
based on the client's headers.

This further simplifies and generalizes the nginx config
