### PR TITLE
Add `push-images` as dep to all components

### DIFF
--- a/push-images
+++ b/push-images
@@ -101,8 +101,19 @@ def get_dependencies(component):
     except KeyError:
         raise ConfigError(
             "Couldn't find dependencies for component {}".format(component))
+
+    deps.extend(common_dependencies())
     return deps
 
+def common_dependencies():
+    # If this script changes, push all images (should be rare).
+    # This is required because of the following case:
+    # 1. someone forgets to add their component to `push-images`
+    # 2. pushes their work to master
+    # 3. realises CI hasn't pushed the image
+    # 4. Edits `push-images` accordingly, but the image, again, isn't pushed
+    #    because the code was not changed.
+    return ['push-images']
 
 def has_changed_since(since, component):
     """Has 'component' changed since the given revision?


### PR DESCRIPTION
This is required because of the following case:
1. someone forgets to add their component to `push-images`
2. pushes their work to master
3. realises CI hasn't pushed the image
4. Edits `push-images` accordingly, but the image, again, isn't pushed
   because the code was not changed.

See #1487 