### PR TITLE
Do not set the opaque url when forwarding requests

### DIFF
--- a/authfe/proxy.go
+++ b/authfe/proxy.go
@@ -58,11 +58,7 @@ func (p proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r.URL.Host = p.hostAndPort
 	r.URL.Scheme = "http"
 
-	// Ensure the URL is not incorrectly munged by go.
-	r.URL.Opaque = r.RequestURI
-	r.URL.RawQuery = ""
-
-	log.Debugf("Forwarding %s %s to %s", r.Method, r.RequestURI, p.hostAndPort)
+	log.Debugf("Forwarding %s %s to %s, final URL: %s", r.Method, r.RequestURI, p.hostAndPort, r.URL)
 
 	// Detect whether we should do websockets
 	if middleware.IsWSHandshakeRequest(r) {


### PR DESCRIPTION
It allows redirecting to absolute URLs through path tweaking and it's not
necessary anymore. From https://golang.org/pkg/net/url/#URL :

> Go 1.5 introduced the RawPath field to hold the encoded form of Path. The
> Parse function sets both Path and RawPath in the URL it returns, and URL's
> String method uses RawPath if it is a valid encoding of Path, by calling the
> EscapedPath method.
>
> In earlier versions of Go, the more indirect workarounds were that an HTTP
> server could consult req.RequestURI and an HTTP client could construct a URL
> struct directly and set the Opaque field instead of Path. These still work as
> well.

Fixes #1068