### PR TITLE
CircleCi deployment step: compare against master

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -63,7 +63,7 @@ deployment:
           echo Last successful build was commit $LAST_BUILD_COMMIT
           ./push-images --if-changed-since $LAST_BUILD_COMMIT
   dry_run:
-    branch: /^((?!master).)*$/  # not the master branch
+    branch: /^(?!master$).*/  # not master branch
     commands:
       - |
           set -o pipefail


### PR DESCRIPTION
push-images compares the codebase against the previous commit in the current branch in circleci.
If circleci does not know the previous commit it returns null. There's no point in checking for differences againt null.
Comparing always against master allows to reproduce the build's behaviour in master from a non-master branch.