### PR TITLE
Add support for quay.io webhooks

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -361,6 +361,7 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 			"/api/flux/v6/integrations",
 			[]PrefixRoutable{
 				PrefixMethods{"/dockerhub/image", []string{"POST"}, c.fluxV6Host},
+				PrefixMethods{"/quay/image", []string{"POST"}, c.fluxV6Host},
 			},
 			nil,
 		},


### PR DESCRIPTION
Allows flux-api to receive image push hooks from quay.io. Follow on from #1524.