### PR TITLE
Install shfmt from binary

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,11 +10,13 @@ RUN go get -tags netgo \
 		github.com/kisielk/errcheck \
 		github.com/mjibson/esc \
 		github.com/client9/misspell/cmd/misspell \
-		gopkg.in/mvdan/sh.v1/cmd/shfmt \
 		github.com/golang/protobuf/protoc-gen-go \
 		github.com/gogo/protobuf/protoc-gen-gogoslick \
 		github.com/gogo/protobuf/gogoproto && \
 	rm -rf /go/pkg/ /go/src/
+RUN curl -fsSL -o shfmt https://github.com/mvdan/sh/releases/download/v1.3.0/shfmt_v1.3.0_linux_amd64 && \
+	chmod +x shfmt && \
+	mv shfmt /usr/bin
 RUN mkdir protoc && \
 	cd protoc && \
 	curl -O -L https://github.com/google/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip && \


### PR DESCRIPTION
If you don't have a cached build environment, it no longer builds.

Copied from https://github.com/weaveworks/cortex/pull/434