### PR TITLE
Marketo tracking: Add munchkin_hash to the json result from /api/users/lookup such that we can do associateLeads calls.

### DIFF
--- a/users/api/api.go
+++ b/users/api/api.go
@@ -13,15 +13,16 @@ import (
 
 // API implements the users api.
 type API struct {
-	directLogin       bool
-	logSuccess        bool
-	sessions          sessions.Store
-	db                db.DB
-	logins            *login.Providers
-	templates         templates.Engine
-	emailer           emailer.Emailer
-	marketingQueues   marketing.Queues
-	forceFeatureFlags []string
+	directLogin        bool
+	logSuccess         bool
+	sessions           sessions.Store
+	db                 db.DB
+	logins             *login.Providers
+	templates          templates.Engine
+	emailer            emailer.Emailer
+	marketingQueues    marketing.Queues
+	forceFeatureFlags  []string
+	marketoMunchkinKey string
 	http.Handler
 }
 
@@ -35,17 +36,19 @@ func New(
 	templates templates.Engine,
 	marketingQueues marketing.Queues,
 	forceFeatureFlags []string,
+	marketoMunchkinKey string,
 ) *API {
 	a := &API{
-		directLogin:       directLogin,
-		logSuccess:        logSuccess,
-		sessions:          sessions,
-		db:                db,
-		logins:            logins,
-		templates:         templates,
-		emailer:           emailer,
-		marketingQueues:   marketingQueues,
-		forceFeatureFlags: forceFeatureFlags,
+		directLogin:        directLogin,
+		logSuccess:         logSuccess,
+		sessions:           sessions,
+		db:                 db,
+		logins:             logins,
+		templates:          templates,
+		emailer:            emailer,
+		marketingQueues:    marketingQueues,
+		forceFeatureFlags:  forceFeatureFlags,
+		marketoMunchkinKey: marketoMunchkinKey,
 	}
 	a.Handler = a.routes()
 	return a

--- a/users/api/api_tokens_test.go
+++ b/users/api/api_tokens_test.go
@@ -86,7 +86,8 @@ func Test_APITokens_CreateAndUseAPIToken(t *testing.T) {
 
 		// It should give access to all instances
 		assert.Equal(t, map[string]interface{}{
-			"email": user.Email,
+			"email":         user.Email,
+			"munchkin_hash": app.MunchkinHash(user.Email),
 			"organizations": []interface{}{
 				map[string]interface{}{
 					"id":   org1.ExternalID,

--- a/users/api/helpers_test.go
+++ b/users/api/helpers_test.go
@@ -50,7 +50,7 @@ func setup(t *testing.T) {
 		Domain:      domain,
 		FromAddress: "test@test.com",
 	}
-	app = api.New(directLogin, true, emailer, sessionStore, database, logins, templates, nil, nil)
+	app = api.New(directLogin, true, emailer, sessionStore, database, logins, templates, nil, nil, "")
 }
 
 func cleanup(t *testing.T) {

--- a/users/api/lookup_test.go
+++ b/users/api/lookup_test.go
@@ -61,7 +61,8 @@ func Test_PublicLookup(t *testing.T) {
 	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
 	assert.Equal(t, user.Email, body["email"])
 	assert.Equal(t, map[string]interface{}{
-		"email": user.Email,
+		"email":         user.Email,
+		"munchkin_hash": app.MunchkinHash(user.Email),
 		"organizations": []interface{}{
 			map[string]interface{}{
 				"id":                 org.ExternalID,

--- a/users/cmd/users/main.go
+++ b/users/cmd/users/main.go
@@ -40,10 +40,11 @@ func main() {
 		pardotPassword = flag.String("pardot-password", "", "Password of Pardot account.")
 		pardotUserKey  = flag.String("pardot-userkey", "", "User key of Pardot account.")
 
-		marketoClientID = flag.String("marketo-client-id", "", "Client ID of Marketo account.  If not supplied marketo integration will be disabled.")
-		marketoSecret   = flag.String("marketo-secret", "", "Secret for Marketo account.")
-		marketoEndpoint = flag.String("marketo-endpoint", "", "REST API endpoint for Marketo.")
-		marketoProgram  = flag.String("marketo-program", "2016_00_Website_WeaveCloud", "Program name to add leads to (for Marketo).")
+		marketoClientID    = flag.String("marketo-client-id", "", "Client ID of Marketo account.  If not supplied marketo integration will be disabled.")
+		marketoSecret      = flag.String("marketo-secret", "", "Secret for Marketo account.")
+		marketoEndpoint    = flag.String("marketo-endpoint", "", "REST API endpoint for Marketo.")
+		marketoProgram     = flag.String("marketo-program", "2016_00_Website_WeaveCloud", "Program name to add leads to (for Marketo).")
+		marketoMunchkinKey = flag.String("marketo-munchkin-key", "", "Secret key for Marketo munchkin.")
 
 		emailFromAddress = flag.String("email-from-address", "Weave Cloud <support@weave.works>", "From address for emails.")
 
@@ -98,7 +99,7 @@ func main() {
 	logrus.Infof("Listening on port %d", *port)
 	mux := http.NewServeMux()
 
-	mux.Handle("/", api.New(*directLogin, *logSuccess, emailer, sessions, db, logins, templates, marketingQueues, forceFeatureFlags))
+	mux.Handle("/", api.New(*directLogin, *logSuccess, emailer, sessions, db, logins, templates, marketingQueues, forceFeatureFlags, *marketoMunchkinKey))
 	mux.Handle("/metrics", makePrometheusHandler())
 	if err := graceful.RunWithErr(fmt.Sprintf(":%d", *port), *stopTimeout, mux); err != nil {
 		logrus.Fatal(err)


### PR DESCRIPTION
Park of https://github.com/weaveworks/service-ui/issues/73

For more details, read:
- http://developers.marketo.com/blog/merge-anonymous-visitor-activity-when-visitor-fills-out-form/
- http://developers.marketo.com/javascript-api/lead-tracking/api-reference/#munchkin_associatelead