### PR TITLE
Use separate instrumentation method name for each usage uploader

### DIFF
--- a/billing-uploader/job/usage.go
+++ b/billing-uploader/job/usage.go
@@ -67,7 +67,7 @@ func NewUsageUpload(db db.DB, users users.UsersClient, uploader usage.Uploader, 
 // Run starts the job and logs errors.
 func (j *UsageUpload) Run() {
 	if err := j.Do(); err != nil {
-		log.Errorf("Error running upload job: %v", err)
+		log.Errorf("Error running upload job [%v]: %v", j.uploader.ID(), err)
 	}
 }
 

--- a/billing-uploader/main.go
+++ b/billing-uploader/main.go
@@ -120,7 +120,7 @@ func main() {
 		w.Write([]byte(index))
 	})
 	server.HTTP.Path("/upload").Methods("POST").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "usage /upload/gcp or /upload/zuora", http.StatusSeeOther)
+		http.Error(w, "use /upload/gcp or /upload/zuora", http.StatusSeeOther)
 	})
 	server.HTTP.Path("/upload/gcp").Methods("POST").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := gcpUpload.Do(); err != nil {


### PR DESCRIPTION
This allows us to detect errors for each uploader separately.