### PR TITLE
Drop first_probe_udpate_at from `organizations`

### DIFF
--- a/users/db/migrations/023_drop_org_first_probe_update_at.up.sql
+++ b/users/db/migrations/023_drop_org_first_probe_update_at.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE organizations DROP COLUMN first_probe_update_at;


### PR DESCRIPTION
It's not in use anymore, closes #783