### PR TITLE
Include user emails in private admin org lookup

### DIFF
--- a/users/api/admin.go
+++ b/users/api/admin.go
@@ -85,11 +85,12 @@ type listOrganizationsView struct {
 }
 
 type privateOrgView struct {
-	ID           string   `json:"id"`
-	InternalID   string   `json:"internal_id"`
-	Name         string   `json:"name"`
-	CreatedAt    string   `json:"created_at"`
-	FeatureFlags []string `json:"feature_flags,omitempty"`
+	ID           string        `json:"id"`
+	InternalID   string        `json:"internal_id"`
+	Name         string        `json:"name"`
+	CreatedAt    string        `json:"created_at"`
+	FeatureFlags []string      `json:"feature_flags,omitempty"`
+	Users        []*users.User `json:"users,omitempty"`
 }
 
 func (a *API) listOrganizations(w http.ResponseWriter, r *http.Request) {
@@ -151,12 +152,19 @@ func (a *API) adminShowOrganization(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	users, err := a.db.ListOrganizationUsers(r.Context(), orgExternalID)
+	if err != nil {
+		render.Error(w, r, err)
+		return
+	}
+
 	render.JSON(w, http.StatusOK, privateOrgView{
 		ID:           org.ExternalID,
 		InternalID:   org.ID,
 		Name:         org.Name,
 		CreatedAt:    org.FormatCreatedAt(),
 		FeatureFlags: org.FeatureFlags,
+		Users:        users,
 	})
 }
 


### PR DESCRIPTION
Output looks like:
```js
{
  id: "local-test",
  internal_id: "1",
  name: "Local Test Instance",
  created_at: "2017-03-03T15:46:14Z",
  users: [
    {email: "test@test"}
  ]
}
```