### PR TITLE
Use official Node.js docker image for service-ui-kicker

### DIFF
--- a/service-ui-kicker/Dockerfile
+++ b/service-ui-kicker/Dockerfile
@@ -1,6 +1,6 @@
-FROM mhart/alpine-node:8.4
+FROM node:8.4.0-alpine
 MAINTAINER Weaveworks Inc <help@weave.works>
-RUN apk add --no-cache git openssh
+RUN apk add --no-cache python make gcc g++ git openssh
 RUN git config --global user.email "team+gitbot@weave.works"
 ENV GIT_SSH_COMMAND "ssh -oStrictHostKeyChecking=no"
 WORKDIR /


### PR DESCRIPTION
Fixes https://github.com/weaveworks/service-ui/issues/973

Caused by https://github.com/weaveworks/service/pull/1321

The `node-sass` package is a Node.js "addon" which means it is a binary that needs to be downloaded or compiled when installed. For popular linux distros (ubuntu), there are pre-built binaries that will be downloaded by the package manager. For less popular distros (alpine), the package must be compiled on the machine in which it is being installed.

This adds a bunch of installation dependencies, such as python2, make, gcc, which were not installed on the `alpine` docker image. Using the official `node` docker image should solve the problem and keep the build environment consistent with `service-ui`.

The `node` image also has `git` and `openssh` built in.