### PR TITLE
Create .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.go]
+indent_style = tab
+
+[*.{js,jsx,json}]
+indent_style = space
+indent_size = 2
+
+[*.{yml,yaml,toml}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
http://editorconfig.org/ is becoming the standard way of letting editors know what settings to use for things like indent styles and sizes.

It is supported by default for many editors and there are plugins for the rest.
