### PR TITLE
Create postgres-configs-db docker image

### DIFF
--- a/postgres-configs-db/Dockerfile
+++ b/postgres-configs-db/Dockerfile
@@ -1,0 +1,3 @@
+FROM postgres:9.6
+ENV POSTGRES_DB configs
+ADD init.sql /docker-entrypoint-initdb.d/

--- a/postgres-configs-db/init.sql
+++ b/postgres-configs-db/init.sql
@@ -1,0 +1,2 @@
+-- The configs database already exists due to the default database created by the POSTGRES_DB env var
+CREATE DATABASE notebooks;


### PR DESCRIPTION
Use `postgres:9.6` image and use the `docker-entrypoint-initdb.d` folder to run additional sql to create the notebooks database.

Test plan: ran locally and checked both databases were created and the configs and notebooks services could connect to them