### PR TITLE
Don't put the UserID in the OrgID for call to /api/ui/analytics.

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -125,11 +125,6 @@ func newAnalyticsLogger(userIDHeader string) HTTPEventExtractor {
 			sessionID = sessionCookie.Value
 		}
 
-		orgID, err := user.ExtractOrgID(r.Context())
-		if err != nil {
-			return Event{}, false
-		}
-
 		values, err := ioutil.ReadAll(&io.LimitedReader{
 			R: r.Body,
 			N: maxAnalyticsPayloadSize,
@@ -139,14 +134,13 @@ func newAnalyticsLogger(userIDHeader string) HTTPEventExtractor {
 		}
 
 		event := Event{
-			ID:             r.URL.Path,
-			SessionID:      sessionID,
-			Product:        "scope-ui",
-			UserAgent:      r.UserAgent(),
-			OrganizationID: orgID,
-			UserID:         r.Header.Get(userIDHeader),
-			Values:         string(values),
-			IPAddress:      mustSplitHostname(r),
+			ID:        r.URL.Path,
+			SessionID: sessionID,
+			Product:   "scope-ui",
+			UserAgent: r.UserAgent(),
+			UserID:    r.Header.Get(userIDHeader),
+			Values:    string(values),
+			IPAddress: mustSplitHostname(r),
 		}
 		return event, true
 	}
@@ -180,7 +174,8 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 	}
 
 	authUserMiddleware := users_client.AuthUserMiddleware{
-		UsersClient: authenticator,
+		UsersClient:  authenticator,
+		UserIDHeader: userIDHeader,
 	}
 
 	billingAuthMiddleware := users_client.AuthOrgMiddleware{

--- a/users/client/middleware.go
+++ b/users/client/middleware.go
@@ -156,7 +156,7 @@ func (a AuthAdminMiddleware) Wrap(next http.Handler) http.Handler {
 // cookie (and not to any specific org)
 type AuthUserMiddleware struct {
 	UsersClient         users.UsersClient
-	FeatureFlagsHeader  string
+	UserIDHeader        string
 	RequireFeatureFlags []string
 }
 
@@ -178,8 +178,7 @@ func (a AuthUserMiddleware) Wrap(next http.Handler) http.Handler {
 			return
 		}
 
-		r = r.WithContext(user.InjectOrgID(r.Context(), response.UserID))
-		user.InjectOrgIDIntoHTTPRequest(r.Context(), r)
+		r.Header.Add(a.UserIDHeader, response.UserID)
 		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
We we're abusing the org id as the user id for calls to /api/ui/analytics.  We shouldn't.