### PR TITLE
Include only the newest version of a config

### DIFF
--- a/configs/db/postgres/postgres.go
+++ b/configs/db/postgres/postgres.go
@@ -88,10 +88,10 @@ func (d DB) findConfig(entityID, entityType, subsystem string) (configs.ConfigVi
 
 func (d DB) findConfigs(filter squirrel.Sqlizer) (map[string]configs.ConfigView, error) {
 	rows, err := d.Select("id", "owner_id", "config").
-		Options("DISTINCT ON (id)").
+		Options("DISTINCT ON (owner_id)").
 		From("configs").
 		Where(filter).
-		OrderBy("id DESC").
+		OrderBy("owner_id, id DESC").
 		Query()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Experimentation showed that we were getting older instances of configs when
fetching all configs for a subsystem. This is because I don't know how to
postgres. I learned a thing, and now I'm postgressing rightly.

Related to weaveworks/cortex#163