### PR TITLE
Account for flux API v7+

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -212,8 +212,8 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 			Prefix{"/report", c.collectionHost},
 			Prefix{"/prom/push", c.promDistributorHost},
 			Prefix{"/net/peer", c.peerDiscoveryHost},
-			PrefixMethods{"/flux/v6", []string{"POST", "PATCH"}, c.fluxV6Host},
-			PrefixMethods{"/flux", []string{"POST", "PATCH"}, c.fluxHost},
+			PrefixMethods{"/flux/{flux_vsn:v[345]}", []string{"POST", "PATCH"}, c.fluxHost},
+			PrefixMethods{"/flux", []string{"POST", "PATCH"}, c.fluxV6Host},
 			PrefixMethods{"/prom/alertmanager/alerts", []string{"POST"}, c.promAlertmanagerHost},
 			PrefixMethods{"/prom/alertmanager/v1/alerts", []string{"POST"}, c.promAlertmanagerHost},
 		},
@@ -231,8 +231,8 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 		Matchables([]Prefix{
 			{"/control", c.controlHost},
 			{"/pipe", c.pipeHost},
-			{"/flux/v6", c.fluxV6Host}, // NB uses same as below until we have config in place
-			{"/flux", c.fluxHost},
+			{"/flux/{flux_vsn:v[345]}", c.fluxHost},
+			{"/flux", c.fluxV6Host},
 			{"/prom/alertmanager", c.promAlertmanagerHost},
 			{"/prom/configs", c.configsHost},
 			{"/prom", c.promQuerierHost},
@@ -271,11 +271,11 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 				// API to insert deploy key requires GH token. Insert token with middleware.
 				{"/api/flux/v5/integrations/github",
 					fluxGHTokenMiddleware.Wrap(c.fluxHost)},
-				{"/api/flux/v6/integrations/github",
+				{"/api/flux/{flux_vsn}/integrations/github",
 					fluxGHTokenMiddleware.Wrap(c.fluxV6Host)},
 				// While we transition to newer Flux API
-				{"/api/flux/v6", c.fluxV6Host},
-				{"/api/flux", c.fluxHost},
+				{"/api/flux/{flux_vsn:v[345]}", c.fluxHost},
+				{"/api/flux", c.fluxV6Host},
 				{"/api/prom/alertmanager", c.promAlertmanagerHost},
 				{"/api/prom/configs", c.configsHost},
 				{"/api/prom/notebooks", c.notebooksHost},


### PR DESCRIPTION
This turns the route matching around: previously it was

 - any route with flux/v6 goes to the v6 service
 - else any route to flux/ goes to the old service

Now it has

 - any route with flux/v3, v4, or v5 goes to the old service
 - else any route with flux/ goes to the new service.

This way, v7 and upwards will be forwarded to the new service.