### PR TITLE
Do not check CSRF in safe methods

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -410,7 +410,7 @@ func (o originCheckerMiddleware) Wrap(next http.Handler) http.Handler {
 }
 
 func isSafeMethod(method string) bool {
-	return method == http.MethodGet || r.Method == http.MethodHead
+	return method == http.MethodGet || method == http.MethodHead
 }
 
 // Gorilla Router with sensible defaults, namely:


### PR DESCRIPTION
Do not check for CSRF in GET/HEAD methods

Fixes #1072 