### PR TITLE
Move unauth'ed apis above apis with IDs

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -290,6 +290,9 @@ func routes(c Config) (http.Handler, error) {
 				uiHTTPlogger,
 			),
 		},
+		// These billing api endpoints have no orgExternalID, so we can't do authorization on them.
+		path{"/api/billing/accounts", trimPrefix("/api/billing", newProxy(c.billingAPIHost))},
+		path{"/api/billing/payments/authTokens", trimPrefix("/api/billing", newProxy(c.billingAPIHost))},
 		prefix{
 			"/api/billing",
 			[]path{
@@ -304,9 +307,6 @@ func routes(c Config) (http.Handler, error) {
 				uiHTTPlogger,
 			),
 		},
-		// These billing api endpoints have no orgExternalID, so we can't do authorization on them.
-		path{"/api/billing/accounts", trimPrefix("/api/billing", newProxy(c.billingAPIHost))},
-		path{"/api/billing/payments/authTokens", trimPrefix("/api/billing", newProxy(c.billingAPIHost))},
 
 		// unauthenticated communication
 		prefix{


### PR DESCRIPTION
The route `/payments/{orgExternalID}` was also catching the route `/api/billing/payments/authTokens`, interpreting authTokens as the id. By moving the `/api/billing/payments/authTokens` catch above the ID versions, it should catch first.