### PR TITLE
Add flux-url alias to flux-svc-url parameter

### DIFF
--- a/github-receiver/main.go
+++ b/github-receiver/main.go
@@ -11,6 +11,7 @@ import (
 func main() {
 	var (
 		fluxSvcURL    = flag.String("flux-svc-url", "fluxsvc.flux.svc.cluster.local.:80", "Flux service base URL")
+		fluxURL       = flag.String("flux-url", "", "Flux base URL")
 		webhookSecret = flag.String("webhook-secret", "", "Github App webhook secret")
 		cfg           = server.Config{
 			MetricsNamespace:        common.PrometheusNamespace,
@@ -22,6 +23,9 @@ func main() {
 
 	if *webhookSecret == "" {
 		log.Fatal("webhook secret not set")
+	}
+	if *fluxURL != "" {
+		*fluxSvcURL = *fluxURL
 	}
 
 	server, err := server.New(cfg)


### PR DESCRIPTION
I'm doing a rename of all things fluxsvc to flux-api. This alias needs to exist until all yamels have been changed.