### PR TITLE
Expose eventmanager to the UI

### DIFF
--- a/authfe/config.go
+++ b/authfe/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	githubReceiverHost     proxyConfig
 	launchGeneratorHost    proxyConfig
 	notificationConfigHost proxyConfig
+	notificationEventHost  proxyConfig
 	notificationSenderHost proxyConfig
 	peerDiscoveryHost      proxyConfig
 	pipeHost               proxyConfig
@@ -87,6 +88,7 @@ func (c *Config) proxies() map[string]*proxyConfig {
 		"notebooks":            &c.notebooksHost,
 		"notification-configs": &c.notificationConfigHost,
 		"notification-sender":  &c.notificationSenderHost,
+		"notification-events":  &c.notificationEventHost,
 		"peer-discovery":       &c.peerDiscoveryHost,
 		"pipe":                 &c.pipeHost,
 		"prom-alertmanager":    &c.promAlertmanagerHost,

--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -282,7 +282,9 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 				Prefix{"/api/prom", c.promQuerierHost},
 				Prefix{"/api/net/peer", c.peerDiscoveryHost},
 				Prefix{"/api/notification/config", c.notificationConfigHost},
+				// Configmanager reads from the events database; eventmanager handles sending notifications
 				PrefixMethods{"/api/notification/events", []string{"GET"}, c.notificationConfigHost},
+				PrefixMethods{"/api/notification/events", []string{"POST"}, c.notificationEventHost},
 				Prefix{"/api/notification/sender", c.notificationSenderHost},
 				Prefix{"/api", c.queryHost},
 


### PR DESCRIPTION
Helps with https://github.com/weaveworks/notification/issues/69

Exposes eventmanager to the UI, behind authfe. Allows for the UI to create events.

Relies on https://github.com/weaveworks/notification/pull/101