### PR TITLE
Route and link to alertmanager status page

### DIFF
--- a/authfe/admin.go
+++ b/authfe/admin.go
@@ -34,6 +34,7 @@ func adminRoot(w http.ResponseWriter, r *http.Request) {
 			<li><a href="/admin/kubedash/">Kubernetes Dashboard</a></li>
 			<li><a href="/admin/compare-images/">Compare Images</a></li>
 			<li><a href="/admin/cortex/ring">Cortex Ring</a></li>
+			<li><a href="/admin/cortex/alertmanager/status">Cortex Alertmanager Status</a></li>
 			<li><a href="/admin/billing/admin">Billing Admin</a></li>
 			<li><a href="/admin/billing/aggregator">Billing Aggregator</a></li>
 			<li><a href="/admin/billing/uploader">Billing Uploader</a></li>

--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -316,6 +316,7 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 				{"/prometheus", c.prometheusHost},
 				{"/kubedash", trimPrefix("/admin/kubedash", c.kubedashHost)},
 				{"/compare-images", trimPrefix("/admin/compare-images", c.compareImagesHost)},
+				{"/cortex/alertmanager/status", trimPrefix("/admin/cortex/alertmanager/status", c.promAlertmanagerHost)},
 				{"/cortex/ring", trimPrefix("/admin/cortex", c.promDistributorHost)},
 				{"/loki", trimPrefix("/admin/loki", c.lokiHost)},
 				{"/", http.HandlerFunc(adminRoot)},


### PR DESCRIPTION
Depends on quay.io/weaveworks/cortex-alertmanager:master-0bc4351 being deployed.

See https://github.com/weaveworks/cortex/pull/396 for details.