### PR TITLE
Add billing payment-methods to unauthenticated routes

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -351,6 +351,7 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 		// These billing api endpoints have no orgExternalID, so we can't do authorization on them.
 		path{"/api/billing/accounts", c.billingAPIHost},
 		path{"/api/billing/payments/authTokens", c.billingAPIHost},
+		path{"/api/billing/payments/{paymentID}", c.billingAPIHost},
 		// The main billing api requires authorization.
 		prefix{
 			"/api/billing",


### PR DESCRIPTION
Payment method updates were 401'ing. Letting this be unauthenticated should be okay, since orphaned payment methods (no account associated) get purged by Zuora after 240 hours.