### PR TITLE
Un-do change from 'peer' to 'peerui' for peer discovery URLs

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -335,7 +335,7 @@ func routes(c Config) (http.Handler, error) {
 				{"/api/prom/alertmanager", newProxy(c.promAlertmanagerHost)},
 				{"/api/prom/configs", newProxy(c.configsHost)},
 				{"/api/prom", cortexQuerierClient},
-				{"/api/weavenet/peerui", newProxy(c.peerDiscoveryHost)},
+				{"/api/weavenet/peer", newProxy(c.peerDiscoveryHost)},
 				{"/api", newProxy(c.queryHost)},
 
 				// Catch-all forward to query service, which is a Scope instance that we


### PR DESCRIPTION
The UI will come in on a different prefix so we don't need the suffix
to be unique.