### PR TITLE
Revert "Revert "Simplify nginx config by removing websocket special cases" (#959)"

### DIFF
--- a/authfe/proxy.go
+++ b/authfe/proxy.go
@@ -70,8 +70,16 @@ func (p proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func isWSHandshakeRequest(req *http.Request) bool {
-	return strings.ToLower(req.Header.Get("Upgrade")) == "websocket" &&
-		strings.ToLower(req.Header.Get("Connection")) == "upgrade"
+	if strings.ToLower(req.Header.Get("Upgrade")) == "websocket" {
+		// Connection header values can be of form "foo, bar, ..."
+		parts := strings.Split(strings.ToLower(req.Header.Get("Connection")), ",")
+		for _, part := range parts {
+			if strings.TrimSpace(part) == "upgrade" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (p proxy) proxyWS(w http.ResponseWriter, r *http.Request) {

--- a/frontend-mt/routes.conf
+++ b/frontend-mt/routes.conf
@@ -1,13 +1,10 @@
 
 location /admin/ {
   proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-
-  proxy_redirect off;
-  proxy_pass_request_headers on;
   proxy_set_header Upgrade $http_upgrade;
-  proxy_set_header Connection Upgrade;
-  proxy_intercept_errors on;
+  proxy_set_header Connection $http_connection;
 
+  proxy_intercept_errors on;
   error_page 401 = @401;
 }
 
@@ -15,24 +12,10 @@ location @401 {
   return 302 $scheme://$host/login;
 }
 
-# topology (from UI), pipe (from both UI and probe) and control (from probe) websockets
-location ~ ^/api/(app/[^/]+/api/(topology/[^/]+/ws|pipe/pipe-[^/]+)|pipe/pipe-[^/]+/probe|control/ws)$ {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-  proxy_http_version 1.1;
-  proxy_set_header Upgrade $http_upgrade;
-  proxy_set_header Connection "upgrade";
-}
-
-location ~ ^/demo/?((?<=/).*)?$ {
-  proxy_pass http://authfe.default.svc.cluster.local$request_uri;
-
-  proxy_redirect off;
-  proxy_pass_request_headers on;
-  proxy_set_header Upgrade $http_upgrade;
-  proxy_set_header Connection Upgrade;
-}
-
 # The rest will be routed by authfe without further modification
 location / {
   proxy_pass http://authfe.default.svc.cluster.local$request_uri;
+  # nginx doesn't pass these headers to the proxy by default, force it to
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection $http_connection;
 }


### PR DESCRIPTION
This reverts commit 234434c5384cfc56905d9b32c8e240d178bcd5e2,
since the issue it exposed (JS sending a malformed query string that nginx
could handle but authfe could not) is soon to be fixed: https://github.com/weaveworks/scope/pull/1953
