### PR TITLE
Add munchkin hash and email to various login endpoints

### DIFF
--- a/users/api/account_test.go
+++ b/users/api/account_test.go
@@ -34,8 +34,10 @@ func Test_Account_AttachOauthAccount(t *testing.T) {
 	body := map[string]interface{}{}
 	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
 	assert.Equal(t, map[string]interface{}{
-		"attach":     true,
-		"firstLogin": true,
+		"attach":       true,
+		"firstLogin":   true,
+		"email":        remoteEmail,
+		"munchkinHash": app.MunchkinHash(remoteEmail),
 	}, body)
 	assert.Len(t, sentEmails, 0)
 
@@ -100,8 +102,10 @@ func Test_Account_AttachOauthAccount_AlreadyAttachedToAnotherAccount(t *testing.
 	body = map[string]interface{}{}
 	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
 	assert.Equal(t, map[string]interface{}{
-		"attach":     true,
-		"firstLogin": true,
+		"attach":       true,
+		"firstLogin":   true,
+		"email":        fran.Email,
+		"munchkinHash": app.MunchkinHash(fran.Email),
 	}, body)
 	assert.Len(t, sentEmails, 0)
 
@@ -154,8 +158,10 @@ func Test_Account_AttachOauthAccount_AlreadyAttachedToSameAccount(t *testing.T) 
 	body := map[string]interface{}{}
 	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
 	assert.Equal(t, map[string]interface{}{
-		"attach":     true,
-		"firstLogin": true,
+		"attach":       true,
+		"firstLogin":   true,
+		"email":        remoteEmail,
+		"munchkinHash": app.MunchkinHash(remoteEmail),
 	}, body)
 	assert.Len(t, sentEmails, 0)
 

--- a/users/api/login.go
+++ b/users/api/login.go
@@ -83,9 +83,11 @@ func (a *API) listAttachedLoginProviders(currentUser *users.User, w http.Respons
 }
 
 type attachLoginProviderView struct {
-	FirstLogin  bool `json:"firstLogin,omitempty"`
-	UserCreated bool `json:"userCreated,omitempty"`
-	Attach      bool `json:"attach,omitempty"`
+	FirstLogin   bool   `json:"firstLogin,omitempty"`
+	UserCreated  bool   `json:"userCreated,omitempty"`
+	Attach       bool   `json:"attach,omitempty"`
+	Email        string `json:"email"`
+	MunchkinHash string `json:"munchkinHash"`
 }
 
 func (a *API) attachLoginProvider(w http.ResponseWriter, r *http.Request) {
@@ -181,6 +183,8 @@ func (a *API) attachLoginProvider(w http.ResponseWriter, r *http.Request) {
 	}
 
 	view.FirstLogin = u.FirstLoginAt.IsZero()
+	view.Email = email
+	view.MunchkinHash = a.MunchkinHash(email)
 
 	if err := a.updateUserAtLogin(u); err != nil {
 		render.Error(w, r, err)
@@ -290,7 +294,9 @@ func (a *API) generateUserToken(user *users.User) (string, error) {
 }
 
 type loginView struct {
-	FirstLogin bool `json:"firstLogin,omitempty"`
+	FirstLogin   bool   `json:"firstLogin,omitempty"`
+	Email        string `json:"email"`
+	MunchkinHash string `json:"munchkinHash"`
 }
 
 func (a *API) login(w http.ResponseWriter, r *http.Request) {
@@ -337,7 +343,11 @@ func (a *API) login(w http.ResponseWriter, r *http.Request) {
 		render.Error(w, r, users.ErrInvalidAuthenticationData)
 		return
 	}
-	render.JSON(w, http.StatusOK, loginView{FirstLogin: firstLogin})
+	render.JSON(w, http.StatusOK, loginView{
+		FirstLogin:   firstLogin,
+		Email:        email,
+		MunchkinHash: a.MunchkinHash(email),
+	})
 }
 
 func (a *API) updateUserAtLogin(u *users.User) error {

--- a/users/api/signup_test.go
+++ b/users/api/signup_test.go
@@ -103,7 +103,9 @@ func Test_Signup(t *testing.T) {
 	body = map[string]interface{}{}
 	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
 	assert.Equal(t, map[string]interface{}{
-		"firstLogin": true,
+		"firstLogin":   true,
+		"email":        user.Email,
+		"munchkinHash": app.MunchkinHash(user.Email),
 	}, body)
 
 	user, err = database.FindUserByEmail(email)
@@ -130,7 +132,10 @@ func Test_Signup(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	body = map[string]interface{}{}
 	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
-	assert.Equal(t, map[string]interface{}{}, body)
+	assert.Equal(t, map[string]interface{}{
+		"email":        user.Email,
+		"munchkinHash": app.MunchkinHash(user.Email),
+	}, body)
 
 	user, err = database.FindUserByEmail(email)
 	require.NoError(t, err)
@@ -195,8 +200,10 @@ func Test_Signup_ViaOAuth(t *testing.T) {
 	body := map[string]interface{}{}
 	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
 	assert.Equal(t, map[string]interface{}{
-		"firstLogin":  true,
-		"userCreated": true,
+		"firstLogin":   true,
+		"userCreated":  true,
+		"email":        email,
+		"munchkinHash": app.MunchkinHash(email),
 	}, body)
 	assert.Len(t, sentEmails, 0)
 
@@ -242,7 +249,9 @@ func Test_Signup_ViaOAuth_MatchesByEmail(t *testing.T) {
 	body := map[string]interface{}{}
 	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
 	assert.Equal(t, map[string]interface{}{
-		"firstLogin": true,
+		"firstLogin":   true,
+		"email":        user.Email,
+		"munchkinHash": app.MunchkinHash(user.Email),
 	}, body)
 
 	assert.Equal(t, user.ID, found.ID, "user id should match the existing")


### PR DESCRIPTION
As we want to do the associate lead call to munchkin when the user logs in.