### PR TITLE
Add new routes for cortex configs

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -289,7 +289,8 @@ func routes(c Config) (http.Handler, error) {
 			{"/report", newProxy(c.collectionHost)},
 			{"/control", newProxy(c.controlHost)},
 			{"/pipe", newProxy(c.pipeHost)},
-			// TODO: Remove this once all Weaveworks clients are updated
+			// TODO: Remove this once this change has been deployed to
+			// production and service-conf#670 has been merged.
 			{"/configs", newProxy(c.configsHost)},
 			{"/flux", newProxy(c.fluxHost)},
 			{"/prom/configs", newProxy(c.configsHost)},
@@ -319,7 +320,8 @@ func routes(c Config) (http.Handler, error) {
 				{"/api/topology", newProxy(c.queryHost)},
 				{"/api/control", newProxy(c.controlHost)},
 				{"/api/pipe", newProxy(c.pipeHost)},
-				// TODO: Remove this once the UI client is updated
+				// TODO: Remove this once service-ui#334 has been merged and
+				// deployed to production.
 				{"/api/configs", newProxy(c.configsHost)},
 				// API to insert deploy key requires GH token. Insert token with middleware.
 				{"/api/flux/v5/integrations/github",


### PR DESCRIPTION
Follow up from weaveworks/cortex#344. Prerequisite for weaveworks/service-ui#334.

Tested locally and everything seems to work fine.