### PR TITLE
Update service UI deps to Node v6

### DIFF
--- a/ui-server/client/package.json
+++ b/ui-server/client/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "autoprefixer": "6.3.3",
-    "babel-core": "6.7.2",
+    "babel-core": "6.10.4",
     "babel-eslint": "5.0.0",
     "babel-jest": "9.0.3",
     "babel-loader": "6.2.4",
@@ -57,7 +57,7 @@
     "eslint-plugin-react": "4.2.2",
     "file-loader": "0.8.5",
     "html-webpack-plugin": "^2.16.0",
-    "jest-cli": "0.9.2",
+    "jest-cli": "16.0.2",
     "less": "~2.6.1",
     "reqwest": "^2.0.5",
     "url-loader": "0.5.7",
@@ -74,15 +74,12 @@
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
-    "testFileExtensions": [
-      "js"
-    ],
     "moduleFileExtensions": [
       "js",
       "json"
-    ],
-    "unmockedModulePathPatterns": [
-      "/node_modules/"
     ]
+  },
+  "engines": {
+    "node": "6.9.0"
   }
 }


### PR DESCRIPTION
#978 
Scope deps were updated by this PR: https://github.com/weaveworks/scope/issues/1959

This PR keeps the service repo up to date with those changes. 