### PR TITLE
Minimize session-refresh race conditions

### DIFF
--- a/users/api/login.go
+++ b/users/api/login.go
@@ -115,7 +115,7 @@ func (a *API) attachLoginProvider(w http.ResponseWriter, r *http.Request) {
 			// If we have an existing session and an provider, we should use
 			// that. This means that we'll associate the provider (if we have
 			// one) with the logged in session.
-			userID, err := a.sessions.Get(r)
+			session, err := a.sessions.Get(r)
 			switch err {
 			case nil:
 				view.Attach = true
@@ -124,7 +124,7 @@ func (a *API) attachLoginProvider(w http.ResponseWriter, r *http.Request) {
 			default:
 				return nil, err
 			}
-			return a.db.FindUserByID(r.Context(), userID)
+			return a.db.FindUserByID(r.Context(), session.UserID)
 		},
 		func() (*users.User, error) {
 			// If the user has already attached this provider, this is a no-op, so we

--- a/users/api/sessions_test.go
+++ b/users/api/sessions_test.go
@@ -19,10 +19,10 @@ func Test_Sessions_EncodeDecode(t *testing.T) {
 	encoded, err := sessionStore.Encode(user.ID)
 	require.NoError(t, err)
 
-	foundID, err := sessionStore.Decode(encoded)
+	foundSession, err := sessionStore.Decode(encoded)
 	require.NoError(t, err)
 
-	assert.Equal(t, user.ID, foundID)
+	assert.Equal(t, user.ID, foundSession.UserID)
 }
 
 func Test_Sessions_Get_NoCookie(t *testing.T) {
@@ -30,7 +30,7 @@ func Test_Sessions_Get_NoCookie(t *testing.T) {
 	defer cleanup(t)
 
 	r, _ := http.NewRequest("GET", "/", nil)
-	userID, err := sessionStore.Get(r)
+	session, err := sessionStore.Get(r)
 	assert.Equal(t, users.ErrInvalidAuthenticationData, err)
-	assert.Equal(t, "", userID)
+	assert.Equal(t, "", session.UserID)
 }


### PR DESCRIPTION
~Also, move the session refresh to the users client to make sure it happens regardless of caching.~

Fixes #1064 

~I am not happy about how the session cookie code is split between the client and store. Suggestions to improve it are welcome.~ (I am going to only do it in the users service, for uncached requests, which is fine since cache entries expire after 30s)