### PR TITLE
Update kicker to work with nodejs 8.4

### DIFF
--- a/service-ui-kicker/Dockerfile
+++ b/service-ui-kicker/Dockerfile
@@ -1,7 +1,6 @@
-FROM alpine:3.6
+FROM mhart/alpine-node:8.4
 MAINTAINER Weaveworks Inc <help@weave.works>
-RUN apk add --no-cache nodejs-npm git openssh
-RUN npm install -g yarn
+RUN apk add --no-cache git openssh
 RUN git config --global user.email "team+gitbot@weave.works"
 ENV GIT_SSH_COMMAND "ssh -oStrictHostKeyChecking=no"
 WORKDIR /

--- a/service-ui-kicker/committer/committer.go
+++ b/service-ui-kicker/committer/committer.go
@@ -23,7 +23,7 @@ const (
 func yarnUpdateScopeVersion(version string, path string) error {
 	weaveScopePackage := fmt.Sprintf("weave-scope@https://s3.amazonaws.com/weaveworks-js-modules/weave-scope/%s/weave-scope.tgz", version)
 
-	cmd := exec.Command("yarn", "add", weaveScopePackage)
+	cmd := exec.Command("yarn", "add", "--ignore-engines", weaveScopePackage)
 	cmd.Dir = path
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
 - Change docker image to mhart/alpine-node that ships with nodejs 8.4 && yarn
 - use `yarn add --ignore-engines` to ignore engines check, otherwise there is the error:
`error /service-ui/client/node_modules/weave-scope/node_modules/node-sass: Command failed.`