### PR TITLE
Add optional, unused flux host argument to authfe

### DIFF
--- a/authfe/main.go
+++ b/authfe/main.go
@@ -107,6 +107,10 @@ func main() {
 	flag.StringVar(&c.outputHeader, "output.header", "X-Scope-OrgID", "Name of header containing org id on forwarded requests")
 	flag.StringVar(&c.apiInfo, "api.info", "scopeservice:0.1", "Version info for the api to serve, in format ID:VERSION")
 
+	// temporary, to allow configs to mention this argument before it
+	// becomes mandatory
+	_ = flag.String("flux", "", "Hostname and port for Flux service (unused)")
+
 	hostFlags := []struct {
 		dest *string
 		name string


### PR DESCRIPTION
If we add a mandatory argument, the config must immediately be updated to supply it. Adding the argument but not using it means we can update the config independently, and make the argument mandatory at some point thereafter (as in #970).
