### PR TITLE
authfe: Add routes for notifications config manager, rename cortex config manager cli arg

### DIFF
--- a/authfe/config.go
+++ b/authfe/config.go
@@ -29,20 +29,21 @@ type Config struct {
 	targetOrigin  string
 
 	// User-visible services - keep alphabetically sorted pls
-	billingAPIHost      proxyConfig
-	billingUIHost       proxyConfig
-	collectionHost      proxyConfig
-	configsHost         proxyConfig
-	controlHost         proxyConfig
-	demoHost            proxyConfig
-	fluxHost            proxyConfig
-	fluxV6Host          proxyConfig
-	launchGeneratorHost proxyConfig
-	peerDiscoveryHost   proxyConfig
-	pipeHost            proxyConfig
-	queryHost           proxyConfig
-	uiMetricsHost       proxyConfig
-	uiServerHost        proxyConfig
+	billingAPIHost         proxyConfig
+	billingUIHost          proxyConfig
+	collectionHost         proxyConfig
+	controlHost            proxyConfig
+	demoHost               proxyConfig
+	fluxHost               proxyConfig
+	fluxV6Host             proxyConfig
+	launchGeneratorHost    proxyConfig
+	notificationConfigHost proxyConfig
+	peerDiscoveryHost      proxyConfig
+	pipeHost               proxyConfig
+	promConfigsHost        proxyConfig
+	queryHost              proxyConfig
+	uiMetricsHost          proxyConfig
+	uiServerHost           proxyConfig
 
 	// Admin services - keep alphabetically sorted pls
 	alertmanagerHost      proxyConfig
@@ -71,24 +72,25 @@ type Config struct {
 func (c *Config) proxies() map[string]*proxyConfig {
 	return map[string]*proxyConfig{
 		// User-visible services - keep alphabetically sorted pls.
-		"billing-api":       &c.billingAPIHost,
-		"billing-ui":        &c.billingUIHost,
-		"collection":        &c.collectionHost,
-		"configs":           &c.configsHost,
-		"control":           &c.controlHost,
-		"demo":              &c.demoHost,
-		"flux":              &c.fluxHost,
-		"flux-v6":           &c.fluxV6Host,
-		"launch-generator":  &c.launchGeneratorHost,
-		"notebooks":         &c.notebooksHost,
-		"peer-discovery":    &c.peerDiscoveryHost,
-		"pipe":              &c.pipeHost,
-		"prom-alertmanager": &c.promAlertmanagerHost,
-		"prom-distributor":  &c.promDistributorHost,
-		"prom-querier":      &c.promQuerierHost,
-		"query":             &c.queryHost,
-		"ui-metrics":        &c.uiMetricsHost,
-		"ui-server":         &c.uiServerHost,
+		"billing-api":          &c.billingAPIHost,
+		"billing-ui":           &c.billingUIHost,
+		"collection":           &c.collectionHost,
+		"control":              &c.controlHost,
+		"demo":                 &c.demoHost,
+		"flux":                 &c.fluxHost,
+		"flux-v6":              &c.fluxV6Host,
+		"launch-generator":     &c.launchGeneratorHost,
+		"notebooks":            &c.notebooksHost,
+		"notification-configs": &c.notificationConfigHost,
+		"peer-discovery":       &c.peerDiscoveryHost,
+		"pipe":                 &c.pipeHost,
+		"prom-alertmanager":    &c.promAlertmanagerHost,
+		"prom-configs":         &c.promConfigsHost,
+		"prom-distributor":     &c.promDistributorHost,
+		"prom-querier":         &c.promQuerierHost,
+		"query":                &c.queryHost,
+		"ui-metrics":           &c.uiMetricsHost,
+		"ui-server":            &c.uiServerHost,
 
 		// Admin services - keep alphabetically sorted pls.
 		"alertmanager":       &c.alertmanagerHost,
@@ -108,6 +110,10 @@ func (c *Config) proxies() map[string]*proxyConfig {
 		"service-ui-kicker":  &c.serviceUIKickerHost,
 		"terradiff":          &c.terradiffHost,
 		"users":              &c.usersHost,
+
+		// For backwards compatibility - remove this once command line flags are updated.
+		// Giving the same pointer to flag twice will make them aliases of each other.
+		"configs": &c.promConfigsHost,
 	}
 }
 

--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -234,7 +234,7 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 			{"/flux/{flux_vsn:v[345]}", c.fluxHost},
 			{"/flux", c.fluxV6Host},
 			{"/prom/alertmanager", c.promAlertmanagerHost},
-			{"/prom/configs", c.configsHost},
+			{"/prom/configs", c.promConfigsHost},
 			{"/prom", c.promQuerierHost},
 		}),
 		middleware.Merge(
@@ -263,36 +263,38 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 		// For all ui <-> app communication, authenticated using cookie credentials
 		MiddlewarePrefix{
 			"/api/app/{orgExternalID}",
-			Matchables([]Prefix{
-				{"/api/report", c.queryHost},
-				{"/api/topology", c.queryHost},
-				{"/api/control", c.controlHost},
-				{"/api/pipe", c.pipeHost},
+			[]PrefixRoutable{
+				Prefix{"/api/report", c.queryHost},
+				Prefix{"/api/topology", c.queryHost},
+				Prefix{"/api/control", c.controlHost},
+				Prefix{"/api/pipe", c.pipeHost},
 				// API to insert deploy key requires GH token. Insert token with middleware.
-				{"/api/flux/v5/integrations/github",
+				Prefix{"/api/flux/v5/integrations/github",
 					fluxGHTokenMiddleware.Wrap(c.fluxHost)},
-				{"/api/flux/{flux_vsn}/integrations/github",
+				Prefix{"/api/flux/{flux_vsn}/integrations/github",
 					fluxGHTokenMiddleware.Wrap(c.fluxV6Host)},
 				// While we transition to newer Flux API
-				{"/api/flux/{flux_vsn:v[345]}", c.fluxHost},
-				{"/api/flux", c.fluxV6Host},
-				{"/api/prom/alertmanager", c.promAlertmanagerHost},
-				{"/api/prom/configs", c.configsHost},
-				{"/api/prom/notebooks", c.notebooksHost},
-				{"/api/prom", c.promQuerierHost},
-				{"/api/net/peer", c.peerDiscoveryHost},
-				{"/api", c.queryHost},
+				Prefix{"/api/flux/{flux_vsn:v[345]}", c.fluxHost},
+				Prefix{"/api/flux", c.fluxV6Host},
+				Prefix{"/api/prom/alertmanager", c.promAlertmanagerHost},
+				Prefix{"/api/prom/configs", c.promConfigsHost},
+				Prefix{"/api/prom/notebooks", c.notebooksHost},
+				Prefix{"/api/prom", c.promQuerierHost},
+				Prefix{"/api/net/peer", c.peerDiscoveryHost},
+				Prefix{"/api/notification/config", c.notificationConfigHost},
+				PrefixMethods{"/api/notification/events", []string{"GET"}, c.notificationConfigHost},
+				Prefix{"/api", c.queryHost},
 
 				// Catch-all forward to query service, which is a Scope instance that we
 				// use to serve the Scope UI.  Note we forward /index.html to
 				// /ui/index.html etc, as we never want to expose the root of a services
 				// to the outside world - they can get at the debug info and metrics that
 				// way.
-				{"/", middleware.Merge(
+				Prefix{"/", middleware.Merge(
 					noCacheOnRoot,
 					middleware.PathRewrite(regexp.MustCompile("(.*)"), "/ui$1"),
 				).Wrap(c.queryHost)},
-			}),
+			},
 			middleware.Merge(
 				authUserOrgDataAccessMiddleware,
 				middleware.PathRewrite(regexp.MustCompile("^/api/app/[^/]+"), ""),


### PR DESCRIPTION
Had to rename prometheus/cortex configsHost -> promConfigsHost and 'configs' -> 'prom-configs' to remove ambiguity.

We keep the old command line flag for back-compat until we've made a change to stop using it.

Had to turn a list of Prefix into a list of PrefixRoutable in order to use a PrefixMethods
to prevent users from being able to POST to /api/notification/events