### PR TITLE
Update go-github version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -131,7 +131,7 @@
 [[projects]]
   name = "github.com/google/go-github"
   packages = ["github"]
-  revision = "a68a8707f3c18a3a47bb0975ca29a9239792dc01"
+  revision = "a8b8751f9d056ab7f60ab6d9caba15db9d701b09"
 
 [[projects]]
   branch = "master"
@@ -466,6 +466,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c2277a724e6c809c5f9e4b66be61e2b5e07729de48b14db6dbb8bf496548bc55"
+  inputs-digest = "c61510252fc926af71f77f5525e5fdc2813bea082bb2ff8924c02f8553f8a38a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -7,7 +7,7 @@
 # can update.
 [[constraint]]
   name = "github.com/google/go-github"
-  revision = "a68a8707f3c18a3a47bb0975ca29a9239792dc01"
+  revision = "a8b8751f9d056ab7f60ab6d9caba15db9d701b09"
 
 # github.com/opentracing-contrib/go-stdlib doesn't support hijacking until
 # https://github.com/opentracing-contrib/go-stdlib/pull/11 is merged.

--- a/vendor/github.com/google/go-github/AUTHORS
+++ b/vendor/github.com/google/go-github/AUTHORS
@@ -2,6 +2,7 @@
 # This file is distinct from the CONTRIBUTORS files.
 # See the latter for an explanation.
 
+Ainsley Chong <ainsley.chong@gmail.com>
 Akeda Bagus <akeda@x-team.com>
 Alec Thomas <alec@swapoff.org>
 Alexander Harkness <me@bearbin.net>
@@ -30,6 +31,7 @@ erwinvaneyk <erwinvaneyk@gmail.com>
 Filippo Valsorda <hi@filippo.io>
 Francis <hello@francismakes.com>
 Fredrik Jönsson <fredrik.jonsson@izettle.com>
+Garrett Squire <garrettsquire@gmail.com>
 Georgy Buranov <gburanov@gmail.com>
 Google Inc.
 griffin_stewie <panterathefamilyguy@gmail.com>

--- a/vendor/github.com/google/go-github/CONTRIBUTORS
+++ b/vendor/github.com/google/go-github/CONTRIBUTORS
@@ -10,6 +10,7 @@
 # copyright _license_.  You retain the copyright on your
 # contributions.
 
+Ainsley Chong <ainsley.chong@gmail.com>
 Akeda Bagus <akeda@x-team.com>
 Alec Thomas <alec@swapoff.org>
 Alex Bramley <a.bramley@gmail.com>
@@ -45,6 +46,7 @@ erwinvaneyk <erwinvaneyk@gmail.com>
 Filippo Valsorda <hi@filippo.io>
 Francis <hello@francismakes.com>
 Fredrik Jönsson <fredrik.jonsson@izettle.com>
+Garrett Squire <garrettsquire@gmail.com>
 Georgy Buranov <gburanov@gmail.com>
 Glenn Lewis <gmlewis@google.com>
 griffin_stewie <panterathefamilyguy@gmail.com>
@@ -56,6 +58,7 @@ Isao Jonas <isao.jonas@gmail.com>
 Jameel Haffejee <RC1140@republiccommandos.co.za>
 Jason Hall <jasonhall@google.com>
 Jihoon Chung <j.c@navercorp.com>
+Joe Tsai <joetsai@digital-static.net>
 John Engelman <john.r.engelman@gmail.com>
 Julien Rostand <jrostand@users.noreply.github.com>
 Justin Abrahms <justin@abrah.ms>

--- a/vendor/github.com/google/go-github/github/activity_notifications.go
+++ b/vendor/github.com/google/go-github/github/activity_notifications.go
@@ -42,6 +42,8 @@ type NotificationListOptions struct {
 	Participating bool      `url:"participating,omitempty"`
 	Since         time.Time `url:"since,omitempty"`
 	Before        time.Time `url:"before,omitempty"`
+
+	ListOptions
 }
 
 // ListNotifications lists all notifications for the authenticated user.

--- a/vendor/github.com/google/go-github/github/authorizations.go
+++ b/vendor/github.com/google/go-github/github/authorizations.go
@@ -35,6 +35,9 @@ const (
 	ScopeReadPublicKey  Scope = "read:public_key"
 	ScopeWritePublicKey Scope = "write:public_key"
 	ScopeAdminPublicKey Scope = "admin:public_key"
+	ScopeReadGPGKey     Scope = "read:gpg_key"
+	ScopeWriteGPGKey    Scope = "write:gpg_key"
+	ScopeAdminGPGKey    Scope = "admin:gpg_key"
 )
 
 // AuthorizationsService handles communication with the authorization related

--- a/vendor/github.com/google/go-github/github/git_commits.go
+++ b/vendor/github.com/google/go-github/github/git_commits.go
@@ -10,16 +10,25 @@ import (
 	"time"
 )
 
+// SignatureVerification represents GPG signature verification.
+type SignatureVerification struct {
+	Verified  *bool   `json:"verified,omitempty"`
+	Reason    *string `json:"reason,omitempty"`
+	Signature *string `json:"signature,omitempty"`
+	Payload   *string `json:"payload,omitempty"`
+}
+
 // Commit represents a GitHub commit.
 type Commit struct {
-	SHA       *string       `json:"sha,omitempty"`
-	Author    *CommitAuthor `json:"author,omitempty"`
-	Committer *CommitAuthor `json:"committer,omitempty"`
-	Message   *string       `json:"message,omitempty"`
-	Tree      *Tree         `json:"tree,omitempty"`
-	Parents   []Commit      `json:"parents,omitempty"`
-	Stats     *CommitStats  `json:"stats,omitempty"`
-	URL       *string       `json:"url,omitempty"`
+	SHA          *string                `json:"sha,omitempty"`
+	Author       *CommitAuthor          `json:"author,omitempty"`
+	Committer    *CommitAuthor          `json:"committer,omitempty"`
+	Message      *string                `json:"message,omitempty"`
+	Tree         *Tree                  `json:"tree,omitempty"`
+	Parents      []Commit               `json:"parents,omitempty"`
+	Stats        *CommitStats           `json:"stats,omitempty"`
+	URL          *string                `json:"url,omitempty"`
+	Verification *SignatureVerification `json:"verification,omitempty"`
 
 	// CommentCount is the number of GitHub comments on the commit.  This
 	// is only populated for requests that fetch GitHub data like
@@ -55,6 +64,9 @@ func (s *GitService) GetCommit(owner string, repo string, sha string) (*Commit, 
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGitSigningPreview)
 
 	c := new(Commit)
 	resp, err := s.client.Do(req, c)

--- a/vendor/github.com/google/go-github/github/git_commits_test.go
+++ b/vendor/github.com/google/go-github/github/git_commits_test.go
@@ -19,6 +19,7 @@ func TestGitService_GetCommit(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/git/commits/s", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGitSigningPreview)
 		fmt.Fprint(w, `{"sha":"s","message":"m","author":{"name":"n"}}`)
 	})
 

