### PR TITLE
Revert all changes since 42ea40c

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -67,9 +67,6 @@ func routes(c Config) (http.Handler, error) {
 	for _, route := range []routable{
 		path{"/metrics", prometheus.Handler()},
 
-		// demo service paths get rewritten to remove /demo/ prefix, so trailing slash is required
-		path{"/demo", redirect("/demo/")},
-
 		// For all ui <-> app communication, authenticated using cookie credentials
 		prefix{
 			"/api/app/{orgExternalID}",
@@ -191,12 +188,6 @@ func newRouter() *mux.Router {
 
 func trimPrefix(regex string, handler http.Handler) http.Handler {
 	return middleware.PathRewrite(regexp.MustCompile("^"+regex), "").Wrap(handler)
-}
-
-func redirect(dest string) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, dest, 302)
-	})
 }
 
 type routable interface {

--- a/frontend-mt/routes.conf
+++ b/frontend-mt/routes.conf
@@ -1,10 +1,53 @@
+# Users service
+location = /api/users/login {
+  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
+}
+
+location /api/users/ {
+  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
+  proxy_connect_timeout 5s;
+  proxy_read_timeout 5s;
+  proxy_send_timeout 5s;
+}
+
+# Serve scope index.html with no caching
+location ~ ^/api/app/[^/]+/$ {
+  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
+}
+
+location /api/app/ {
+  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
+}
+
+location /api/org/ {
+  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
+}
+
+location /api/deploy {
+  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
+}
+
+location /api/config {
+  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
+}
+
+location /api/prom {
+  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
+}
+
+location = /api/report {
+  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
+}
 
 location /admin/ {
   proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-  proxy_set_header Upgrade $http_upgrade;
-  proxy_set_header Connection $http_connection;
 
+  proxy_redirect off;
+  proxy_pass_request_headers on;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection Upgrade;
   proxy_intercept_errors on;
+
   error_page 401 = @401;
 }
 
@@ -12,15 +55,49 @@ location @401 {
   return 302 $scheme://$host/login;
 }
 
+# pipe delete requests from probe
+location ~ ^/api/pipe/pipe-[^/]+$ {
+  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
+}
+
+# topology (from UI), pipe (from both UI and probe) and control (from probe) websockets
+location ~ ^/api/(app/[^/]+/api/(topology/[^/]+/ws|pipe/pipe-[^/]+)|pipe/pipe-[^/]+/probe|control/ws)$ {
+  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
+  proxy_http_version 1.1;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection "upgrade";
+}
+
 # Static version file
 location = /api {
   alias /home/weave/api.json;
 }
 
-# The rest will be routed by authfe without further modification
+location /launch/k8s/ {
+  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
+}
+
+# Demo app served at /demo/
+location = /demo {
+  rewrite ^ /demo/ redirect;
+  break;
+}
+
+location ~ ^/demo/?((?<=/).*)?$ {
+  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
+
+  proxy_redirect off;
+  proxy_pass_request_headers on;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection Upgrade;
+}
+
+# Serve service index.html with no-caching.
+location = / {
+  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
+}
+
+# The rest will be served by the ui-server
 location / {
   proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-  # nginx doesn't pass these headers to the proxy by default, force it to
-  proxy_set_header Upgrade $http_upgrade;
-  proxy_set_header Connection $http_connection;
 }


### PR DESCRIPTION
We know at least one of these changes breaks /demo in firefox.
They are all interminged and conflicting, so we're reverting all of them for now
so that prod can recover, and will narrow down and re-merge later.

This reverts commits:
    "frontend: Remove special cases for websockets" fdab1138d3ca085d7b79391006fe90bb2ca9b805
    "frontend: Simplify routing rules" 1db34662c5377adccffa880156e23b43cfecf55b
    "Move responsibility for redirecting "/demo" -> "/demo/" from frontend to authfe" 18d68663bbe06dd07e7331b2ed0024ec6456032f

pr-assigner: ignore

This PR is in response to incident #937
