### PR TITLE
Rename net to discovery in service status response

### DIFF
--- a/users/api/services.go
+++ b/users/api/services.go
@@ -29,10 +29,10 @@ type getOrgServiceStatusView struct {
 	Connected            bool       `json:"connected"`
 	FirstSeenConnectedAt *time.Time `json:"firstSeenConnectedAt"`
 
-	Flux  fluxStatus  `json:"flux"`
-	Scope scopeStatus `json:"scope"`
-	Prom  promStatus  `json:"prom"`
-	Net   netStatus   `json:"net"`
+	Flux      fluxStatus  `json:"flux"`
+	Scope     scopeStatus `json:"scope"`
+	Prom      promStatus  `json:"prom"`
+	Discovery netStatus   `json:"discovery"`
 }
 
 type fluxStatus struct {
@@ -123,7 +123,7 @@ func (a *API) getOrgServiceStatus(currentUser *users.User, w http.ResponseWriter
 		Flux:                 status.flux,
 		Scope:                status.scope,
 		Prom:                 status.prom,
-		Net:                  status.net,
+		Discovery:            status.net,
 	})
 }
 

--- a/users/api/services_test.go
+++ b/users/api/services_test.go
@@ -51,7 +51,7 @@ func MockServices(config *mockServicesConfig) *httptest.Server {
 				}
 			}
 		case "/api/probes":
-			if config.Net.Online {
+			if config.Scope.Online {
 				probes := []interface{}{}
 				for i := 0; i < config.Scope.NumberOfProbes; i++ {
 					probes = append(probes, struct{}{})
@@ -131,7 +131,7 @@ func Test_GetOrgServiceStatus(t *testing.T) {
 				"numberOfMetrics": float64(0),
 				"error":           "Unexpected status code: 500",
 			},
-			"net": map[string]interface{}{
+			"discovery": map[string]interface{}{
 				"numberOfPeers": float64(0),
 				"error":         "Unexpected status code: 500",
 			},
@@ -170,7 +170,7 @@ func Test_GetOrgServiceStatus(t *testing.T) {
 			"prom": map[string]interface{}{
 				"numberOfMetrics": float64(0),
 			},
-			"net": map[string]interface{}{
+			"discovery": map[string]interface{}{
 				"numberOfPeers": float64(0),
 			},
 		}, body)
@@ -211,7 +211,7 @@ func Test_GetOrgServiceStatus(t *testing.T) {
 			"prom": map[string]interface{}{
 				"numberOfMetrics": float64(4),
 			},
-			"net": map[string]interface{}{
+			"discovery": map[string]interface{}{
 				"numberOfPeers": float64(2),
 			},
 		}, body)
@@ -251,7 +251,7 @@ func Test_GetOrgServiceStatus(t *testing.T) {
 			"prom": map[string]interface{}{
 				"numberOfMetrics": float64(0),
 			},
-			"net": map[string]interface{}{
+			"discovery": map[string]interface{}{
 				"numberOfPeers": float64(0),
 			},
 		}, body)


### PR DESCRIPTION
service-ui uses the word "discovery" for net. Update the API to return this so it's easier to lookup consistently. Still keep the term "net" internally.

```
export const SERVICES = [
  'flux',
  'scope',
  'prom',
  'discovery'
];```