--- a/vendor/github.com/google/go-github/github/git_tags.go
+++ b/vendor/github.com/google/go-github/github/git_tags.go
@@ -11,12 +11,13 @@ import (
 
 // Tag represents a tag object.
 type Tag struct {
-	Tag     *string       `json:"tag,omitempty"`
-	SHA     *string       `json:"sha,omitempty"`
-	URL     *string       `json:"url,omitempty"`
-	Message *string       `json:"message,omitempty"`
-	Tagger  *CommitAuthor `json:"tagger,omitempty"`
-	Object  *GitObject    `json:"object,omitempty"`
+	Tag          *string                `json:"tag,omitempty"`
+	SHA          *string                `json:"sha,omitempty"`
+	URL          *string                `json:"url,omitempty"`
+	Message      *string                `json:"message,omitempty"`
+	Tagger       *CommitAuthor          `json:"tagger,omitempty"`
+	Object       *GitObject             `json:"object,omitempty"`
+	Verification *SignatureVerification `json:"verification,omitempty"`
 }
 
 // createTagRequest represents the body of a CreateTag request.  This is mostly
@@ -39,6 +40,9 @@ func (s *GitService) GetTag(owner string, repo string, sha string) (*Tag, *Respo
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGitSigningPreview)
 
 	tag := new(Tag)
 	resp, err := s.client.Do(req, tag)

--- a/vendor/github.com/google/go-github/github/git_tags_test.go
+++ b/vendor/github.com/google/go-github/github/git_tags_test.go
@@ -19,6 +19,7 @@ func TestGitService_GetTag(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/git/tags/s", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGitSigningPreview)
 
 		fmt.Fprint(w, `{"tag": "t"}`)
 	})

