### PR TITLE
Add TrialExpiresAt field to Proto returned by users service.

### DIFF
--- a/users/grpc/lookup.go
+++ b/users/grpc/lookup.go
@@ -231,6 +231,7 @@ func (a *usersServer) GetOrganization(ctx context.Context, req *users.GetOrganiz
 			FirstSeenConnectedAt:  organization.FirstSeenConnectedAt,
 			Platform:              organization.Platform,
 			Environment:           organization.Environment,
+			TrialExpiresAt:        organization.TrialExpiresAt,
 			ZuoraAccountNumber:    organization.ZuoraAccountNumber,
 			ZuoraAccountCreatedAt: organization.ZuoraAccountCreatedAt,
 		},


### PR DESCRIPTION
Add missing `TrialExpireAt` field to return Proto object.
This most likely was an omission when this field was added in other places.

Fixes weaveworks/billing/issues/222.