### PR TITLE
Users: Extract the anti-CSRF token correctly

### DIFF
--- a/users/login/github.go
+++ b/users/login/github.go
@@ -28,9 +28,9 @@ func NewGithubProvider() Provider {
 }
 
 func (g *github) Link(r *http.Request) (Link, bool) {
-	l, _ := g.OAuth.Link(r)
+	l, ok := g.OAuth.Link(r)
 	l.BackgroundColor = "#444444"
-	return l, true
+	return l, ok
 }
 
 // Login converts a user to a db ID

--- a/users/login/google.go
+++ b/users/login/google.go
@@ -35,9 +35,9 @@ func NewGoogleProvider() Provider {
 }
 
 func (g *google) Link(r *http.Request) (Link, bool) {
-	l, _ := g.OAuth.Link(r)
+	l, ok := g.OAuth.Link(r)
 	l.BackgroundColor = "#dd4b39"
-	return l, true
+	return l, ok
 }
 
 // Login converts a user to a db ID


### PR DESCRIPTION
Also, for extra security, do not build the OAuth callback unless the anti-CSRF
token is present.

Fixes #1187

I (ironically) broke the token extraction in #1104 , when moving the anti-CSRF token generation to authfe.

I wrongly assumed that [`nosurf.Token()`](https://github.com/weaveworks/service/blob/afed827e9caa640699e5451a282b7b20f3bcf72d/vendor/github.com/justinas/nosurf/context.go#L25-L44) directly extracts the token from its request parameter. However, `nosurf.Token()` is stateful and operates on a context previously set by the `nosurf` handler. Moving the nosurf handler to `authfe` caused the `users` service to stop setting the context, in turn causing `nosurf.Token()` to always return `""`.

I still need to verify everything works end to end in dev (local testing is hard due to OAuth redirect restrictions from Google/GitHub).