### PR TITLE
Insert starting id for initial GCP usage upload

### DIFF
--- a/billing-api/db/migrations/007_insert_usage_uploads_gcp.up.sql
+++ b/billing-api/db/migrations/007_insert_usage_uploads_gcp.up.sql
@@ -1,0 +1,2 @@
+-- Usage upload starts now, from latest aggregate.
+INSERT INTO usage_uploads (max_aggregate_id, uploader) SELECT MAX(id), 'gcp' FROM aggregates;


### PR DESCRIPTION
We need to tell the uploader where to start.

Fixes the error
```
ERRO: 2017/11/18 00:00:00.148564 Failed reading aggregate ID: sql: Scan error on column index 0: converting driver.Value type <nil> ("<nil>") to a int: invalid syntax uploader=gcp
```