### PR TITLE
Initialize Partner API if credentials given

### DIFF
--- a/users/cmd/users/main.go
+++ b/users/cmd/users/main.go
@@ -134,9 +134,13 @@ func main() {
 		mixpanelClient = marketing.NewMixpanelClient(*mixpanelToken)
 	}
 
-	partnerClient, err := partner.NewClient(partnerCfg)
-	if err != nil {
-		log.Fatalf("Failed creating Google Partner Subscriptions API client: %v", err)
+	var partnerClient partner.API
+	if partnerCfg.ServiceAccountKeyFile != "" {
+		var err error
+		partnerClient, err = partner.NewClient(partnerCfg)
+		if err != nil {
+			log.Fatalf("Failed creating Google Partner Subscriptions API client: %v", err)
+		}
 	}
 
 	webhookTokenMap := make(map[string]struct{})


### PR DESCRIPTION
Don't attempt to create Partner Subscriptions API client if  `-partner-subscriptions-api.service-account-key-file` is empty.

Allows to start `users` locally, while omitting partner subscriptions params.