### PR TITLE
Update billing routes for moved services

### DIFF
--- a/authfe/admin.go
+++ b/authfe/admin.go
@@ -34,7 +34,9 @@ func adminRoot(w http.ResponseWriter, r *http.Request) {
 			<li><a href="/admin/kubedash/">Kubernetes Dashboard</a></li>
 			<li><a href="/admin/compare-images/">Compare Images</a></li>
 			<li><a href="/admin/cortex/ring">Cortex Ring</a></li>
-			<li><a href="/admin/billing-admin">Billing Admin</a></li>
+			<li><a href="/admin/billing/admin">Billing Admin</a></li>
+			<li><a href="/admin/billing/aggregator">Billing Aggregator</a></li>
+			<li><a href="/admin/billing/uploader">Billing Uploader</a></li>
 		</ul>
 	</body>
 </html>

--- a/authfe/main.go
+++ b/authfe/main.go
@@ -106,6 +106,8 @@ func main() {
 		// Admin services - keep alphabetically sorted pls.
 		{&c.alertmanagerHost, "alertmanager"},
 		{&c.ansiblediffHost, "ansiblediff"},
+		{&c.billingAggregatorHost, "billing-aggregator"},
+		{&c.billingUploaderHost, "billing-uploader"},
 		{&c.compareImagesHost, "compare-images"},
 		{&c.devGrafanaHost, "dev-grafana"},
 		{&c.grafanaHost, "grafana"},

--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -65,8 +65,10 @@ type Config struct {
 	// Admin services - keep alphabetically sorted pls
 	alertmanagerHost        string
 	ansiblediffHost         string
-	devGrafanaHost          string
+	billingAggregatorHost   string
+	billingUploaderHost     string
 	compareImagesHost       string
+	devGrafanaHost          string
 	grafanaHost             string
 	kubedashHost            string
 	kubediffHost            string
@@ -75,9 +77,9 @@ type Config struct {
 	promAlertmanagerHost    string
 	promDistributorHost     string
 	promDistributorHostGRPC string
-	prometheusHost          string
 	promQuerierHost         string
 	promQuerierHostGRPC     string
+	prometheusHost          string
 	scopeHost               string
 	terradiffHost           string
 	usersHost               string
@@ -376,7 +378,9 @@ func routes(c Config) (http.Handler, error) {
 				{"/prod-grafana", trimPrefix("/admin/prod-grafana", newProxy(c.prodGrafanaHost))},
 				{"/scope", trimPrefix("/admin/scope", newProxy(c.scopeHost))},
 				{"/users", trimPrefix("/admin/users", newProxy(c.usersHost))},
-				{"/billing-admin", newProxy(c.billingAPIHost)},
+				{"/billing/admin", trimPrefix("/admin/billing/admin", newProxy(c.billingAPIHost))},
+				{"/billing/aggregator", trimPrefix("/admin/billing/aggregator", newProxy(c.billingAggregatorHost))},
+				{"/billing/uploader", trimPrefix("/admin/billing/uploader", newProxy(c.billingUploaderHost))},
 				{"/kubediff", trimPrefix("/admin/kubediff", newProxy(c.kubediffHost))},
 				{"/terradiff", trimPrefix("/admin/terradiff", newProxy(c.terradiffHost))},
 				{"/ansiblediff", trimPrefix("/admin/ansiblediff", newProxy(c.ansiblediffHost))},


### PR DESCRIPTION
This will temporarily break the billing apis when deploying, but no one is using them, so.

## TODO

- [x] Remove the billing-usage and billing-admin flags from authfe before merging this! (see https://github.com/weaveworks/service-conf/pull/709)