### PR TITLE
Add warning alert when we fail to push more than 10% of prospects to marketing for an hour

### DIFF
--- a/monitoring/prometheus/alert.rules
+++ b/monitoring/prometheus/alert.rules
@@ -183,3 +183,12 @@ ALERT ApiServerDown
     summary = "Kubernetes API server down for 5m",
     description = "Kubernetes API server down for 5m",
   }
+
+ALERT MarketingFail
+  IF          sum(rate(marketing_prospects_sent_count{job="default/users",status="failed"}[5m])) / sum(rate(marketing_prospects_sent_count{job="default/users"}[5m])) > 0.1
+  FOR         1h
+  LABELS      { severity="warning" }
+  ANNOTATIONS {
+    summary = "We're failing to push prospects to marketing.",
+    description = "We're failing to push prospects to marketing.",
+  }


### PR DESCRIPTION
Fixes #941 
