### PR TITLE
New links on "All Users" page to access Organizations per User

### DIFF
--- a/users/api/routes.go
+++ b/users/api/routes.go
@@ -67,6 +67,7 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 		{"admin_users_users_userID_admin", "POST", "/admin/users/users/{userID}/admin", a.makeUserAdmin},
 		{"admin_users_users_userID_become", "POST", "/admin/users/users/{userID}/become", a.becomeUser},
 		{"admin_users_users_userID_logins_provider_token", "GET", "/admin/users/users/{userID}/logins/{provider}/token", a.getUserToken},
+		{"admin_users_users_userID_organizations", "GET", "/admin/users/users/{userID}/organizations", a.listOrganizationsForUser},
 	} {
 		r.Handle(route.path, route.handler).Methods(route.method).Name(route.name)
 	}

--- a/users/templates/list_organizations.html
+++ b/users/templates/list_organizations.html
@@ -1,11 +1,19 @@
 <!doctype html>
 <html>
+  {{with .}}
   <head>
-    <title>Weave Cloud - Organizations</title>
+    {{if .UserEmail}}
+    <title>Weave Cloud - Organizations for {{.UserEmail}}</title>
+    {{else}}
+    <title>Weave Cloud - All Organizations</title>
+    {{end}}
   </head>
   <body>
-    <h2>Organizations</h2>
-    {{with .}}
+    {{if .UserEmail}}
+    <h2>Organizations for User {{.UserEmail}}</h2>
+    {{else}}
+    <h2>All Organizations</h2>
+    {{end}}
     <table>
       <tr>
         <th>ID</th>

--- a/users/templates/list_users.html
+++ b/users/templates/list_users.html
@@ -41,6 +41,9 @@
             <input type="submit" value="Become User" />
           </form>
         </td>
+        <td>
+          <a href="users/{{.ID}}/organizations">Organizations</a>
+        </td>
       </tr>
       {{end}}
     </table>


### PR DESCRIPTION
Clicking new link for user of interest invokes 'Organisations for User x@y'
page which has same features as 'All Organisations' page

To resolve #1193 Link user in '/admin/users/private/api/users' to a list of organisations