### PR TITLE
Return HTTP 501 Not Implemented for missing hosts

### DIFF
--- a/authfe/main.go
+++ b/authfe/main.go
@@ -137,7 +137,7 @@ func main() {
 	}
 
 	for _, hostFlag := range hostFlags {
-		flag.StringVar(hostFlag.dest, hostFlag.name, "", fmt.Sprintf("Hostname & port for %s service (required)", hostFlag.name))
+		flag.StringVar(hostFlag.dest, hostFlag.name, "", fmt.Sprintf("Hostname & port for %s service", hostFlag.name))
 	}
 
 	flag.Parse()
@@ -149,7 +149,7 @@ func main() {
 
 	for _, hostFlag := range hostFlags {
 		if *hostFlag.dest == "" {
-			log.Fatalf("Must specify a %s host", hostFlag.name)
+			log.Warningf("Host for %s not given; will not be proxied", hostFlag.name)
 		}
 	}
 

--- a/authfe/proxy.go
+++ b/authfe/proxy.go
@@ -47,6 +47,11 @@ func newProxy(hostAndPort string) proxy {
 }
 
 func (p proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if p.hostAndPort == "" {
+		w.WriteHeader(http.StatusNotImplemented)
+		return
+	}
+
 	// Tweak request before sending
 	r.Host = p.hostAndPort
 	r.URL.Host = p.hostAndPort


### PR DESCRIPTION
This is preferable to failing to start, because it means arguments can be added with updating deployment config in lock-step.

Addresses #973.