### PR TITLE
No more need to strip the prefix for flux api

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -221,7 +221,7 @@ func routes(c Config) (http.Handler, error) {
 				{"/api/pipe", newProxy(c.pipeHost)},
 				{"/api/deploy", newProxy(c.deployHost)},
 				{"/api/config", newProxy(c.deployHost)},
-				{"/api/flux", trimPrefix("/api/flux", newProxy(c.fluxHost))},
+				{"/api/flux", newProxy(c.fluxHost)},
 				{"/api/prom", newProxy(ifEmpty(c.promHost, c.promQuerierHost))},
 				{"/api", newProxy(c.queryHost)},
 
@@ -262,7 +262,7 @@ func routes(c Config) (http.Handler, error) {
 				{"/pipe", newProxy(c.pipeHost)},
 				{"/deploy", newProxy(c.deployHost)},
 				{"/config", newProxy(c.deployHost)},
-				{"/flux", trimPrefix("/api/flux", newProxy(c.fluxHost))},
+				{"/flux", newProxy(c.fluxHost)},
 				{"/prom", newProxy(ifEmpty(c.promHost, c.promDistributorHost))},
 			},
 			middleware.Merge(


### PR DESCRIPTION
Flux now serves it's api both at `/` (for standalone deployments), and at `/api/flux` to play better with authfe (and hide prom metrics).

Merge after https://github.com/weaveworks/flux/pull/397 is deployed through to prod.