### PR TITLE
Add instrumentation to users service

### DIFF
--- a/users/cmd/users/main.go
+++ b/users/cmd/users/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"math/rand"
-	"net/http"
 	"strings"
 	"time"
 
@@ -159,10 +158,11 @@ func main() {
 
 	log.Infof("Listening on port %d", *port)
 	s, err := server.New(server.Config{
-		MetricsNamespace: common.PrometheusNamespace,
-		HTTPListenPort:   *port,
-		GRPCListenPort:   *grpcPort,
-		GRPCMiddleware:   []grpc.UnaryServerInterceptor{render.GRPCErrorInterceptor},
+		MetricsNamespace:        common.PrometheusNamespace,
+		HTTPListenPort:          *port,
+		GRPCListenPort:          *grpcPort,
+		GRPCMiddleware:          []grpc.UnaryServerInterceptor{render.GRPCErrorInterceptor},
+		RegisterInstrumentation: true,
 	})
 	if err != nil {
 		log.Fatalf("Failed to create server: %v", err)
@@ -205,8 +205,4 @@ func makeLocalTestUser(a *api.API, email, instanceID, instanceName, token string
 		log.Errorf("Error creating local test instance: %v", err)
 		return
 	}
-}
-
-func makePrometheusHandler() http.Handler {
-	return prometheus.Handler()
 }


### PR DESCRIPTION
Recent update of dependencies (#1372) introduced a change from weaveworks/common#47 which added a flag to control whether instrumentation routes should be registered.

Although that PR says that it's intended to preserve existing behaviour, this doesn't appear to have been the case.

This PR explicitly enables instrumentation for users, which ought to fix the alerts we're seeing right now.