### PR TITLE
Build images on a consistently-numbered version of Alpine (3.6)

### DIFF
--- a/authfe/Dockerfile
+++ b/authfe/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.6
 MAINTAINER Weaveworks Inc <help@weave.works>
 WORKDIR /
 COPY authfe /

--- a/billing/aggregator/Dockerfile
+++ b/billing/aggregator/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.6
 EXPOSE 80
 ENTRYPOINT ["/aggregator"]
 RUN apk add --update \

--- a/billing/api/Dockerfile
+++ b/billing/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.6
 EXPOSE 80
 ENTRYPOINT ["/api"]
 RUN apk add --update \

--- a/billing/enforcer/Dockerfile
+++ b/billing/enforcer/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.6
 EXPOSE 80
 ENTRYPOINT ["/enforcer"]
 RUN apk add --update \

--- a/billing/uploader/Dockerfile
+++ b/billing/uploader/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.6
 EXPOSE 80
 ENTRYPOINT ["/uploader"]
 RUN apk add --update \

--- a/metrics/Dockerfile
+++ b/metrics/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.6
 MAINTAINER Weaveworks Inc <help@weave.works>
 WORKDIR /
 COPY metrics /

--- a/notebooks/Dockerfile
+++ b/notebooks/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 MAINTAINER Weaveworks Inc <help@weave.works>
 WORKDIR /
 COPY cmd/notebooks/notebooks /

--- a/users/Dockerfile
+++ b/users/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.6
 MAINTAINER Weaveworks Inc <help@weave.works>
 WORKDIR /
 COPY cmd/users/users /


### PR DESCRIPTION
`github-receiver` is already on 3.6
3.6 is the latest version as of when I am writing this; it was stamped on 24th May 2017.
