### PR TITLE
Add `users` to `metrics` image dependencies

### DIFF
--- a/push-images
+++ b/push-images
@@ -45,7 +45,7 @@ These need to correspond to the files used to build the Docker image.
 DEPENDENCIES = {
     'authfe': ['authfe', 'users'],
     'users': ['users', 'common'],
-    'metrics': ['metrics'],
+    'metrics': ['metrics', 'users'],
     'logging': ['logging'],
     'notebooks': ['notebooks'],
     'service-ui-kicker': ['service-ui-kicker'],


### PR DESCRIPTION
The `metrics` image will only be built if anything in its dependency
changes.

Fixes https://github.com/weaveworks/service-conf/issues/1590