### PR TITLE
Push :latest images in CI

### DIFF
--- a/push-images
+++ b/push-images
@@ -69,16 +69,19 @@ do
     # NB this only works if the code is in directories named for the
     # components, of course.
     image=$(basename $c)
-    push_image="${IMAGE_REPOSITORY}/${image}:${IMAGE_TAG}"
-    if [ "$SINCE" = 'false' ] || ! git diff --quiet "$SINCE" -- "$c"/; then
-        build_image="${BUILD_IMAGE_REPO}/${image}:${IMAGE_TAG}"
-        if [ "$IMAGE_REPOSITORY" != "$BUILD_IMAGE_REPO" ]; then
-            echo "Tagging built image ${build_image} for pushing as ${push_image}"
-            docker tag -f "${build_image}" "${push_image}"
-        fi
-        echo "Pushing ${push_image}"
-        docker push "${push_image}"
-    else
-        echo "Not pushing image for $push_image, because no changes in $c since commit $SINCE"
-    fi
+    for tag in "${IMAGE_TAG}" latest
+    do
+	push_image="${IMAGE_REPOSITORY}/${image}:${tag}"
+	if [ "$SINCE" = 'false' ] || ! git diff --quiet "$SINCE" -- "$c"/; then
+            build_image="${BUILD_IMAGE_REPO}/${image}:${IMAGE_TAG}"
+            if [ "$IMAGE_REPOSITORY" != "$BUILD_IMAGE_REPO" ]; then
+		echo "Tagging built image ${build_image} for pushing as ${push_image}"
+		docker tag -f "${build_image}" "${push_image}"
+            fi
+            echo "Pushing ${push_image}"
+            docker push "${push_image}"
+	else
+            echo "Not pushing image for $push_image, because no changes in $c since commit $SINCE"
+	fi
+     done
 done


### PR DESCRIPTION
This simplifies local development. 

The local k8s resources expect `:latest` images (e.g. [`authfe`](https://github.com/weaveworks/service-conf/blob/696e4640088b1b031273e93374b2269ce33d3247/k8s/local/default/authfe-dep.yaml#L22)) but Devs doing local development shouldn't need to worry about building services they don't want to modify.

(CC @fbarl , who suffered this in first person)