### PR TITLE
`push-images`: include billing components

### DIFF
--- a/push-images
+++ b/push-images
@@ -37,7 +37,8 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-COMPONENTS=(authfe users metrics logging notebooks service-ui-kicker github-receiver)
+COMPONENTS=(authfe users metrics logging notebooks service-ui-kicker github-receiver
+    billing-api billing-uploader billing-hpm_demo billing-ingester billing-enforcer billing-aggregator)
 if [ $# -gt 0 ]; then
     COMPONENTS=("$@")
 fi


### PR DESCRIPTION
This should make sure Circleci pushes billing images to Quay.

Sorry for the many PRs. This is run in CircleCI only from master branch, so it's more difficult to test.