### PR TITLE
Inject Github token into request for deploy key insertion

### DIFF
--- a/authfe/main.go
+++ b/authfe/main.go
@@ -141,6 +141,10 @@ func main() {
 		authOptions.ProbeCredCacheExpiration = authCacheExpiration
 	}
 	c.authenticator = users.MakeAuthenticator(authType, authURL, authOptions)
+	c.ghIntegration = &users.TokenRequester{
+		URL:          authURL,
+		UserIDHeader: userIDHeader,
+	}
 
 	if fluentHost != "" {
 		var err error

--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -32,6 +32,7 @@ const maxAnalyticsPayloadSize = 16 * 1024 // bytes
 // Config is all the config we need to build the routes
 type Config struct {
 	authenticator users.Authenticator
+	ghIntegration users.Integration
 	eventLogger   *EventLogger
 	outputHeader  string
 	logSuccess    bool
@@ -233,6 +234,10 @@ func routes(c Config) (http.Handler, error) {
 		RequireFeatureFlags: []string{"billing"},
 	}
 
+	fluxGHTokenMiddleware := users.GHIntegrationMiddleware{
+		T: c.ghIntegration,
+	}
+
 	// middleware to set header to disable caching if path == "/" exactly
 	noCacheOnRoot := middleware.Func(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -303,6 +308,9 @@ func routes(c Config) (http.Handler, error) {
 				{"/api/control", newProxy(c.controlHost)},
 				{"/api/pipe", newProxy(c.pipeHost)},
 				{"/api/configs", newProxy(c.configsHost)},
+				// API to insert deploy key requires GH token. Insert token with middleware.
+				{"/api/flux/v5/integrations/github",
+					fluxGHTokenMiddleware.Wrap(newProxy(c.fluxHost))},
 				{"/api/flux", newProxy(c.fluxHost)},
 				{"/api/prom", cortexQuerierClient},
 				{"/api", newProxy(c.queryHost)},

--- a/users/api/admin_test.go
+++ b/users/api/admin_test.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/weaveworks/service/users/client"
+	"github.com/weaveworks/service/users/db/memory"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+var (
+	ghToken   = "e12eb509a297f56dcc77c86ec9e44369080698a6"
+	ghSession = []byte(`{"token": {"expiry": "0001-01-01T00:00:00Z", "token_type": "bearer", "access_token": "` + ghToken + `"}}`)
+)
+
+func TestAdmin_GetUserToken(t *testing.T) {
+	db, _ := memory.New("", "", 1)
+	usr, _ := db.CreateUser(nil, "test@test")
+	db.AddLoginToUser(nil, usr.ID, "github", "12345", ghSession)
+	a := API{
+		db: db,
+	}
+
+	ts := httptest.NewServer(a.routes())
+	defer ts.Close()
+
+	res, err := http.Get(fmt.Sprintf("%s/private/api/users/%v/logins/github/token", ts.URL, usr.ID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("Expecting StatusOK, got %v", res.StatusCode)
+	}
+	var tok client.ProviderToken
+	err = json.NewDecoder(res.Body).Decode(&tok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok.Token != ghToken {
+		t.Fatalf("Expecting db to return token, got %v", tok.Token)
+	}
+}
+
+func TestAPI_GetUserTokenNoUser(t *testing.T) {
+	db, _ := memory.New("", "", 1)
+	a := API{
+		db: db,
+	}
+
+	ts := httptest.NewServer(a.routes())
+	defer ts.Close()
+
+	res, err := http.Get(fmt.Sprintf("%s/private/api/users/%v/logins/github/token", ts.URL, "unknown"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusNotFound {
+		t.Fatalf("Expecting StatusNotFound, got %v", res.StatusCode)
+	}
+}
+
+func TestAPI_GetUserTokenNoToken(t *testing.T) {
+	db, _ := memory.New("", "", 1)
+	usr, _ := db.CreateUser(nil, "test@test")
+	a := API{
+		db: db,
+	}
+
+	ts := httptest.NewServer(a.routes())
+	defer ts.Close()
+
+	res, err := http.Get(fmt.Sprintf("%s/private/api/users/%v/logins/github/token", ts.URL, usr.ID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("Expecting StatusUnauthorized, got %v", res.StatusCode)
+	}
+}
+
+func TestAPI_GetUserTokenInvalidRouteNoUser(t *testing.T) {
+	a := API{}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		a.getUserToken(w, r)
+	}))
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusUnprocessableEntity {
+		t.Fatalf("Expecting StatusUnprocessableEntity, got %v", res.StatusCode)
+	}
+}

--- a/users/api/routes.go
+++ b/users/api/routes.go
@@ -81,6 +81,7 @@ func (a *API) routes() http.Handler {
 		{"private_api_pardot", "GET", "/private/api/marketing_refresh", a.marketingRefresh},
 		{"private_api_users", "GET", "/private/api/users", a.listUsers},
 		{"private_api_users_userID_admin", "POST", "/private/api/users/{userID}/admin", a.makeUserAdmin},
+		{"private_api_users_userID_logins_provider_token", "GET", "/private/api/users/{userID}/logins/{provider}/token", a.getUserToken},
 	} {
 		r.Handle(route.path, route.handler).Methods(route.method).Name(route.name)
 	}

--- a/users/client/api_error.go
+++ b/users/client/api_error.go
@@ -1,0 +1,18 @@
+package client
+
+import (
+	"fmt"
+)
+
+// APIError When an API call fails, we may want to distinguish among the causes
+// by status code. This type can be used as the base error when we get
+// a non-"HTTP 20x" response, retrievable with errors.Cause(err).
+type APIError struct {
+	StatusCode int
+	Status     string
+	Body       string
+}
+
+func (err *APIError) Error() string {
+	return fmt.Sprintf("%s (%s)", err.Status, err.Body)
+}

--- a/users/client/token_injector.go
+++ b/users/client/token_injector.go
@@ -1,0 +1,116 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+var (
+	errInvalidRequest = errors.New("GH integration - invalid request")
+	errEmptyToken     = errors.New("GH integration - empty token")
+)
+
+// Integration represents an API to get GH specific user stuff from the users db
+type Integration interface {
+	TokenForUser(r *http.Request, provider string) (token string, err error)
+}
+
+// TokenRequester Obtains GH tokens
+type TokenRequester struct {
+	URL          string
+	client       http.Client
+	UserIDHeader string
+}
+
+// ProviderToken is used for passing a token around
+type ProviderToken struct {
+	Token string `json:"token"`
+}
+
+// TokenForUser get a token for a user
+func (t *TokenRequester) TokenForUser(r *http.Request, provider string) (token string, err error) {
+	// This middleware is ran after the authenticate user middleware
+	// so userID information is located in the header.
+	userID := r.Header.Get(t.UserIDHeader)
+	if userID == "" {
+		err = errInvalidRequest
+		return
+	}
+
+	u, err := url.Parse(t.URL)
+	if err != nil {
+		return
+	}
+	u.Path = fmt.Sprintf("/private/api/users/%s/logins/%s/token", userID, provider)
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return
+	}
+
+	return t.decodeToken(t.doTokenRequest(req))
+}
+
+func (t *TokenRequester) doTokenRequest(r *http.Request) (body io.ReadCloser, err error) {
+	resp, err := t.client.Do(r)
+	if err != nil {
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		b, _ := ioutil.ReadAll(resp.Body)
+		err = &APIError{
+			StatusCode: resp.StatusCode,
+			Status:     fmt.Sprint(resp.StatusCode),
+			Body:       string(b),
+		}
+		return
+	}
+	body = resp.Body
+	return
+}
+
+func (t *TokenRequester) decodeToken(body io.ReadCloser, err error) (string, error) {
+	if err != nil {
+		return "", err
+	}
+	defer body.Close()
+	var tok ProviderToken
+	err = json.NewDecoder(body).Decode(&tok)
+	if err != nil {
+		return "", err
+	}
+	if tok.Token == "" {
+		return "", errEmptyToken
+	}
+	return tok.Token, nil
+}
+
+// GHIntegrationMiddleware will inject the GH token into the header of the request
+type GHIntegrationMiddleware struct {
+	T Integration
+}
+
+// Wrap implements middleware.Interface
+func (t GHIntegrationMiddleware) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tok, err := t.T.TokenForUser(r, "github")
+		if err != nil {
+			apiErr, isAPIErr := err.(*APIError)
+			if isAPIErr {
+				w.WriteHeader(apiErr.StatusCode)
+			} else {
+				w.WriteHeader(http.StatusUnprocessableEntity)
+			}
+			fmt.Fprintf(w, err.Error())
+			return
+		}
+		// Set token in header
+		r.Header.Set("GithubToken", tok)
+		next.ServeHTTP(w, r)
+	})
+}

--- a/users/client/token_injector_test.go
+++ b/users/client/token_injector_test.go
@@ -1,0 +1,140 @@
+package client
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGitIntegration_GHIntegrationMiddleware(t *testing.T) {
+	g := &mockGHIntegration{
+		tok: "123",
+	}
+	m := GHIntegrationMiddleware{
+		T: g,
+	}
+	req := http.Request{
+		Header: http.Header{},
+	}
+	m.Wrap(&mockHTTPHandler{}).ServeHTTP(nil, &req)
+	if req.Header.Get("GithubToken") == "" {
+		t.Fatal("Did not set Github token")
+	}
+}
+
+func TestGitIntegration_GHIntegrationMiddlewareFail(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+
+	g := &mockGHIntegration{
+		err: &APIError{
+			StatusCode: http.StatusUnprocessableEntity,
+			Status:     "422",
+			Body:       "test",
+		},
+	}
+	m := GHIntegrationMiddleware{
+		T: g,
+	}
+	w := httptest.NewRecorder()
+	m.Wrap(&mockHTTPHandler{}).ServeHTTP(w, req)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("Expecting 422 but got, %v", w.Code)
+	}
+}
+
+type mockGHIntegration struct {
+	tok string
+	err error
+}
+
+func (g *mockGHIntegration) TokenForUser(_ *http.Request, _ string) (string, error) {
+	return g.tok, g.err
+}
+
+type mockHTTPHandler struct {
+	r *http.Request
+}
+
+func (h *mockHTTPHandler) ServeHTTP(_ http.ResponseWriter, req *http.Request) {
+	h.r = req
+}
+
+func TestGitIntergration_TokenForuser(t *testing.T) {
+	tripper := &mockRoundTripper{
+		statusCode: 200,
+		body:       `{"token": "123"}`,
+	}
+	tr := newRequester(tripper)
+
+	tok, err := tr.TokenForUser(requestWithIDHeader("u1"), "github")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok != "123" {
+		t.Fatalf("tok should have been 123, but got %v", tok)
+	}
+}
+
+func TestGitIntegration_NoUserIdHeader(t *testing.T) {
+	tr := newRequester(nil)
+	_, err := tr.TokenForUser(requestWithIDHeader(""), "github")
+	if err == nil {
+		t.Fatalf("Expected error, but got: %v", err)
+	}
+}
+
+func TestGitIntergration_EmptyToken(t *testing.T) {
+	tripper := &mockRoundTripper{
+		statusCode: 200,
+		body:       `{"token": ""}`,
+	}
+	tr := newRequester(tripper)
+
+	_, err := tr.TokenForUser(requestWithIDHeader("u1"), "github")
+	if err == nil {
+		t.Fatalf("Expecting empty token error, got %v", err)
+	}
+}
+
+func TestGitIntergration_ErrorGettingToken(t *testing.T) {
+	tripper := &mockRoundTripper{
+		statusCode: 401,
+	}
+	tr := newRequester(tripper)
+
+	_, err := tr.TokenForUser(requestWithIDHeader("u1"), "github")
+	if err == nil {
+		t.Fatalf("Expecting error after error getting token, got %v", err)
+	}
+}
+
+type mockRoundTripper struct {
+	statusCode int
+	body       string
+}
+
+func (t *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: t.statusCode,
+		Body:       ioutil.NopCloser(strings.NewReader(t.body)),
+	}, nil
+}
+
+func newRequester(t http.RoundTripper) Integration {
+	return &TokenRequester{
+		client: http.Client{
+			Transport: t,
+		},
+		UserIDHeader: "userID",
+	}
+}
+
+func requestWithIDHeader(val string) *http.Request {
+	h := http.Header{}
+	h.Set("userID", val)
+	return &http.Request{
+		Header: h,
+	}
+}

