### PR TITLE
Re-enable CSRF token check and exclude prefixes

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -480,7 +480,7 @@ func (c csrfTokenVerifier) Wrap(next http.Handler) http.Handler {
 		http.Error(w, "CSRF token mismatch", http.StatusBadRequest)
 	}))
 	for _, prefix := range c.exemptPrefixes {
-		h.ExemptGlob(prefix + "*")
+		h.ExemptRegexp(fmt.Sprintf("^%s.*$", prefix))
 	}
 	return h
 }


### PR DESCRIPTION
We weren't excluding prefixes for probe-paths but exact matches, breaking the flux CLI (See #1151 )