### PR TITLE
Add authfe support for separate cortex query service

### DIFF
--- a/authfe/main.go
+++ b/authfe/main.go
@@ -82,7 +82,9 @@ func main() {
 	}{
 		{&c.deployHost, "deploy"},
 		{&c.fluxHost, "flux"},
-		{&c.promHost, "prom"},
+		{&c.promHost, "prom"}, // for backwards compatibility
+		{&c.promDistributorHost, "prom-distributor"},
+		{&c.promQuerierHost, "prom-querier"},
 		{&c.collectionHost, "collection"},
 		{&c.queryHost, "query"},
 		{&c.controlHost, "control"},


### PR DESCRIPTION
See https://github.com/weaveworks/cortex/pull/218 for the separation of the query service.