### PR TITLE
Add Cortex alertmanager UI / API route for browser

### DIFF
--- a/authfe/main.go
+++ b/authfe/main.go
@@ -91,6 +91,7 @@ func main() {
 		{&c.fluxHost, "flux"},
 		{&c.launchGeneratorHost, "launch-generator"},
 		{&c.pipeHost, "pipe"},
+		{&c.promAlertmanagerHost, "prom-alertmanager"},
 		{&c.promDistributorHost, "prom-distributor"},
 		{&c.promDistributorHostGRPC, "prom-distributor-grpc"},
 		{&c.promQuerierHost, "prom-querier"},

--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -71,6 +71,7 @@ type Config struct {
 	kubediffHost            string
 	lokiHost                string
 	prodGrafanaHost         string
+	promAlertmanagerHost    string
 	promDistributorHost     string
 	promDistributorHostGRPC string
 	prometheusHost          string
@@ -321,6 +322,7 @@ func routes(c Config) (http.Handler, error) {
 				{"/api/flux/v5/integrations/github",
 					fluxGHTokenMiddleware.Wrap(newProxy(c.fluxHost))},
 				{"/api/flux", newProxy(c.fluxHost)},
+				{"/api/prom/alertmanager", newProxy(c.promAlertmanagerHost)},
 				{"/api/prom/configs", newProxy(c.configsHost)},
 				{"/api/prom", cortexQuerierClient},
 				{"/api", newProxy(c.queryHost)},


### PR DESCRIPTION
Means we can serve Alertmanager UI to end-users.

No probe route for now, because I don't have a use case.

CC @davkal @juliusv 
