### PR TITLE
Change URL for git ls-remote

### DIFF
--- a/service-ui-kicker/main.go
+++ b/service-ui-kicker/main.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	secretEnv = "WEBHOOK_SECRET"
-	scopeRepo = "git@github.com:weaveworks/scope.git"
+	scopeRepo = "https://github.com/weaveworks/scope.git"
 )
 
 var path = flag.String("path", "/webhooks", "webhook path for payload URL")


### PR DESCRIPTION
Use HTTPS instead of SSH because of error:
Failed to add the host to the list of known hosts (/root/.ssh/known_hosts).