### PR TITLE
Reset report sheet when uploading billing usage

### DIFF
--- a/billing-uploader/job/usage.go
+++ b/billing-uploader/job/usage.go
@@ -126,6 +126,9 @@ func (j *UsageUpload) Do() error {
 		// Go back at most one week
 		earliest := through.Add(-7 * 24 * time.Hour)
 
+		// Reset previous report
+		j.uploader.Reset()
+
 		// Look up the billing-enabled instances where the trial has expired.
 		resp, err := j.users.GetBillableOrganizations(ctx, &users.GetBillableOrganizationsRequest{
 			Now: through,

--- a/billing-uploader/job/usage/gcp.go
+++ b/billing-uploader/job/usage/gcp.go
@@ -33,6 +33,11 @@ func (g *GCP) ID() string {
 	return "gcp"
 }
 
+// Reset removes all current operations.
+func (g *GCP) Reset() {
+	g.ops = nil
+}
+
 // Add collects node-seconds aggregates.
 func (g *GCP) Add(ctx context.Context, org users.Organization, from, through time.Time, aggs []db.Aggregate) error {
 	for _, agg := range aggs {

--- a/billing-uploader/job/usage/uploader.go
+++ b/billing-uploader/job/usage/uploader.go
@@ -18,6 +18,8 @@ type Uploader interface {
 	Add(ctx context.Context, org users.Organization, from, through time.Time, aggs []db.Aggregate) error
 	// Upload sends recorded aggregates.
 	Upload(ctx context.Context) error
+	// Reset creates a fresh report.
+	Reset()
 	// IsSupported returns whether this uploader handles the given organization.
 	IsSupported(org users.Organization) bool
 	// ThroughTime returns the upper bound we want to upload usage until.

--- a/billing-uploader/job/usage/zuora.go
+++ b/billing-uploader/job/usage/zuora.go
@@ -3,11 +3,13 @@ package usage
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/pkg/errors"
+
 	"github.com/weaveworks/service/billing-api/db"
 	"github.com/weaveworks/service/common/zuora"
 	"github.com/weaveworks/service/users"
-	"time"
 )
 
 // Zuora sends usage data to Zuora. It implements Uploader.
@@ -18,15 +20,21 @@ type Zuora struct {
 
 // NewZuora creates a Zuora instance.
 func NewZuora(client zuora.Client) *Zuora {
-	return &Zuora{
+	z := &Zuora{
 		cl: client,
-		r:  zuora.NewReport(client.GetConfig()),
 	}
+	z.Reset()
+	return z
 }
 
 // ID identifies this uploader.
 func (z *Zuora) ID() string {
 	return "zuora"
+}
+
+// Reset replaces the current report with an empty one
+func (z *Zuora) Reset() {
+	z.r = zuora.NewReport(z.cl.GetConfig())
 }
 
 // Add collects usage by grouping aggregates in billing periods.


### PR DESCRIPTION
We have duplicate Zuora usage entries 3 days back which I'm not going to delete because no real customer was affected.