### PR TITLE
Do not check CSRF token for GCP Pub/Sub webhook

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -426,8 +426,8 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 	// * the Cortex alert manager, incorporating tokens would require forking it
 	//   (see https://github.com/weaveworks/service-ui/issues/461#issuecomment-299458350)
 	//   and we don't see alert-silencing as very security-sensitive.
-	// * incoming webhooks (service-ui-kicker and github-receiver), as these are validated
-	//   by checking HMAC integrity
+	// * incoming webhooks (service-ui-kicker, github-receiver and gcp-launcher-webhook), as these are validated
+	//   by checking HMAC integrity or arbitrary secrets.
 	csrfExemptPrefixes := dataUploadRoutes.AbsolutePrefixes()
 	csrfExemptPrefixes = append(csrfExemptPrefixes, dataAccessRoutes.AbsolutePrefixes()...)
 	csrfExemptPrefixes = append(
@@ -435,6 +435,7 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 		"/admin/alertmanager",
 		"/service-ui-kicker",
 		"/api/ui/metrics",
+		"/gcp-launcher/webhook",
 		"/github-receiver",
 		`/api/app/[a-zA-Z0-9_-]+/api/prom/alertmanager`, // Regex copy-pasted from users/organization.go
 		"/api/users/signup_webhook",                     // Validated by explicit token in the users service


### PR DESCRIPTION
Currently, incoming requests fail with:
```
$ curl -X POST "https://frontend.dev.weave.works/api/gcp-launcher/webhook?secret=tm1kCj1sGsvMWOGekwIIYohV3HrKwirk5eoVDTN6rdcZ"
CSRF token mismatch: The CSRF token in the cookie doesn't match the one received in a form/header.
```

Part of #1475.