### PR TITLE
We should also cache positive authentication responses...

### DIFF
--- a/users/client/authenticator.go
+++ b/users/client/authenticator.go
@@ -243,7 +243,7 @@ func (m *webAuthenticator) AuthenticateProbe(w http.ResponseWriter, r *http.Requ
 	}
 	lookupReq.Header.Set(AuthHeaderName, authHeader)
 	orgID, _, featureFlags, err := m.decodeOrg(m.doAuthenticateRequest(w, lookupReq))
-	if isUnauthorized(err) && m.probeCredCache != nil {
+	if m.probeCredCache != nil && (err == nil || isUnauthorized(err)) {
 		m.probeCredCache.Set(authHeader, probeCredCacheValue{orgID: orgID, featureFlags: featureFlags, err: err})
 	}
 	return orgID, featureFlags, err


### PR DESCRIPTION
In https://github.com/weaveworks/service/pull/1048, we started only caching unauthorised errors (instead of all error).  Problem was we stopped caching positive responses.

Part of https://github.com/weaveworks/service-conf/issues/524