### PR TITLE
Cache negative auth results from the users service.

### DIFF
--- a/users/client/authenticator.go
+++ b/users/client/authenticator.go
@@ -238,10 +238,18 @@ func (m *webAuthenticator) AuthenticateProbe(w http.ResponseWriter, r *http.Requ
 	}
 	lookupReq.Header.Set(AuthHeaderName, authHeader)
 	orgID, _, featureFlags, err := m.decodeOrg(m.doAuthenticateRequest(w, lookupReq))
-	if m.probeCredCache != nil {
+	if isUnauthorized(err) && m.probeCredCache != nil {
 		m.probeCredCache.Set(authHeader, probeCredCacheValue{orgID: orgID, featureFlags: featureFlags, err: err})
 	}
 	return orgID, featureFlags, err
+}
+
+func isUnauthorized(err error) bool {
+	unauthorized, ok := err.(*Unauthorized)
+	if !ok {
+		return false
+	}
+	return unauthorized.httpStatus == http.StatusUnauthorized
 }
 
 func (m *webAuthenticator) AuthenticateAdmin(w http.ResponseWriter, r *http.Request) (string, error) {


### PR DESCRIPTION
Right now we're only caching positive auth results for probes; this means a single mis-configured prometheus pointing at the service puts as much load on the users server as _all other traffic_:

![screen shot 2016-12-20 at 11 06 21](https://cloud.githubusercontent.com/assets/444037/21348302/5dcf6f7e-c6a4-11e6-81f1-b340cce618f4.png)
