### PR TITLE
authfe: Add a flag to switch between external and internal ui-server routes

### DIFF
--- a/authfe/main.go
+++ b/authfe/main.go
@@ -70,6 +70,7 @@ func main() {
 	flag.StringVar(&fluentHost, "fluent", "", "Hostname & port for fluent")
 	flag.StringVar(&c.outputHeader, "output.header", "X-Scope-OrgID", "Name of header containing org id on forwarded requests")
 	flag.StringVar(&c.apiInfo, "api.info", "scopeservice:0.1", "Version info for the api to serve, in format ID:VERSION")
+	flag.BoolVar(&c.externalUI, "externalUI", true, "Point to externally hosted static UI assets")
 
 	// Security-related flags
 	flag.StringVar(&c.targetOrigin, "hostname", "", "Hostname through which this server is accessed, for same-origin checks (CSRF protection)")


### PR DESCRIPTION
External (non-index.html served from s3) is default, and served from ui-server/
Internal (all files served from ui-server) is enabled with -externalUI=false and served from ui-server/internal/
	but note that from an external perspective this /internal route is hidden, it's translated at authfe

Fixes https://github.com/weaveworks/service-ui/issues/300