### PR TITLE
Rename 'weavenet' to 'net' in URLs, for simplicity

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -300,7 +300,7 @@ func routes(c Config) (http.Handler, error) {
 			{"/prom/configs", newProxy(c.configsHost)},
 			{"/prom/push", cortexDistributorClient},
 			{"/prom", cortexQuerierClient},
-			{"/weavenet/peer", newProxy(c.peerDiscoveryHost)},
+			{"/net/peer", newProxy(c.peerDiscoveryHost)},
 		},
 		middleware.Merge(
 			users_client.AuthProbeMiddleware{
@@ -338,7 +338,7 @@ func routes(c Config) (http.Handler, error) {
 				{"/api/prom/alertmanager", newProxy(c.promAlertmanagerHost)},
 				{"/api/prom/configs", newProxy(c.configsHost)},
 				{"/api/prom", cortexQuerierClient},
-				{"/api/weavenet/peer", newProxy(c.peerDiscoveryHost)},
+				{"/api/net/peer", newProxy(c.peerDiscoveryHost)},
 				{"/api", newProxy(c.queryHost)},
 
 				// Catch-all forward to query service, which is a Scope instance that we


### PR DESCRIPTION
Following discussion in Slack
https://weaveworks.slack.com/archives/C0CG6Q4BG/p1491831959779571
https://weaveworks.slack.com/archives/C0CG6Q4BG/p1491832071818863
