### PR TITLE
Add missed changes from flux/#792

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -624,6 +624,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "942552654fba5151f63dbfbc74fa37596ed7bea0b11d15a44323dc3d6107c57d"
+  inputs-digest = "e2d993ba415f314d1d7585cd942ed4fc4481643ce58489d31645b7f0c8f20ea5"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/flux-api/notifications/notifications.go
+++ b/flux-api/notifications/notifications.go
@@ -6,7 +6,7 @@ import (
 )
 
 // DefaultNotifyEvents is the default list of events on which we notify.
-var DefaultNotifyEvents = []string{"release", "autorelease"}
+var DefaultNotifyEvents = []string{event.EventRelease, event.EventAutoRelease}
 
 // Event sends a notification for the given event if cfg specifies HookURL.
 func Event(cfg instance.Config, e event.Event) error {


### PR DESCRIPTION
This adds the changes I missed from [flux/#792](https://github.com/weaveworks/flux/pull/792).

`fluxsvc_test.go` still needs to be ported. That will come soon.