### PR TITLE
Plumb through view analytics

### DIFF
--- a/authfe/main.go
+++ b/authfe/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"net/http"
 	"regexp"
 	"time"
 
@@ -11,7 +10,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tylerb/graceful"
 
-	"github.com/weaveworks/scope/common/xfer"
 	"github.com/weaveworks/service/common/logging"
 	users "github.com/weaveworks/service/users/client"
 )
@@ -46,40 +44,6 @@ func init() {
 	prometheus.MustRegister(requestDuration)
 	prometheus.MustRegister(wsConnections)
 	prometheus.MustRegister(wsRequestCount)
-}
-
-func newProbeRequestLogger(orgIDHeader string) logging.HTTPEventExtractor {
-	return func(r *http.Request) (logging.Event, bool) {
-		event := logging.Event{
-			ID:             r.URL.Path,
-			Product:        "scope-probe",
-			Version:        r.Header.Get(xfer.ScopeProbeVersionHeader),
-			UserAgent:      r.UserAgent(),
-			ClientID:       r.Header.Get(xfer.ScopeProbeIDHeader),
-			OrganizationID: r.Header.Get(orgIDHeader),
-		}
-		return event, true
-	}
-}
-
-func newUIRequestLogger(orgIDHeader, userIDHeader string) logging.HTTPEventExtractor {
-	return func(r *http.Request) (logging.Event, bool) {
-		sessionCookie, err := r.Cookie(sessionCookieKey)
-		var sessionID string
-		if err == nil {
-			sessionID = sessionCookie.Value
-		}
-
-		event := logging.Event{
-			ID:             r.URL.Path,
-			SessionID:      sessionID,
-			Product:        "scope-ui",
-			UserAgent:      r.UserAgent(),
-			OrganizationID: r.Header.Get(orgIDHeader),
-			UserID:         r.Header.Get(userIDHeader),
-		}
-		return event, true
-	}
 }
 
 func main() {

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,8 +9,7 @@ RUN go get -tags netgo \
 		github.com/golang/lint/golint \
 		github.com/kisielk/errcheck \
 		github.com/mjibson/esc \
-		github.com/client9/misspell/cmd/misspell \
-		github.com/prometheus/prometheus/cmd/promtool && \
+		github.com/client9/misspell/cmd/misspell && \
 	rm -rf /go/pkg/ /go/src/
 COPY build.sh /
 ENTRYPOINT ["/build.sh"]

--- a/common/logging/event.go
+++ b/common/logging/event.go
@@ -22,6 +22,7 @@ type Event struct {
 	ClientID       string `msg:"client_id"`
 	OrganizationID string `msg:"org_id"`
 	UserID         string `msg:"user_id"`
+	Values         string `msg:"values"`
 }
 
 // EventLogger logs events to the analytics system

--- a/logging/schema_service_events.json
+++ b/logging/schema_service_events.json
@@ -52,6 +52,12 @@
       "type": "STRING",
       "mode": "NULLABLE",
       "description": "Client generated session id."
+    },
+    {
+      "name": "values",
+      "type": "STRING",
+      "mode": "NULLABLE",
+      "description": "Arbitrary JSON encoded values from the UI."
     }
 ]
 


### PR DESCRIPTION
/cc @davkal - see https://github.com/weaveworks/service-ui/pull/21 for UI side.

Adds endpoint `/api/analytics` for the UI to post arbitrary blobs to.  They will end up in bigquery values field, which bigquery can parse however it sees fit (but the intention is json).

Limits size of said field to 16KB.