### PR TITLE
Add `withPlatform` boolean arg to flux API status resource

### DIFF
--- a/flux-api/api/api.go
+++ b/flux-api/api/api.go
@@ -16,7 +16,7 @@ type Service interface {
 	api.Client
 	api.Upstream
 
-	Status(context.Context) (service.Status, error)
+	Status(ctx context.Context, withPlatform bool) (service.Status, error)
 	History(context.Context, update.ResourceSpec, time.Time, int64, time.Time) ([]history.Entry, error)
 	GetConfig(ctx context.Context, fingerprint string) (config.Instance, error)
 	SetConfig(context.Context, config.Instance) error

--- a/flux-api/http/server.go
+++ b/flux-api/http/server.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -425,7 +426,19 @@ func (s httpService) PostIntegrationsGithub(w http.ResponseWriter, r *http.Reque
 
 func (s httpService) Status(w http.ResponseWriter, r *http.Request) {
 	ctx := getRequestContext(r)
-	status, err := s.service.Status(ctx)
+
+	withPlatform := true // If value isn't supplied, default to old behaviour
+	withPlatformValue := r.FormValue("withPlatform")
+	if len(withPlatformValue) > 0 {
+		var err error
+		withPlatform, err = strconv.ParseBool(withPlatformValue)
+		if err != nil {
+			transport.WriteError(w, r, http.StatusBadRequest, err)
+			return
+		}
+	}
+
+	status, err := s.service.Status(ctx, withPlatform)
 	if err != nil {
 		transport.ErrorResponse(w, r, err)
 		return


### PR DESCRIPTION
If `withPlatform` is `false`, the flux API service does not attempt to populate the elements of the status structure that involve making RPC calls to the platform, giving a method to quickly ascertain connected status and last connection time without the risk of lengthy RPC timeouts.

If not supplied at all, `true` is assumed for backwards compatibility.