### PR TITLE
authfe: /demo is 404ing, fix it by removing redirect entirely

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -341,11 +341,9 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 				{"/launch/k8s", c.launchGeneratorHost},
 				{"/k8s", c.launchGeneratorHost},
 
-				// Demo service paths get rewritten to remove /demo/ prefix, so trailing
-				// slash is required. We then rewrite /demo/* to /* and send it to demo.
-				// Note that we need to match on /demo/ first since these are prefix matches
-				{"/demo/", middleware.PathRewrite(regexp.MustCompile("/demo/(.*)"), "/$1").Wrap(c.demoHost)},
-				{"/demo", redirect("/demo/")},
+				// Demo service paths get rewritten to remove /demo/ prefix.
+				// We match both /demo and /demo/... using the same regex
+				{"/demo", middleware.PathRewrite(regexp.MustCompile("/demo/?(.*)"), "/$1").Wrap(c.demoHost)},
 
 				// Forward requests (unauthenticated) to the ui-metrics job.
 				{"/api/ui/metrics", c.uiMetricsHost},


### PR DESCRIPTION
The problem is that /demo/ is transformed to /demo and passed to PathPrefix,
so we can't actually idependently match /demo and /demo/ under our current scheme!
So we get rid of the redirect entirely and just have /demo and /demo/ both go to the same place.
We do this by fixing the regex to also match /demo (previously it wasn't, so we were passing the
/demo path through, getting a 404).

This fixes the bug introduced by https://github.com/weaveworks/service/pull/1243 where `/demo/` works but `/demo` gives a 404.