### PR TITLE
Change email invite URL to /instances page

### DIFF
--- a/users/emailer/emailer.go
+++ b/users/emailer/emailer.go
@@ -35,7 +35,7 @@ func inviteURL(email, rawToken, domain, orgName string) string {
 }
 
 func organizationURL(domain, orgExternalID string) string {
-	return fmt.Sprintf("%s/org/%s", domain, orgExternalID)
+	return fmt.Sprintf("%s/instances/%s", domain, orgExternalID)
 }
 
 // Emailer is the interface which emailers implement. There should be a method


### PR DESCRIPTION
Needed for https://github.com/weaveworks/service-ui/issues/339

Used in conjunction with: https://github.com/weaveworks/service-ui/pull/637

Direct invited users to the instances page instead of the org page.

cc @davkal and @awh, just so other people know I am doing this 🙃 