### PR TITLE
Give nginx explicit hash bucket size

### DIFF
--- a/frontend-mt/default.conf
+++ b/frontend-mt/default.conf
@@ -13,6 +13,8 @@ log_by_lua '
   metric_latency:observe(ngx.now() - ngx.req.start_time(), {})
 ';
 
+server_names_hash_bucket_size 64;
+
 server {
     # NB this is the default server, for requests that don't match (ie
     # ones that go to frontend.default.svc.cluster.local or fronend.dev.weave.works)


### PR DESCRIPTION
Nginx creates a hash table for server names based on the cache line size it detects. Usually this ends up being 64; but, in some virtual machines (one using KVM, in my case) it incorrectly defaults to 32.

This is not big enough for the server names used in frontend's configuration, and nginx refuses to start. To work around this, set it to the required value (64) explicitly.
