### PR TITLE
log unauthenticated requests (again)

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -102,10 +102,7 @@ func newUIRequestLogger(userIDHeader string) HTTPEventExtractor {
 			sessionID = sessionCookie.Value
 		}
 
-		orgID, err := user.ExtractOrgID(r.Context())
-		if err != nil {
-			return Event{}, false
-		}
+		orgID, _ := user.ExtractOrgID(r.Context())
 
 		event := Event{
 			ID:             r.URL.Path,


### PR DESCRIPTION
they don't carry an org id; failure to find that id ought not to prevent their logging.

This is important for the likes of launch-generator.

Fixes #1186.