### PR TITLE
Do not check csrf tokens for ui metrics endpoint

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -402,6 +402,7 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 	csrfExemptPrefixes = append(csrfExemptPrefixes, dataAccessRoutes.AbsolutePrefixes()...)
 	csrfExemptPrefixes = append(csrfExemptPrefixes, "/admin/alertmanager")
 	csrfExemptPrefixes = append(csrfExemptPrefixes, "/service-ui-kicker")
+	csrfExemptPrefixes = append(csrfExemptPrefixes, "/api/ui/metrics")
 	csrfExemptPrefixes = append(
 		csrfExemptPrefixes,
 		`/api/app/[a-zA-Z0-9_-]+/api/prom/alertmanager`, // Regex copy-pasted from users/organization.go


### PR DESCRIPTION
I noticed the CSRF errors have been occuring when posting to `/api/ui/metrics`. This endpoint is handled by the prometheus go client handler. 

I'm unsure why it could be causing CSRF mismatch errors, but we do not need to have CSRF on this endpoint. I would like to see if this affects the problem we are seeing.

https://github.com/weaveworks/service-ui/issues/848