### PR TITLE
Store subscription status when updating subscription

### DIFF
--- a/gcp-launcher-webhook/subscription/messagehandler.go
+++ b/gcp-launcher-webhook/subscription/messagehandler.go
@@ -133,10 +133,11 @@ func (m MessageHandler) updateGCP(ctx context.Context, sub *partner.Subscription
 	consumerID := sub.ExtractResourceLabel("weave-cloud", partner.ConsumerIDLabelKey)
 	_, err := m.Users.UpdateGCP(ctx, &users.UpdateGCPRequest{
 		GCP: &users.GoogleCloudPlatform{
-			ExternalAccountID: sub.ExternalAccountID,
-			ConsumerID:        consumerID,
-			SubscriptionName:  sub.Name,
-			SubscriptionLevel: level,
+			ExternalAccountID:  sub.ExternalAccountID,
+			ConsumerID:         consumerID,
+			SubscriptionName:   sub.Name,
+			SubscriptionLevel:  level,
+			SubscriptionStatus: string(sub.Status),
 		},
 	})
 	return err

--- a/gcp-launcher-webhook/subscription/messagehandler_test.go
+++ b/gcp-launcher-webhook/subscription/messagehandler_test.go
@@ -117,10 +117,11 @@ func TestMessageHandler_Handle_cancel(t *testing.T) {
 	client.EXPECT().
 		UpdateGCP(ctx, &users.UpdateGCPRequest{
 			GCP: &users.GoogleCloudPlatform{
-				ExternalAccountID: externalAccountID,
-				ConsumerID:        "project_number:123",
-				SubscriptionName:  "partnerSubscriptions/1",
-				SubscriptionLevel: "enterprise",
+				ExternalAccountID:  externalAccountID,
+				ConsumerID:         "project_number:123",
+				SubscriptionName:   "partnerSubscriptions/1",
+				SubscriptionLevel:  "enterprise",
+				SubscriptionStatus: "COMPLETE",
 			}}).
 		Return(nil, nil)
 
@@ -160,10 +161,11 @@ func TestMessageHandler_Handle_reactivationPlanChange(t *testing.T) {
 	client.EXPECT().
 		UpdateGCP(ctx, &users.UpdateGCPRequest{
 			GCP: &users.GoogleCloudPlatform{
-				ExternalAccountID: externalAccountID,
-				ConsumerID:        "project_number:123",
-				SubscriptionName:  "partnerSubscriptions/1",
-				SubscriptionLevel: "enterprise",
+				ExternalAccountID:  externalAccountID,
+				ConsumerID:         "project_number:123",
+				SubscriptionName:   "partnerSubscriptions/1",
+				SubscriptionLevel:  "enterprise",
+				SubscriptionStatus: "PENDING",
 			}}).
 		Return(nil, nil)
 


### PR DESCRIPTION
Subscription status was reset to empty string on incoming message because it wasn't forwarded to the database.