### PR TITLE
Return 204 for notebooks delete API

### DIFF
--- a/notebooks/api/notebook.go
+++ b/notebooks/api/notebook.go
@@ -219,9 +219,5 @@ func (a *API) deleteNotebook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err := w.Write([]byte("OK")); err != nil {
-		log.Errorf("Error returning response: %v", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/notebooks/api/notebook_test.go
+++ b/notebooks/api/notebook_test.go
@@ -254,9 +254,9 @@ func TestAPI_deleteNotebook(t *testing.T) {
 
 	// Make request to update notebook with ID notebookID2
 	w = requestAsUser(t, "org1", "user1", "DELETE", fmt.Sprintf("/api/prom/notebooks/%s", createResult.ID), nil)
-	assert.Equal(t, w.Code, http.StatusOK)
+	assert.Equal(t, w.Code, http.StatusNoContent)
 
 	// Check it was deleted
 	w = requestAsUser(t, "org1", "user1", "GET", fmt.Sprintf("/api/prom/notebooks/%s", createResult.ID), nil)
-	assert.Equal(t, w.Code, 404)
+	assert.Equal(t, w.Code, http.StatusNotFound)
 }


### PR DESCRIPTION
We should return 204 when the delete api is successfully called as there is no content returned.