### PR TITLE
Remove user count from org admin page

### DIFF
--- a/users/api/admin.go
+++ b/users/api/admin.go
@@ -87,19 +87,8 @@ func (a *API) listOrganizations(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	orgUsers := map[string]int{}
-	for _, org := range organizations {
-		us, err := a.db.ListOrganizationUsers(r.Context(), org.ExternalID)
-		if err != nil {
-			render.Error(w, r, err)
-			return
-		}
-		orgUsers[org.ExternalID] = len(us)
-	}
-
 	b, err := a.templates.Bytes("list_organizations.html", map[string]interface{}{
-		"Organizations":     organizations,
-		"OrganizationUsers": orgUsers,
+		"Organizations": organizations,
 	})
 	if err != nil {
 		render.Error(w, r, err)

--- a/users/templates/list_organizations.html
+++ b/users/templates/list_organizations.html
@@ -11,7 +11,6 @@
         <th>ID</th>
         <th>Name</th>
         <th>CreatedAt</th>
-        <th>Users</th>
         <th>DenyUIFeatures</th>
         <th>DenyTokenAuth</th>
         <th>FeatureFlags</th>
@@ -21,7 +20,6 @@
         <td>{{.ExternalID}}</td>
         <td>{{.Name}}</td>
         <td>{{.FormatCreatedAt}}</td>
-        <td>{{index $.OrganizationUsers .ExternalID}}</td>
         <td>
           <form action="organizations/{{.ExternalID}}" method="POST">
             <input type="hidden" name="csrf_token" value="$__CSRF_TOKEN_PLACEHOLDER__">


### PR DESCRIPTION
The query that counts users is run once per organisation, which is starting to cause scaling issues in production.

Fixes #1253.