### PR TITLE
Improve creation of GCP Pub/Sub subscription

### DIFF
--- a/common/gcp/pubsub/publisher/config.go
+++ b/common/gcp/pubsub/publisher/config.go
@@ -1,6 +1,9 @@
 package publisher
 
-import "flag"
+import (
+	"flag"
+	"time"
+)
 
 // Config holds the configuration for a publisher client.
 type Config struct {
@@ -8,6 +11,7 @@ type Config struct {
 	TopicID               string
 	TopicProjectID        string
 	ServiceAccountKeyFile string
+	AckDeadline           time.Duration
 
 	// CreateTopic says whether to attempt to create the topic. Needs permission to check for
 	// existence of the topic in the topic project.
@@ -21,4 +25,5 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	flag.StringVar(&c.TopicID, name+".topic-id", "weaveworks-public-cloudmarketplacepartner.googleapis.com", "Topic ID for the Pub/Sub subscription")
 	flag.StringVar(&c.TopicProjectID, name+".topic-project-id", "cloud-billing-subscriptions", "Only pass if topic is under another project")
 	flag.StringVar(&c.ServiceAccountKeyFile, name+".service-account-key-file", "", "Service account key JSON file")
+	flag.DurationVar(&c.AckDeadline, name+".ack-deadline", 10*time.Second, "Time to acknowledge the message before it is sent again. See also: https://cloud.google.com/pubsub/docs/subscriber#create")
 }

--- a/gcp-launcher-webhook/main.go
+++ b/gcp-launcher-webhook/main.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -100,7 +99,7 @@ func createSubscription(cfg *config) {
 		log.Fatalf("Failed creating Pub/Sub publisher: %v", err)
 	}
 	defer pub.Close()
-	sub, err := pub.CreateSubscription(cfg.subscriptionID, cfg.Endpoint(), 10*time.Second)
+	sub, err := pub.CreateSubscription(cfg.subscriptionID, cfg.Endpoint(), cfg.publisher.AckDeadline)
 	if err != nil {
 		log.Fatalf("Failed subscribing to Pub/Sub topic: %v", err)
 	}


### PR DESCRIPTION
Changelog:
- Close the client right after programmatically creating the GCP Pub/Sub subscription at startup.
- Make the ACK deadline configurable (previously hard-coded to 10 seconds).

N.B.: as discussed IRL, if we start to have multiple replicas of this service, we might face race conditions during the creation of the GCP Pub/Sub subscription. Creating the GCP Pub/Sub subscription could then either be done manually in GCP, or via Terraform.

Part of #1475.