### PR TITLE
Fix issue where /demo/ redirects to /demo/ in a loop

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -343,8 +343,9 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 
 				// Demo service paths get rewritten to remove /demo/ prefix, so trailing
 				// slash is required. We then rewrite /demo/* to /* and send it to demo.
-				{"/demo", redirect("/demo/")},
+				// Note that we need to match on /demo/ first since these are prefix matches
 				{"/demo/", middleware.PathRewrite(regexp.MustCompile("/demo/(.*)"), "/$1").Wrap(c.demoHost)},
+				{"/demo", redirect("/demo/")},
 
 				// Forward requests (unauthenticated) to the ui-metrics job.
 				{"/api/ui/metrics", c.uiMetricsHost},


### PR DESCRIPTION
Because route matching is prefix-matching, /demo matches /demo/
We reverse the order so /demo/ route matches first