### PR TITLE
Revert the revert of commits 18d68663bbe06dd07e7331b2ed0024ec6456032f and 1db34662c5377adccffa880156e23b43cfecf55b

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -68,6 +68,8 @@ func routes(c Config) (http.Handler, error) {
 	for _, route := range []routable{
 		path{"/metrics", prometheus.Handler()},
 
+		// demo service paths get rewritten to remove /demo/ prefix, so trailing slash is required
+		path{"/demo", redirect("/demo/")},
 		// special case static version info
 		path{"/api", parseAPIInfo(c.apiInfo)},
 
@@ -194,6 +196,12 @@ func newRouter() *mux.Router {
 
 func trimPrefix(regex string, handler http.Handler) http.Handler {
 	return middleware.PathRewrite(regexp.MustCompile("^"+regex), "").Wrap(handler)
+}
+
+func redirect(dest string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, dest, 302)
+	})
 }
 
 type routable interface {

--- a/frontend-mt/routes.conf
+++ b/frontend-mt/routes.conf
@@ -1,43 +1,3 @@
-# Users service
-location = /api/users/login {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-}
-
-location /api/users/ {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-  proxy_connect_timeout 5s;
-  proxy_read_timeout 5s;
-  proxy_send_timeout 5s;
-}
-
-# Serve scope index.html with no caching
-location ~ ^/api/app/[^/]+/$ {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-}
-
-location /api/app/ {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-}
-
-location /api/org/ {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-}
-
-location /api/deploy {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-}
-
-location /api/config {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-}
-
-location /api/prom {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-}
-
-location = /api/report {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-}
 
 location /admin/ {
   proxy_pass http://authfe.default.svc.cluster.local$request_uri;
@@ -55,27 +15,12 @@ location @401 {
   return 302 $scheme://$host/login;
 }
 
-# pipe delete requests from probe
-location ~ ^/api/pipe/pipe-[^/]+$ {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-}
-
 # topology (from UI), pipe (from both UI and probe) and control (from probe) websockets
 location ~ ^/api/(app/[^/]+/api/(topology/[^/]+/ws|pipe/pipe-[^/]+)|pipe/pipe-[^/]+/probe|control/ws)$ {
   proxy_pass http://authfe.default.svc.cluster.local$request_uri;
   proxy_http_version 1.1;
   proxy_set_header Upgrade $http_upgrade;
   proxy_set_header Connection "upgrade";
-}
-
-location /launch/k8s/ {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-}
-
-# Demo app served at /demo/
-location = /demo {
-  rewrite ^ /demo/ redirect;
-  break;
 }
 
 location ~ ^/demo/?((?<=/).*)?$ {
@@ -87,12 +32,7 @@ location ~ ^/demo/?((?<=/).*)?$ {
   proxy_set_header Connection Upgrade;
 }
 
-# Serve service index.html with no-caching.
-location = / {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-}
-
-# The rest will be served by the ui-server
+# The rest will be routed by authfe without further modification
 location / {
   proxy_pass http://authfe.default.svc.cluster.local$request_uri;
 }


### PR DESCRIPTION
This reverts most of 729d0b6ef799fbcd0b5f3e89cbda5aeb303f045d
except keeps fdab1138d3ca085d7b79391006fe90bb2ca9b805 out.

I tested locally and reproduced the failure,
then confirmed that it works correctly with this commit.
So now I'm certain fdab1138d3ca085d7b79391006fe90bb2ca9b805 is at fault.
