### PR TITLE
Respect the flux-v6 argument

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -212,7 +212,7 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 			Prefix{"/report", c.collectionHost},
 			Prefix{"/prom/push", c.promDistributorHost},
 			Prefix{"/net/peer", c.peerDiscoveryHost},
-			PrefixMethods{"/flux/v6", []string{"POST", "PATCH"}, c.fluxHost}, // NB uses same as below until we have config in place
+			PrefixMethods{"/flux/v6", []string{"POST", "PATCH"}, c.fluxV6Host}, // NB uses same as below until we have config in place
 			PrefixMethods{"/flux", []string{"POST", "PATCH"}, c.fluxHost},
 			PrefixMethods{"/prom/alertmanager/alerts", []string{"POST"}, c.promAlertmanagerHost},
 			PrefixMethods{"/prom/alertmanager/v1/alerts", []string{"POST"}, c.promAlertmanagerHost},
@@ -231,7 +231,7 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 		Matchables([]Prefix{
 			{"/control", c.controlHost},
 			{"/pipe", c.pipeHost},
-			{"/flux/v6", c.fluxHost}, // NB uses same as below until we have config in place
+			{"/flux/v6", c.fluxV6Host}, // NB uses same as below until we have config in place
 			{"/flux", c.fluxHost},
 			{"/prom/alertmanager", c.promAlertmanagerHost},
 			{"/prom/configs", c.configsHost},
@@ -272,7 +272,7 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 				{"/api/flux/v5/integrations/github",
 					fluxGHTokenMiddleware.Wrap(c.fluxHost)},
 				// While we transition to newer Flux API
-				{"/api/flux/v6", c.fluxHost}, // NB uses same as below until we have config in place
+				{"/api/flux/v6", c.fluxV6Host}, // NB uses same as below until we have config in place
 				{"/api/flux", c.fluxHost},
 				{"/api/prom/alertmanager", c.promAlertmanagerHost},
 				{"/api/prom/configs", c.configsHost},


### PR DESCRIPTION
This argument was introduced to route requests to the new flux service; but ignored, since that was not running in prod. Now it's running and has the right value in the authfe config, we can actually route requests to it.

In dev both `--flux` and `--flux-v6` point to the same service, which still serves the <v6 routes. It's only in prod we want to forward requests to different services.