--- a/vendor/github.com/google/go-github/github/github_test.go
+++ b/vendor/github.com/google/go-github/github/github_test.go
@@ -198,7 +198,7 @@ func TestNewRequest_invalidJSON(t *testing.T) {
 	c := NewClient(nil)
 
 	type T struct {
-		A map[int]interface{}
+		A map[interface{}]interface{}
 	}
 	_, err := c.NewRequest("GET", "/", &T{})
 

--- a/vendor/github.com/google/go-github/github/issues.go
+++ b/vendor/github.com/google/go-github/github/issues.go
@@ -36,6 +36,7 @@ type Issue struct {
 	Milestone        *Milestone        `json:"milestone,omitempty"`
 	PullRequestLinks *PullRequestLinks `json:"pull_request,omitempty"`
 	Repository       *Repository       `json:"repository,omitempty"`
+	Reactions        *Reactions        `json:"reactions,omitempty"`
 
 	// TextMatches is only populated from search results that request text matches
 	// See: search.go and https://developer.github.com/v3/search/#text-match-metadata
@@ -131,6 +132,9 @@ func (s *IssuesService) listIssues(u string, opt *IssueListOptions) ([]Issue, *R
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
 	issues := new([]Issue)
 	resp, err := s.client.Do(req, issues)
 	if err != nil {
@@ -195,6 +199,9 @@ func (s *IssuesService) ListByRepo(owner string, repo string, opt *IssueListByRe
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
 	issues := new([]Issue)
 	resp, err := s.client.Do(req, issues)
 	if err != nil {
@@ -213,6 +220,9 @@ func (s *IssuesService) Get(owner string, repo string, number int) (*Issue, *Res
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	issue := new(Issue)
 	resp, err := s.client.Do(req, issue)

--- a/vendor/github.com/google/go-github/github/issues_comments.go
+++ b/vendor/github.com/google/go-github/github/issues_comments.go
@@ -15,6 +15,7 @@ type IssueComment struct {
 	ID        *int       `json:"id,omitempty"`
 	Body      *string    `json:"body,omitempty"`
 	User      *User      `json:"user,omitempty"`
+	Reactions *Reactions `json:"reactions,omitempty"`
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 	URL       *string    `json:"url,omitempty"`
@@ -61,6 +62,10 @@ func (s *IssuesService) ListComments(owner string, repo string, number int, opt 
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
 	comments := new([]IssueComment)
 	resp, err := s.client.Do(req, comments)
 	if err != nil {
@@ -80,6 +85,10 @@ func (s *IssuesService) GetComment(owner string, repo string, id int) (*IssueCom
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
 	comment := new(IssueComment)
 	resp, err := s.client.Do(req, comment)
 	if err != nil {

--- a/vendor/github.com/google/go-github/github/issues_comments_test.go
+++ b/vendor/github.com/google/go-github/github/issues_comments_test.go
@@ -20,6 +20,7 @@ func TestIssuesService_ListComments_allIssues(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/issues/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		testFormValues(t, r, values{
 			"sort":      "updated",
 			"direction": "desc",
@@ -52,6 +53,7 @@ func TestIssuesService_ListComments_specificIssue(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
@@ -77,6 +79,7 @@ func TestIssuesService_GetComment(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/issues/comments/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		fmt.Fprint(w, `{"id":1}`)
 	})
 

--- a/vendor/github.com/google/go-github/github/issues_milestones.go
+++ b/vendor/github.com/google/go-github/github/issues_milestones.go
@@ -47,6 +47,8 @@ type MilestoneListOptions struct {
 	// Direction in which to sort milestones. Possible values are: asc, desc.
 	// Default is "asc".
 	Direction string `url:"direction,omitempty"`
+
+	ListOptions
 }
 
 // ListMilestones lists all milestones for a repository.

--- a/vendor/github.com/google/go-github/github/issues_milestones_test.go
+++ b/vendor/github.com/google/go-github/github/issues_milestones_test.go
@@ -23,11 +23,12 @@ func TestIssuesService_ListMilestones(t *testing.T) {
 			"state":     "closed",
 			"sort":      "due_date",
 			"direction": "asc",
+			"page":      "2",
 		})
 		fmt.Fprint(w, `[{"number":1}]`)
 	})
 
-	opt := &MilestoneListOptions{"closed", "due_date", "asc"}
+	opt := &MilestoneListOptions{"closed", "due_date", "asc", ListOptions{Page: 2}}
 	milestones, _, err := client.Issues.ListMilestones("o", "r", opt)
 	if err != nil {
 		t.Errorf("IssuesService.ListMilestones returned error: %v", err)

--- a/vendor/github.com/google/go-github/github/issues_test.go
+++ b/vendor/github.com/google/go-github/github/issues_test.go
@@ -20,6 +20,7 @@ func TestIssuesService_List_all(t *testing.T) {
 
 	mux.HandleFunc("/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		testFormValues(t, r, values{
 			"filter":    "all",
 			"state":     "closed",
@@ -56,6 +57,7 @@ func TestIssuesService_List_owned(t *testing.T) {
 
 	mux.HandleFunc("/user/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		fmt.Fprint(w, `[{"number":1}]`)
 	})
 
@@ -76,6 +78,7 @@ func TestIssuesService_ListByOrg(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		fmt.Fprint(w, `[{"number":1}]`)
 	})
 
@@ -101,6 +104,7 @@ func TestIssuesService_ListByRepo(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/issues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		testFormValues(t, r, values{
 			"milestone": "*",
 			"state":     "closed",
@@ -142,6 +146,7 @@ func TestIssuesService_Get(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/issues/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		fmt.Fprint(w, `{"number":1, "labels": [{"url": "u", "name": "n", "color": "c"}]}`)
 	})
 

--- a/vendor/github.com/google/go-github/github/messages.go
+++ b/vendor/github.com/google/go-github/github/messages.go
@@ -1,0 +1,119 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This file provides functions for validating payloads from GitHub Webhooks.
+// GitHub docs: https://developer.github.com/webhooks/securing/#validating-payloads-from-github
+
+package github
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+const (
+	// sha1Prefix is the prefix used by GitHub before the HMAC hexdigest.
+	sha1Prefix = "sha1"
+	// sha256Prefix and sha512Prefix are provided for future compatibility.
+	sha256Prefix = "sha256"
+	sha512Prefix = "sha512"
+	// signatureHeader is the GitHub header key used to pass the HMAC hexdigest.
+	signatureHeader = "X-Hub-Signature"
+)
+
+// genMAC generates the HMAC signature for a message provided the secret key
+// and hashFunc.
+func genMAC(message, key []byte, hashFunc func() hash.Hash) []byte {
+	mac := hmac.New(hashFunc, key)
+	mac.Write(message)
+	return mac.Sum(nil)
+}
+
+// checkMAC reports whether messageMAC is a valid HMAC tag for message.
+func checkMAC(message, messageMAC, key []byte, hashFunc func() hash.Hash) bool {
+	expectedMAC := genMAC(message, key, hashFunc)
+	return hmac.Equal(messageMAC, expectedMAC)
+}
+
+// messageMAC returns the hex-decoded HMAC tag from the signature and its
+// corresponding hash function.
+func messageMAC(signature string) ([]byte, func() hash.Hash, error) {
+	if signature == "" {
+		return nil, nil, errors.New("missing signature")
+	}
+	sigParts := strings.SplitN(signature, "=", 2)
+	if len(sigParts) != 2 {
+		return nil, nil, fmt.Errorf("error parsing signature %q", signature)
+	}
+
+	var hashFunc func() hash.Hash
+	switch sigParts[0] {
+	case sha1Prefix:
+		hashFunc = sha1.New
+	case sha256Prefix:
+		hashFunc = sha256.New
+	case sha512Prefix:
+		hashFunc = sha512.New
+	default:
+		return nil, nil, fmt.Errorf("unknown hash type prefix: %q", sigParts[0])
+	}
+
+	buf, err := hex.DecodeString(sigParts[1])
+	if err != nil {
+		return nil, nil, fmt.Errorf("error decoding signature %q: %v", signature, err)
+	}
+	return buf, hashFunc, nil
+}
+
+// ValidatePayload validates an incoming GitHub Webhook event request
+// and returns the (JSON) payload.
+// secretKey is the GitHub Webhook secret message.
+//
+// Example usage:
+//
+//     func (s *GitHubEventMonitor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+//       payload, err := github.ValidatePayload(r, s.webhookSecretKey)
+//       if err != nil { ... }
+//       // Process payload...
+//     }
+//
+func ValidatePayload(r *http.Request, secretKey []byte) (payload []byte, err error) {
+	payload, err = ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	sig := r.Header.Get(signatureHeader)
+	if err := validateSignature(sig, payload, secretKey); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+// validateSignature validates the signature for the given payload.
+// signature is the GitHub hash signature delivered in the X-Hub-Signature header.
+// payload is the JSON payload sent by GitHub Webhooks.
+// secretKey is the GitHub Webhook secret message.
+//
+// GitHub docs: https://developer.github.com/webhooks/securing/#validating-payloads-from-github
+func validateSignature(signature string, payload, secretKey []byte) error {
+	messageMAC, hashFunc, err := messageMAC(signature)
+	if err != nil {
+		return err
+	}
+	if !checkMAC(payload, messageMAC, secretKey, hashFunc) {
+		return errors.New("payload signature check failed")
+	}
+	return nil
+}

--- a/vendor/github.com/google/go-github/github/messages_test.go
+++ b/vendor/github.com/google/go-github/github/messages_test.go
@@ -1,0 +1,81 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+)
+
+func TestValidatePayload(t *testing.T) {
+	const defaultBody = `{"yo":true}` // All tests below use the default request body and signature.
+	const defaultSignature = "sha1=126f2c800419c60137ce748d7672e77b65cf16d6"
+	secretKey := []byte("0123456789abcdef")
+	tests := []struct {
+		signature   string
+		eventID     string
+		event       string
+		wantEventID string
+		wantEvent   string
+		wantPayload string
+	}{
+		// The following tests generate expected errors:
+		{},                         // Missing signature
+		{signature: "yo"},          // Missing signature prefix
+		{signature: "sha1=yo"},     // Signature not hex string
+		{signature: "sha1=012345"}, // Invalid signature
+		// The following tests expect err=nil:
+		{
+			signature:   defaultSignature,
+			eventID:     "dead-beef",
+			event:       "ping",
+			wantEventID: "dead-beef",
+			wantEvent:   "ping",
+			wantPayload: defaultBody,
+		},
+		{
+			signature:   defaultSignature,
+			event:       "ping",
+			wantEvent:   "ping",
+			wantPayload: defaultBody,
+		},
+		{
+			signature:   "sha256=b1f8020f5b4cd42042f807dd939015c4a418bc1ff7f604dd55b0a19b5d953d9b",
+			event:       "ping",
+			wantEvent:   "ping",
+			wantPayload: defaultBody,
+		},
+		{
+			signature:   "sha512=8456767023c1195682e182a23b3f5d19150ecea598fde8cb85918f7281b16079471b1329f92b912c4d8bd7455cb159777db8f29608b20c7c87323ba65ae62e1f",
+			event:       "ping",
+			wantEvent:   "ping",
+			wantPayload: defaultBody,
+		},
+	}
+
+	for _, test := range tests {
+		buf := bytes.NewBufferString(defaultBody)
+		req, err := http.NewRequest("GET", "http://localhost/event", buf)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		if test.signature != "" {
+			req.Header.Set(signatureHeader, test.signature)
+		}
+
+		got, err := ValidatePayload(req, secretKey)
+		if err != nil {
+			if test.wantPayload != "" {
+				t.Errorf("ValidatePayload(%#v): err = %v, want nil", test, err)
+			}
+			continue
+		}
+		if string(got) != test.wantPayload {
+			t.Errorf("ValidatePayload = %q, want %q", got, test.wantPayload)
+		}
+	}
+}

--- a/vendor/github.com/google/go-github/github/orgs.go
+++ b/vendor/github.com/google/go-github/github/orgs.go
@@ -73,6 +73,8 @@ func (p Plan) String() string {
 type OrganizationsListOptions struct {
 	// Since filters Organizations by ID.
 	Since int `url:"since,omitempty"`
+
+	ListOptions
 }
 
 // ListAll lists all organizations, in the order that they were created on GitHub.

--- a/vendor/github.com/google/go-github/github/orgs_members.go
+++ b/vendor/github.com/google/go-github/github/orgs_members.go
@@ -86,10 +86,6 @@ func (s *OrganizationsService) ListMembers(org string, opt *ListMembersOptions) 
 		return nil, nil, err
 	}
 
-	if opt != nil && opt.Role != "" {
-		req.Header.Set("Accept", mediaTypeOrgPermissionPreview)
-	}
-
 	members := new([]User)
 	resp, err := s.client.Do(req, members)
 	if err != nil {

--- a/vendor/github.com/google/go-github/github/orgs_members_test.go
+++ b/vendor/github.com/google/go-github/github/orgs_members_test.go
@@ -19,7 +19,6 @@ func TestOrganizationsService_ListMembers(t *testing.T) {
 
 	mux.HandleFunc("/orgs/o/members", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeOrgPermissionPreview)
 		testFormValues(t, r, values{
 			"filter": "2fa_disabled",
 			"role":   "admin",

--- a/vendor/github.com/google/go-github/github/orgs_teams.go
+++ b/vendor/github.com/google/go-github/github/orgs_teams.go
@@ -94,10 +94,6 @@ func (s *OrganizationsService) CreateTeam(org string, team *Team) (*Team, *Respo
 		return nil, nil, err
 	}
 
-	if team.Privacy != nil {
-		req.Header.Set("Accept", mediaTypeOrgPermissionPreview)
-	}
-
 	t := new(Team)
 	resp, err := s.client.Do(req, t)
 	if err != nil {
@@ -115,10 +111,6 @@ func (s *OrganizationsService) EditTeam(id int, team *Team) (*Team, *Response, e
 	req, err := s.client.NewRequest("PATCH", u, team)
 	if err != nil {
 		return nil, nil, err
-	}
-
-	if team.Privacy != nil {
-		req.Header.Set("Accept", mediaTypeOrgPermissionPreview)
 	}
 
 	t := new(Team)
@@ -167,10 +159,6 @@ func (s *OrganizationsService) ListTeamMembers(team int, opt *OrganizationListTe
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, nil, err
-	}
-
-	if opt != nil && opt.Role != "" {
-		req.Header.Set("Accept", mediaTypeOrgPermissionPreview)
 	}
 
 	members := new([]User)
@@ -225,7 +213,7 @@ func (s *OrganizationsService) ListTeamRepos(team int, opt *ListOptions) ([]Repo
 // repository is managed by team, a Repository is returned which includes the
 // permissions team has for that repo.
 //
-// GitHub API docs: http://developer.github.com/v3/orgs/teams/#get-team-repo
+// GitHub API docs: https://developer.github.com/v3/orgs/teams/#check-if-a-team-manages-a-repository
 func (s *OrganizationsService) IsTeamRepo(team int, owner string, repo string) (*Repository, *Response, error) {
 	u := fmt.Sprintf("teams/%v/repos/%v/%v", team, owner, repo)
 	req, err := s.client.NewRequest("GET", u, nil)
@@ -233,7 +221,7 @@ func (s *OrganizationsService) IsTeamRepo(team int, owner string, repo string) (
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeOrgPermissionRepoPreview)
+	req.Header.Set("Accept", mediaTypeOrgPermissionRepo)
 
 	repository := new(Repository)
 	resp, err := s.client.Do(req, repository)
@@ -267,10 +255,6 @@ func (s *OrganizationsService) AddTeamRepo(team int, owner string, repo string, 
 	req, err := s.client.NewRequest("PUT", u, opt)
 	if err != nil {
 		return nil, err
-	}
-
-	if opt != nil {
-		req.Header.Set("Accept", mediaTypeOrgPermissionPreview)
 	}
 
 	return s.client.Do(req, nil)
@@ -370,10 +354,6 @@ func (s *OrganizationsService) AddTeamMembership(team int, user string, opt *Org
 	req, err := s.client.NewRequest("PUT", u, opt)
 	if err != nil {
 		return nil, nil, err
-	}
-
-	if opt != nil {
-		req.Header.Set("Accept", mediaTypeOrgPermissionPreview)
 	}
 
 	t := new(Membership)

--- a/vendor/github.com/google/go-github/github/orgs_teams_test.go
+++ b/vendor/github.com/google/go-github/github/orgs_teams_test.go
@@ -71,7 +71,6 @@ func TestOrganizationsService_CreateTeam(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", mediaTypeOrgPermissionPreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -106,7 +105,6 @@ func TestOrganizationsService_EditTeam(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PATCH")
-		testHeader(t, r, "Accept", mediaTypeOrgPermissionPreview)
 		if !reflect.DeepEqual(v, input) {
 			t.Errorf("Request body = %+v, want %+v", v, input)
 		}
@@ -145,7 +143,6 @@ func TestOrganizationsService_ListTeamMembers(t *testing.T) {
 
 	mux.HandleFunc("/teams/1/members", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeOrgPermissionPreview)
 		testFormValues(t, r, values{"role": "member", "page": "2"})
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
@@ -291,7 +288,7 @@ func TestOrganizationsService_IsTeamRepo_true(t *testing.T) {
 
 	mux.HandleFunc("/teams/1/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeOrgPermissionRepoPreview)
+		testHeader(t, r, "Accept", mediaTypeOrgPermissionRepo)
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -364,7 +361,6 @@ func TestOrganizationsService_AddTeamRepo(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", mediaTypeOrgPermissionPreview)
 		if !reflect.DeepEqual(v, opt) {
 			t.Errorf("Request body = %+v, want %+v", v, opt)
 		}
@@ -449,7 +445,6 @@ func TestOrganizationsService_AddTeamMembership(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", mediaTypeOrgPermissionPreview)
 		if !reflect.DeepEqual(v, opt) {
 			t.Errorf("Request body = %+v, want %+v", v, opt)
 		}

--- a/vendor/github.com/google/go-github/github/pulls_comments.go
+++ b/vendor/github.com/google/go-github/github/pulls_comments.go
@@ -22,6 +22,7 @@ type PullRequestComment struct {
 	CommitID         *string    `json:"commit_id,omitempty"`
 	OriginalCommitID *string    `json:"original_commit_id,omitempty"`
 	User             *User      `json:"user,omitempty"`
+	Reactions        *Reactions `json:"reactions,omitempty"`
 	CreatedAt        *time.Time `json:"created_at,omitempty"`
 	UpdatedAt        *time.Time `json:"updated_at,omitempty"`
 	URL              *string    `json:"url,omitempty"`
@@ -70,6 +71,9 @@ func (s *PullRequestsService) ListComments(owner string, repo string, number int
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
 	comments := new([]PullRequestComment)
 	resp, err := s.client.Do(req, comments)
 	if err != nil {
@@ -88,6 +92,9 @@ func (s *PullRequestsService) GetComment(owner string, repo string, number int) 
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	comment := new(PullRequestComment)
 	resp, err := s.client.Do(req, comment)

--- a/vendor/github.com/google/go-github/github/pulls_comments_test.go
+++ b/vendor/github.com/google/go-github/github/pulls_comments_test.go
@@ -20,6 +20,7 @@ func TestPullRequestsService_ListComments_allPulls(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/pulls/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		testFormValues(t, r, values{
 			"sort":      "updated",
 			"direction": "desc",
@@ -53,6 +54,7 @@ func TestPullRequestsService_ListComments_specificPull(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/pulls/1/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		fmt.Fprint(w, `[{"id":1}]`)
 	})
 
@@ -79,6 +81,7 @@ func TestPullRequestsService_GetComment(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/pulls/comments/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		fmt.Fprint(w, `{"id":1}`)
 	})
 

--- a/vendor/github.com/google/go-github/github/pulls_test.go
+++ b/vendor/github.com/google/go-github/github/pulls_test.go
@@ -341,6 +341,7 @@ func TestPullRequestsService_Merge(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/pulls/1/merge", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
+		testHeader(t, r, "Accept", mediaTypeSquashPreview)
 		fmt.Fprint(w, `
 			{
 			  "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
@@ -349,7 +350,8 @@ func TestPullRequestsService_Merge(t *testing.T) {
 			}`)
 	})
 
-	merge, _, err := client.PullRequests.Merge("o", "r", 1, "merging pull request")
+	options := &PullRequestOptions{Squash: true}
+	merge, _, err := client.PullRequests.Merge("o", "r", 1, "merging pull request", options)
 	if err != nil {
 		t.Errorf("PullRequests.Merge returned error: %v", err)
 	}

--- a/vendor/github.com/google/go-github/github/reactions.go
+++ b/vendor/github.com/google/go-github/github/reactions.go
@@ -1,0 +1,272 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import "fmt"
+
+// ReactionsService provides access to the reactions-related functions in the
+// GitHub API.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/
+type ReactionsService struct {
+	client *Client
+}
+
+// Reaction represents a GitHub reaction.
+type Reaction struct {
+	// ID is the Reaction ID.
+	ID   *int  `json:"id,omitempty"`
+	User *User `json:"user,omitempty"`
+	// Content is the type of reaction.
+	// Possible values are:
+	//     "+1", "-1", "laugh", "confused", "heart", "hooray".
+	Content *string `json:"content,omitempty"`
+}
+
+// Reactions represents a summary of GitHub reactions.
+type Reactions struct {
+	TotalCount *int    `json:"total_count,omitempty"`
+	PlusOne    *int    `json:"+1,omitempty"`
+	MinusOne   *int    `json:"-1,omitempty"`
+	Laugh      *int    `json:"laugh,omitempty"`
+	Confused   *int    `json:"confused,omitempty"`
+	Heart      *int    `json:"heart,omitempty"`
+	Hooray     *int    `json:"hooray,omitempty"`
+	URL        *string `json:"url,omitempty"`
+}
+
+func (r Reaction) String() string {
+	return Stringify(r)
+}
+
+// ListCommentReactions lists the reactions for a commit comment.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment
+func (s *ReactionsService) ListCommentReactions(owner, repo string, id int, opt *ListOptions) ([]*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/comments/%v/reactions", owner, repo, id)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	var m []*Reaction
+	resp, err := s.client.Do(req, &m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// CreateCommentReaction creates a reaction for a commit comment.
+// Note that if you have already created a reaction of type content, the
+// previously created reaction will be returned with Status: 200 OK.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#create-reaction-for-a-commit-comment
+func (s ReactionsService) CreateCommentReaction(owner, repo string, id int, content string) (*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/comments/%v/reactions", owner, repo, id)
+
+	body := &Reaction{Content: String(content)}
+	req, err := s.client.NewRequest("POST", u, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	m := &Reaction{}
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// ListIssueReactions lists the reactions for an issue.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#list-reactions-for-an-issue
+func (s *ReactionsService) ListIssueReactions(owner, repo string, number int, opt *ListOptions) ([]*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/%v/reactions", owner, repo, number)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	var m []*Reaction
+	resp, err := s.client.Do(req, &m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// CreateIssueReaction creates a reaction for an issue.
+// Note that if you have already created a reaction of type content, the
+// previously created reaction will be returned with Status: 200 OK.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#create-reaction-for-an-issue
+func (s ReactionsService) CreateIssueReaction(owner, repo string, number int, content string) (*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/%v/reactions", owner, repo, number)
+
+	body := &Reaction{Content: String(content)}
+	req, err := s.client.NewRequest("POST", u, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	m := &Reaction{}
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// ListIssueCommentReactions lists the reactions for an issue comment.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment
+func (s *ReactionsService) ListIssueCommentReactions(owner, repo string, id int, opt *ListOptions) ([]*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/comments/%v/reactions", owner, repo, id)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	var m []*Reaction
+	resp, err := s.client.Do(req, &m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// CreateIssueCommentReaction creates a reaction for an issue comment.
+// Note that if you have already created a reaction of type content, the
+// previously created reaction will be returned with Status: 200 OK.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#create-reaction-for-an-issue-comment
+func (s ReactionsService) CreateIssueCommentReaction(owner, repo string, id int, content string) (*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/issues/comments/%v/reactions", owner, repo, id)
+
+	body := &Reaction{Content: String(content)}
+	req, err := s.client.NewRequest("POST", u, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	m := &Reaction{}
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// ListPullRequestCommentReactions lists the reactions for a pull request review comment.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment
+func (s *ReactionsService) ListPullRequestCommentReactions(owner, repo string, id int, opt *ListOptions) ([]*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%v/reactions", owner, repo, id)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	var m []*Reaction
+	resp, err := s.client.Do(req, &m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// CreatePullRequestCommentReaction creates a reaction for a pull request review comment.
+// Note that if you have already created a reaction of type content, the
+// previously created reaction will be returned with Status: 200 OK.
+//
+// GitHub API docs: https://developer.github.com/v3/reactions/#create-reaction-for-an-issue-comment
+func (s ReactionsService) CreatePullRequestCommentReaction(owner, repo string, id int, content string) (*Reaction, *Response, error) {
+	u := fmt.Sprintf("repos/%v/%v/pulls/comments/%v/reactions", owner, repo, id)
+
+	body := &Reaction{Content: String(content)}
+	req, err := s.client.NewRequest("POST", u, body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	m := &Reaction{}
+	resp, err := s.client.Do(req, m)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return m, resp, nil
+}
+
+// DeleteReaction deletes a reaction.
+//
+// GitHub API docs: https://developer.github.com/v3/reaction/reactions/#delete-a-reaction-archive
+func (s *ReactionsService) DeleteReaction(id int) (*Response, error) {
+	u := fmt.Sprintf("/reactions/%v", id)
+
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
+	return s.client.Do(req, nil)
+}

--- a/vendor/github.com/google/go-github/github/reactions_test.go
+++ b/vendor/github.com/google/go-github/github/reactions_test.go
@@ -1,0 +1,200 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestReactionsService_ListCommentReactions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[{"id":1,"user":{"login":"l","id":2},"content":"+1"}]`))
+	})
+
+	got, _, err := client.Reactions.ListCommentReactions("o", "r", 1, nil)
+	if err != nil {
+		t.Errorf("ListCommentReactions returned error: %v", err)
+	}
+	if want := []*Reaction{{ID: Int(1), User: &User{Login: String("l"), ID: Int(2)}, Content: String("+1")}}; !reflect.DeepEqual(got, want) {
+		t.Errorf("ListCommentReactions = %+v, want %+v", got, want)
+	}
+}
+
+func TestReactionsService_CreateCommentReaction(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
+	})
+
+	got, _, err := client.Reactions.CreateCommentReaction("o", "r", 1, "+1")
+	if err != nil {
+		t.Errorf("CreateCommentReaction returned error: %v", err)
+	}
+	want := &Reaction{ID: Int(1), User: &User{Login: String("l"), ID: Int(2)}, Content: String("+1")}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("CreateCommentReaction = %+v, want %+v", got, want)
+	}
+}
+
+func TestReactionsService_ListIssueReactions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/issues/1/reactions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[{"id":1,"user":{"login":"l","id":2},"content":"+1"}]`))
+	})
+
+	got, _, err := client.Reactions.ListIssueReactions("o", "r", 1, nil)
+	if err != nil {
+		t.Errorf("ListIssueReactions returned error: %v", err)
+	}
+	if want := []*Reaction{{ID: Int(1), User: &User{Login: String("l"), ID: Int(2)}, Content: String("+1")}}; !reflect.DeepEqual(got, want) {
+		t.Errorf("ListIssueReactions = %+v, want %+v", got, want)
+	}
+}
+
+func TestReactionsService_CreateIssueReaction(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/issues/1/reactions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
+	})
+
+	got, _, err := client.Reactions.CreateIssueReaction("o", "r", 1, "+1")
+	if err != nil {
+		t.Errorf("CreateIssueReaction returned error: %v", err)
+	}
+	want := &Reaction{ID: Int(1), User: &User{Login: String("l"), ID: Int(2)}, Content: String("+1")}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("CreateIssueReaction = %+v, want %+v", got, want)
+	}
+}
+
+func TestReactionsService_ListIssueCommentReactions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/issues/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[{"id":1,"user":{"login":"l","id":2},"content":"+1"}]`))
+	})
+
+	got, _, err := client.Reactions.ListIssueCommentReactions("o", "r", 1, nil)
+	if err != nil {
+		t.Errorf("ListIssueCommentReactions returned error: %v", err)
+	}
+	if want := []*Reaction{{ID: Int(1), User: &User{Login: String("l"), ID: Int(2)}, Content: String("+1")}}; !reflect.DeepEqual(got, want) {
+		t.Errorf("ListIssueCommentReactions = %+v, want %+v", got, want)
+	}
+}
+
+func TestReactionsService_CreateIssueCommentReaction(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/issues/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
+	})
+
+	got, _, err := client.Reactions.CreateIssueCommentReaction("o", "r", 1, "+1")
+	if err != nil {
+		t.Errorf("CreateIssueCommentReaction returned error: %v", err)
+	}
+	want := &Reaction{ID: Int(1), User: &User{Login: String("l"), ID: Int(2)}, Content: String("+1")}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("CreateIssueCommentReaction = %+v, want %+v", got, want)
+	}
+}
+
+func TestReactionsService_ListPullRequestCommentReactions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/pulls/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[{"id":1,"user":{"login":"l","id":2},"content":"+1"}]`))
+	})
+
+	got, _, err := client.Reactions.ListPullRequestCommentReactions("o", "r", 1, nil)
+	if err != nil {
+		t.Errorf("ListPullRequestCommentReactions returned error: %v", err)
+	}
+	if want := []*Reaction{{ID: Int(1), User: &User{Login: String("l"), ID: Int(2)}, Content: String("+1")}}; !reflect.DeepEqual(got, want) {
+		t.Errorf("ListPullRequestCommentReactions = %+v, want %+v", got, want)
+	}
+}
+
+func TestReactionsService_CreatePullRequestCommentReaction(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/repos/o/r/pulls/comments/1/reactions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"id":1,"user":{"login":"l","id":2},"content":"+1"}`))
+	})
+
+	got, _, err := client.Reactions.CreatePullRequestCommentReaction("o", "r", 1, "+1")
+	if err != nil {
+		t.Errorf("CreatePullRequestCommentReaction returned error: %v", err)
+	}
+	want := &Reaction{ID: Int(1), User: &User{Login: String("l"), ID: Int(2)}, Content: String("+1")}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("CreatePullRequestCommentReaction = %+v, want %+v", got, want)
+	}
+}
+
+func TestReactionsService_DeleteReaction(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/reactions/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if _, err := client.Reactions.DeleteReaction(1); err != nil {
+		t.Errorf("DeleteReaction returned error: %v", err)
+	}
+}

--- a/vendor/github.com/google/go-github/github/repos_collaborators.go
+++ b/vendor/github.com/google/go-github/github/repos_collaborators.go
@@ -22,8 +22,6 @@ func (s *RepositoriesService) ListCollaborators(owner, repo string, opt *ListOpt
 		return nil, nil, err
 	}
 
-	req.Header.Set("Accept", mediaTypeOrgPermissionPreview)
-
 	users := new([]User)
 	resp, err := s.client.Do(req, users)
 	if err != nil {
@@ -72,10 +70,6 @@ func (s *RepositoriesService) AddCollaborator(owner, repo, user string, opt *Rep
 	req, err := s.client.NewRequest("PUT", u, opt)
 	if err != nil {
 		return nil, err
-	}
-
-	if opt != nil {
-		req.Header.Set("Accept", mediaTypeOrgPermissionPreview)
 	}
 
 	return s.client.Do(req, nil)

--- a/vendor/github.com/google/go-github/github/repos_collaborators_test.go
+++ b/vendor/github.com/google/go-github/github/repos_collaborators_test.go
@@ -19,7 +19,6 @@ func TestRepositoriesService_ListCollaborators(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/collaborators", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", mediaTypeOrgPermissionPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprintf(w, `[{"id":1}, {"id":2}]`)
 	})
@@ -95,7 +94,6 @@ func TestRepositoriesService_AddCollaborator(t *testing.T) {
 		json.NewDecoder(r.Body).Decode(v)
 
 		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", mediaTypeOrgPermissionPreview)
 		if !reflect.DeepEqual(v, opt) {
 			t.Errorf("Request body = %+v, want %+v", v, opt)
 		}

--- a/vendor/github.com/google/go-github/github/repos_comments.go
+++ b/vendor/github.com/google/go-github/github/repos_comments.go
@@ -17,6 +17,7 @@ type RepositoryComment struct {
 	ID        *int       `json:"id,omitempty"`
 	CommitID  *string    `json:"commit_id,omitempty"`
 	User      *User      `json:"user,omitempty"`
+	Reactions *Reactions `json:"reactions,omitempty"`
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
@@ -46,6 +47,9 @@ func (s *RepositoriesService) ListComments(owner, repo string, opt *ListOptions)
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
+
 	comments := new([]RepositoryComment)
 	resp, err := s.client.Do(req, comments)
 	if err != nil {
@@ -69,6 +73,9 @@ func (s *RepositoriesService) ListCommitComments(owner, repo, sha string, opt *L
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	comments := new([]RepositoryComment)
 	resp, err := s.client.Do(req, comments)
@@ -108,6 +115,9 @@ func (s *RepositoriesService) GetComment(owner, repo string, id int) (*Repositor
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeReactionsPreview)
 
 	c := new(RepositoryComment)
 	resp, err := s.client.Do(req, c)

--- a/vendor/github.com/google/go-github/github/repos_comments_test.go
+++ b/vendor/github.com/google/go-github/github/repos_comments_test.go
@@ -19,6 +19,7 @@ func TestRepositoriesService_ListComments(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}, {"id":2}]`)
 	})
@@ -46,6 +47,7 @@ func TestRepositoriesService_ListCommitComments(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/commits/s/comments", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		testFormValues(t, r, values{"page": "2"})
 		fmt.Fprint(w, `[{"id":1}, {"id":2}]`)
 	})
@@ -107,6 +109,7 @@ func TestRepositoriesService_GetComment(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/comments/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeReactionsPreview)
 		fmt.Fprint(w, `{"id":1}`)
 	})
 

--- a/vendor/github.com/google/go-github/github/repos_commits.go
+++ b/vendor/github.com/google/go-github/github/repos_commits.go
@@ -138,6 +138,9 @@ func (s *RepositoriesService) GetCommit(owner, repo, sha string) (*RepositoryCom
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGitSigningPreview)
+
 	commit := new(RepositoryCommit)
 	resp, err := s.client.Do(req, commit)
 	if err != nil {

--- a/vendor/github.com/google/go-github/github/repos_commits_test.go
+++ b/vendor/github.com/google/go-github/github/repos_commits_test.go
@@ -55,6 +55,7 @@ func TestRepositoriesService_GetCommit(t *testing.T) {
 
 	mux.HandleFunc("/repos/o/r/commits/s", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGitSigningPreview)
 		fmt.Fprintf(w, `{
 		  "sha": "s",
 		  "commit": { "message": "m" },

--- a/vendor/github.com/google/go-github/github/users.go
+++ b/vendor/github.com/google/go-github/github/users.go
@@ -138,6 +138,8 @@ func (s *UsersService) Edit(user *User) (*User, *Response, error) {
 type UserListOptions struct {
 	// ID of the last user seen
 	Since int `url:"since,omitempty"`
+
+	ListOptions
 }
 
 // ListAll lists all GitHub users.

--- a/vendor/github.com/google/go-github/github/users_gpg_keys.go
+++ b/vendor/github.com/google/go-github/github/users_gpg_keys.go
@@ -1,0 +1,129 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"fmt"
+	"time"
+)
+
+// GPGKey represents a GitHub user's public GPG key used to verify GPG signed commits and tags.
+//
+// https://developer.github.com/changes/2016-04-04-git-signing-api-preview/
+type GPGKey struct {
+	ID                *int       `json:"id,omitempty"`
+	PrimaryKeyID      *int       `json:"primary_key_id,omitempty"`
+	KeyID             *string    `json:"key_id,omitempty"`
+	PublicKey         *string    `json:"public_key,omitempty"`
+	Emails            []GPGEmail `json:"emails,omitempty"`
+	Subkeys           []GPGKey   `json:"subkeys,omitempty"`
+	CanSign           *bool      `json:"can_sign,omitempty"`
+	CanEncryptComms   *bool      `json:"can_encrypt_comms,omitempty"`
+	CanEncryptStorage *bool      `json:"can_encrypt_storage,omitempty"`
+	CanCertify        *bool      `json:"can_certify,omitempty"`
+	CreatedAt         *time.Time `json:"created_at,omitempty"`
+	ExpiresAt         *time.Time `json:"expires_at,omitempty"`
+}
+
+// String stringifies a GPGKey.
+func (k GPGKey) String() string {
+	return Stringify(k)
+}
+
+// GPGEmail represents an email address associated to a GPG key.
+type GPGEmail struct {
+	Email    *string `json:"email,omitempty"`
+	Verified *bool   `json:"verified,omitempty"`
+}
+
+// ListGPGKeys lists the current user's GPG keys. It requires authentication
+// via Basic Auth or via OAuth with at least read:gpg_key scope.
+//
+// GitHub API docs: https://developer.github.com/v3/users/gpg_keys/#list-your-gpg-keys
+func (s *UsersService) ListGPGKeys() ([]GPGKey, *Response, error) {
+	req, err := s.client.NewRequest("GET", "user/gpg_keys", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGitSigningPreview)
+
+	var keys []GPGKey
+	resp, err := s.client.Do(req, &keys)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return keys, resp, err
+}
+
+// GetGPGKey gets extended details for a single GPG key. It requires authentication
+// via Basic Auth or via OAuth with at least read:gpg_key scope.
+//
+// GitHub API docs: https://developer.github.com/v3/users/gpg_keys/#get-a-single-gpg-key
+func (s *UsersService) GetGPGKey(id int) (*GPGKey, *Response, error) {
+	u := fmt.Sprintf("user/gpg_keys/%v", id)
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGitSigningPreview)
+
+	key := &GPGKey{}
+	resp, err := s.client.Do(req, key)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return key, resp, err
+}
+
+// CreateGPGKey creates a GPG key. It requires authenticatation via Basic Auth
+// or OAuth with at least write:gpg_key scope.
+//
+// GitHub API docs: https://developer.github.com/v3/users/gpg_keys/#create-a-gpg-key
+func (s *UsersService) CreateGPGKey(armoredPublicKey string) (*GPGKey, *Response, error) {
+	gpgKey := &struct {
+		ArmoredPublicKey *string `json:"armored_public_key,omitempty"`
+	}{
+		ArmoredPublicKey: String(armoredPublicKey),
+	}
+	req, err := s.client.NewRequest("POST", "user/gpg_keys", gpgKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGitSigningPreview)
+
+	key := &GPGKey{}
+	resp, err := s.client.Do(req, key)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return key, resp, err
+}
+
+// DeleteGPGKey deletes a GPG key. It requires authentication via Basic Auth or
+// via OAuth with at least admin:gpg_key scope.
+//
+// GitHub API docs: https://developer.github.com/v3/users/gpg_keys/#delete-a-gpg-key
+func (s *UsersService) DeleteGPGKey(id int) (*Response, error) {
+	u := fmt.Sprintf("user/gpg_keys/%v", id)
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeGitSigningPreview)
+
+	return s.client.Do(req, nil)
+}

--- a/vendor/github.com/google/go-github/github/users_gpg_keys_test.go
+++ b/vendor/github.com/google/go-github/github/users_gpg_keys_test.go
@@ -1,0 +1,110 @@
+// Copyright 2016 The go-github AUTHORS. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestUsersService_ListGPGKeys(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/gpg_keys", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGitSigningPreview)
+		fmt.Fprint(w, `[{"id":1,"primary_key_id":2}]`)
+	})
+
+	keys, _, err := client.Users.ListGPGKeys()
+	if err != nil {
+		t.Errorf("Users.ListGPGKeys returned error: %v", err)
+	}
+
+	want := []GPGKey{{ID: Int(1), PrimaryKeyID: Int(2)}}
+	if !reflect.DeepEqual(keys, want) {
+		t.Errorf("Users.ListGPGKeys = %+v, want %+v", keys, want)
+	}
+}
+
+func TestUsersService_GetGPGKey(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/gpg_keys/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testHeader(t, r, "Accept", mediaTypeGitSigningPreview)
+		fmt.Fprint(w, `{"id":1}`)
+	})
+
+	key, _, err := client.Users.GetGPGKey(1)
+	if err != nil {
+		t.Errorf("Users.GetGPGKey returned error: %v", err)
+	}
+
+	want := &GPGKey{ID: Int(1)}
+	if !reflect.DeepEqual(key, want) {
+		t.Errorf("Users.GetGPGKey = %+v, want %+v", key, want)
+	}
+}
+
+func TestUsersService_CreateGPGKey(t *testing.T) {
+	setup()
+	defer teardown()
+
+	input := `
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+Comment: GPGTools - https://gpgtools.org
+
+mQINBFcEd9kBEACo54TDbGhKlXKWMvJgecEUKPPcv7XdnpKdGb3LRw5MvFwT0V0f
+...
+=tqfb
+-----END PGP PUBLIC KEY BLOCK-----`
+
+	mux.HandleFunc("/user/gpg_keys", func(w http.ResponseWriter, r *http.Request) {
+		var gpgKey struct {
+			ArmoredPublicKey *string `json:"armored_public_key,omitempty"`
+		}
+		json.NewDecoder(r.Body).Decode(&gpgKey)
+
+		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", mediaTypeGitSigningPreview)
+		if gpgKey.ArmoredPublicKey == nil || *gpgKey.ArmoredPublicKey != input {
+			t.Errorf("gpgKey = %+v, want %q", gpgKey, input)
+		}
+
+		fmt.Fprint(w, `{"id":1}`)
+	})
+
+	gpgKey, _, err := client.Users.CreateGPGKey(input)
+	if err != nil {
+		t.Errorf("Users.GetGPGKey returned error: %v", err)
+	}
+
+	want := &GPGKey{ID: Int(1)}
+	if !reflect.DeepEqual(gpgKey, want) {
+		t.Errorf("Users.GetGPGKey = %+v, want %+v", gpgKey, want)
+	}
+}
+
+func TestUsersService_DeleteGPGKey(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/user/gpg_keys/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		testHeader(t, r, "Accept", mediaTypeGitSigningPreview)
+	})
+
+	_, err := client.Users.DeleteGPGKey(1)
+	if err != nil {
+		t.Errorf("Users.DeleteGPGKey returned error: %v", err)
+	}
+}

--- a/vendor/github.com/google/go-github/github/users_test.go
+++ b/vendor/github.com/google/go-github/github/users_test.go
@@ -155,11 +155,11 @@ func TestUsersService_ListAll(t *testing.T) {
 
 	mux.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testFormValues(t, r, values{"since": "1"})
+		testFormValues(t, r, values{"since": "1", "page": "2"})
 		fmt.Fprint(w, `[{"id":2}]`)
 	})
 
-	opt := &UserListOptions{1}
+	opt := &UserListOptions{1, ListOptions{Page: 2}}
 	users, _, err := client.Users.ListAll(opt)
 	if err != nil {
 		t.Errorf("Users.Get returned error: %v", err)


### PR DESCRIPTION
I need at least [this version](https://github.com/google/go-github/commit/a8b8751f9d056ab7f60ab6d9caba15db9d701b09) in order for a new github-receiver service to be able to validate signed payloads.