### PR TITLE
circleci: fix deployment step

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -53,6 +53,7 @@ deployment:
           export LAST_BUILD_COMMIT=$(curl -sS 'https://circleci.com/api/v1/project/weaveworks/service/tree/'$CIRCLE_BRANCH'?circle-token='$CIRCLE_TOKEN'&filter=successful&limit=1' | jq -r '.[0].vcs_revision')
           echo Last successful build was commit $LAST_BUILD_COMMIT
           ./push-images --if-changed-since $LAST_BUILD_COMMIT
+  dry_run:
     branch: /^((?!master).)*$/  # not the master branch
     commands:
       - |


### PR DESCRIPTION
It appears that, even though the deployment action is specified for master and non-master, only the non-master is executed.
This caused the master build to not push images.

This change should fix it.

See #1413.
Related to https://github.com/weaveworks/service/pull/1468.