--- a/users/errors.go
+++ b/users/errors.go
@@ -48,4 +48,6 @@ var (
 	ErrOrgExternalIDFormat        = ValidationErrorf("ID can only contain letters, numbers, hyphen, and underscore")
 	ErrOrgNameCannotBeBlank       = ValidationErrorf("Name cannot be blank")
 	ErrOrgTokenIsTaken            = errors.New("Token already taken")
+	ErrLoginNotFound              = errors.New("no login for this user")
+	ErrProviderParameters         = errors.New("Must pass provider and userID")
 )

--- a/users/login/github.go
+++ b/users/login/github.go
@@ -21,7 +21,7 @@ func NewGithubProvider() Provider {
 			name: "Github",
 			Config: oauth2.Config{
 				Endpoint: githubOauth.Endpoint,
-				Scopes:   []string{"user:email"},
+				Scopes:   []string{"user:email", "repo", "write:public_key", "read:public_key"},
 			},
 		},
 	}

--- a/users/render/errors.go
+++ b/users/render/errors.go
@@ -16,6 +16,10 @@ func errorStatusCode(err error) int {
 		return http.StatusNotFound
 	case err == users.ErrInvalidAuthenticationData:
 		return http.StatusUnauthorized
+	case err == users.ErrLoginNotFound:
+		return http.StatusUnauthorized
+	case err == users.ErrProviderParameters:
+		return http.StatusUnprocessableEntity
 	}
 
 	switch err.(type) {


### PR DESCRIPTION
This is a part of https://github.com/weaveworks/flux/issues/225

The goal is to be able to automatically insert a Github deploy key from a click in the ui. The UI can achieve this by calling `/api/app/ancient-sunset-36/api/flux/v5/integrations/github?owner=philwinder&repository=flux-example`, changing the url to match the current instance and the user's GH owner and repo.

It relies on the fact that the user has already logged in and attached their user to GH. If the user doesn't have a GH login, it will return a 401. If the token doesn't work (e.g. wrong scope) it will return a 401. If the user, owner or repo don't exist it will return a 404.

GH might produce some other errors.

The scope is hardcoded. So a current user will have the wrong scope. The user will have to go through the re-login process in order to request a new scope.

This is all acheived by two key bits of code. A new private API to get the user's GH token from the users DB. And a new middleware to inject that token into a request, originating from the ui and ending at flux.

This is a PITA to test manually. You have to use service-conf/k8s/local. Then you have to manually insert GH data into the DB. Build flux. Then query with a UI correct query (i.e. all the session crap). Then it should work. If you want direct access to test the private API, then you will need to edit the users service `-svc` file to open a nodeport.