### PR TITLE
Verify same-origin in requests with Origin or Referer headers

### DIFF
--- a/authfe/main.go
+++ b/authfe/main.go
@@ -74,6 +74,7 @@ func main() {
 	flag.StringVar(&fluentHost, "fluent", "", "Hostname & port for fluent")
 	flag.StringVar(&c.outputHeader, "output.header", "X-Scope-OrgID", "Name of header containing org id on forwarded requests")
 	flag.StringVar(&c.apiInfo, "api.info", "scopeservice:0.1", "Version info for the api to serve, in format ID:VERSION")
+	flag.StringVar(&c.targetOrigin, "hostname", "", "Hostname through which this server is accessed, for same-origin checks (CSRF protection)")
 
 	hostFlags := []struct {
 		dest *string


### PR DESCRIPTION
Fixes #2 

Tested locally in minikube. 

It still needs an accompanying PR in service-conf to add the `-hostname` flag for dev and prod, which I will create once this one is approved. 

Note, however, that this PR is safe to merge by itself since the same-origin verification will not be performed when `-hostname` is empty.