### PR TITLE
Optimise lookupOrg such that it only does one DB query

### DIFF
--- a/users/api/lookup.go
+++ b/users/api/lookup.go
@@ -5,36 +5,61 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+	"golang.org/x/net/context"
 
 	"github.com/weaveworks/service/users"
 	"github.com/weaveworks/service/users/render"
+	"github.com/weaveworks/service/users/sessions"
 )
 
-type lookupOrgView struct {
+type lookupOrgRequest struct {
+	Cookie, OrgExternalID string
+}
+
+type lookupOrgResponse struct {
 	OrganizationID string   `json:"organizationID,omitempty"`
 	UserID         string   `json:"userID,omitempty"`
 	FeatureFlags   []string `json:"featureFlags,omitempty"`
 }
 
-func (a *API) lookupOrg(currentUser *users.User, w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	orgExternalID := vars["orgExternalID"]
-	organizations, err := a.db.ListOrganizationsForUserIDs(r.Context(), currentUser.ID)
+func (a *API) lookupOrgHandler(w http.ResponseWriter, r *http.Request) {
+	cookie, err := sessions.Extract(r)
 	if err != nil {
 		render.Error(w, r, err)
 		return
 	}
+
+	vars := mux.Vars(r)
+	orgExternalID := vars["orgExternalID"]
+	view, err := a.lookupOrg(r.Context(), &lookupOrgRequest{cookie, orgExternalID})
+	if err != nil {
+		render.Error(w, r, err)
+		return
+	}
+
+	render.JSON(w, http.StatusOK, view)
+}
+
+func (a *API) lookupOrg(ctx context.Context, req *lookupOrgRequest) (*lookupOrgResponse, error) {
+	session, err := a.sessions.Decode(req.Cookie)
+	if err != nil {
+		return nil, err
+	}
+
+	organizations, err := a.db.ListOrganizationsForUserIDs(ctx, session.UserID)
+	if err != nil {
+		return nil, err
+	}
 	for _, org := range organizations {
-		if strings.ToLower(org.ExternalID) == strings.ToLower(orgExternalID) {
-			render.JSON(w, http.StatusOK, lookupOrgView{
+		if strings.ToLower(org.ExternalID) == strings.ToLower(req.OrgExternalID) {
+			return &lookupOrgResponse{
 				OrganizationID: org.ID,
-				UserID:         currentUser.ID,
+				UserID:         session.UserID,
 				FeatureFlags:   org.FeatureFlags,
-			})
-			return
+			}, nil
 		}
 	}
-	render.Error(w, r, users.ErrNotFound)
+	return nil, users.ErrInvalidAuthenticationData
 }
 
 type lookupAdminView struct {
@@ -50,7 +75,7 @@ func (a *API) lookupAdmin(currentUser *users.User, w http.ResponseWriter, r *htt
 }
 
 func (a *API) lookupUsingToken(organization *users.Organization, w http.ResponseWriter, r *http.Request) {
-	render.JSON(w, http.StatusOK, lookupOrgView{OrganizationID: organization.ID, FeatureFlags: organization.FeatureFlags})
+	render.JSON(w, http.StatusOK, lookupOrgResponse{OrganizationID: organization.ID, FeatureFlags: organization.FeatureFlags})
 }
 
 type lookupUserView struct {

--- a/users/api/routes.go
+++ b/users/api/routes.go
@@ -69,7 +69,7 @@ func (a *API) routes() http.Handler {
 		// The users service client (i.e. our other services) use these to
 		// authenticate the admin/user/probe.
 		{"private_api_users_admin", "GET", "/private/api/users/admin", a.authenticateUser(a.lookupAdmin)},
-		{"private_api_users_lookup_orgExternalID", "GET", "/private/api/users/lookup/{orgExternalID}", a.authenticateUser(a.lookupOrg)},
+		{"private_api_users_lookup_orgExternalID", "GET", "/private/api/users/lookup/{orgExternalID}", a.lookupOrgHandler},
 		{"private_api_users_lookup", "GET", "/private/api/users/lookup", a.authenticateProbe(a.lookupUsingToken)},
 		{"private_api_users_lookup_user", "GET", "/private/api/users/lookup_user", a.authenticateUser(a.lookupUser)},
 

--- a/users/sessions/store.go
+++ b/users/sessions/store.go
@@ -45,14 +45,23 @@ type Session struct {
 
 // Get fetches the current session for this request.
 func (s Store) Get(r *http.Request) (Session, error) {
+	value, err := Extract(r)
+	if err != nil {
+		return Session{}, err
+	}
+	return s.Decode(value)
+}
+
+// Extract the encoded session from a request.
+func Extract(r *http.Request) (string, error) {
 	cookie, err := r.Cookie(client.AuthCookieName)
 	if err == http.ErrNoCookie {
 		err = users.ErrInvalidAuthenticationData
 	}
 	if err != nil {
-		return Session{}, err
+		return "", err
 	}
-	return s.Decode(cookie.Value)
+	return cookie.Value, nil
 }
 
 // Decode converts an encoded session into a user ID.


### PR DESCRIPTION
I've removed the auth wrapper around lookupOrg, and instead decode the cookie directly in the lookupOrg handler.  We no longer lookup the user when doing a lookupOrg request, but lookup the Organization directly.

Also a little refactoring to lay the ground for gRPCification of this call.

One downside is user auth via tokens won't work anymore, but thats going away right?