### PR TITLE
Change queryEnd field type to json.Number

### DIFF
--- a/notebooks/api/notebook_test.go
+++ b/notebooks/api/notebook_test.go
@@ -144,7 +144,7 @@ func TestAPI_getNotebook(t *testing.T) {
 
 	assert.Len(t, result.Entries, 1)
 	assert.Equal(t, result.Entries[0].Query, "metric{}")
-	assert.Equal(t, result.Entries[0].QueryEnd, "1000.1")
+	assert.Equal(t, result.Entries[0].QueryEnd.String(), "1000.1")
 	assert.Equal(t, result.Entries[0].QueryRange, "1h")
 	assert.Equal(t, result.Entries[0].Type, "graph")
 }
@@ -198,7 +198,7 @@ func TestAPI_updateNotebook(t *testing.T) {
 	assert.Equal(t, getResult.Title, "Updated notebook")
 	assert.Equal(t, getResult.Version, result.Version)
 	assert.Equal(t, getResult.Entries[0].Query, "updatedMetric{}")
-	assert.Equal(t, getResult.Entries[0].QueryEnd, "77.7")
+	assert.Equal(t, getResult.Entries[0].QueryEnd.String(), "77.7")
 	assert.Equal(t, getResult.Entries[0].QueryRange, "7h")
 	assert.Equal(t, getResult.Entries[0].Type, "new")
 }

--- a/notebooks/notebook.go
+++ b/notebooks/notebook.go
@@ -1,6 +1,7 @@
 package notebooks
 
 import (
+	"encoding/json"
 	"errors"
 	"time"
 
@@ -27,8 +28,8 @@ type Notebook struct {
 
 // Entry describes a PromQL query for a notebook
 type Entry struct {
-	Query      string `json:"query"`
-	QueryEnd   string `json:"queryEnd"`
-	QueryRange string `json:"queryRange"`
-	Type       string `json:"type"`
+	Query      string      `json:"query"`
+	QueryEnd   json.Number `json:"queryEnd"`
+	QueryRange string      `json:"queryRange"`
+	Type       string      `json:"type"`
 }


### PR DESCRIPTION
The type of `queryEnd` on the FE side is number, however we wish to store this as a string in the db. Use json.Number to decode as a string and encode as a number.

Test plan: Called API locally, creating a entry with a `number` for `queryEnd` and checking it returned an entry with a `number` `queryEnd`.