### PR TITLE
Add flux v6 argument and routes

### DIFF
--- a/authfe/config.go
+++ b/authfe/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	controlHost         proxyConfig
 	demoHost            proxyConfig
 	fluxHost            proxyConfig
+	fluxV6Host          proxyConfig
 	launchGeneratorHost proxyConfig
 	peerDiscoveryHost   proxyConfig
 	pipeHost            proxyConfig
@@ -76,6 +77,7 @@ func (c *Config) proxies() map[string]*proxyConfig {
 		"control":           &c.controlHost,
 		"demo":              &c.demoHost,
 		"flux":              &c.fluxHost,
+		"flux-v6":           &c.fluxV6Host,
 		"launch-generator":  &c.launchGeneratorHost,
 		"notebooks":         &c.notebooksHost,
 		"peer-discovery":    &c.peerDiscoveryHost,

--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -212,6 +212,7 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 			Prefix{"/report", c.collectionHost},
 			Prefix{"/prom/push", c.promDistributorHost},
 			Prefix{"/net/peer", c.peerDiscoveryHost},
+			PrefixMethods{"/flux/v6", []string{"POST", "PATCH"}, c.fluxHost}, // NB uses same as below until we have config in place
 			PrefixMethods{"/flux", []string{"POST", "PATCH"}, c.fluxHost},
 			PrefixMethods{"/prom/alertmanager/alerts", []string{"POST"}, c.promAlertmanagerHost},
 			PrefixMethods{"/prom/alertmanager/v1/alerts", []string{"POST"}, c.promAlertmanagerHost},
@@ -230,6 +231,7 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 		Matchables([]Prefix{
 			{"/control", c.controlHost},
 			{"/pipe", c.pipeHost},
+			{"/flux/v6", c.fluxHost}, // NB uses same as below until we have config in place
 			{"/flux", c.fluxHost},
 			{"/prom/alertmanager", c.promAlertmanagerHost},
 			{"/prom/configs", c.configsHost},
@@ -269,6 +271,8 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 				// API to insert deploy key requires GH token. Insert token with middleware.
 				{"/api/flux/v5/integrations/github",
 					fluxGHTokenMiddleware.Wrap(c.fluxHost)},
+				// While we transition to newer Flux API
+				{"/api/flux/v6", c.fluxHost}, // NB uses same as below until we have config in place
 				{"/api/flux", c.fluxHost},
 				{"/api/prom/alertmanager", c.promAlertmanagerHost},
 				{"/api/prom/configs", c.configsHost},


### PR DESCRIPTION
So that we can roll the new Flux API out without removing the prior
versions, this commit adds specific routes for v6 of that API, and an
argument for the hostname to which to forward requests.

To avoid having to change config exactly in sync with this code being
deployed, the new routes just use the hostname from the original
argument, and ignore the value of the new argument. Once config has
been updated to supply the new argument, they can be differentiated in
the code (and thereafter, the config).