### PR TITLE
Improve operation names sent to OpenTracing

### DIFF
--- a/authfe/proxy.go
+++ b/authfe/proxy.go
@@ -68,7 +68,7 @@ var proxyTransport http.RoundTripper = &nethttp.Transport{
 func (p *httpProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !middleware.IsWSHandshakeRequest(r) {
 		var ht *nethttp.Tracer
-		cmo := nethttp.OperationName(r.URL.RequestURI())
+		cmo := nethttp.OperationName(fmt.Sprintf("%s %s", r.Method, r.URL.Path))
 		r, ht = nethttp.TraceRequest(opentracing.GlobalTracer(), r, cmo)
 		defer ht.Finish()
 	}

--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -473,7 +473,7 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 		"/admin/prod-grafana",
 	)
 	operationNameFunc := nethttp.OperationNameFunc(func(r *http.Request) string {
-		return r.URL.RequestURI()
+		return fmt.Sprintf("%s %s", r.Method, r.URL.Path)
 	})
 	return middleware.Merge(
 		AuthHeaderStrippingMiddleware{},

--- a/flux-api/main.go
+++ b/flux-api/main.go
@@ -177,7 +177,7 @@ func main() {
 		mux.Handle("/", handler)
 		mux.Handle("/api/flux/", http.StripPrefix("/api/flux", handler))
 		operationNameFunc := nethttp.OperationNameFunc(func(r *http.Request) string {
-			return r.URL.RequestURI()
+			return fmt.Sprintf("%s %s", r.Method, r.URL.Path)
 		})
 		errc <- http.ListenAndServe(*listenAddr, nethttp.Middleware(opentracing.GlobalTracer(), mux, operationNameFunc))
 	}()


### PR DESCRIPTION
Add the method type - GET, POST, etc.

And nethttp already adds a tag `http.url` which contains the full url, so putting it in the name is redundant and breaks the Jaeger UI if the string is long.

Also the drop-down for selecting an operation is unusable if all the different parameter variants are present.

Example of what I mean about the UI:

![image](https://user-images.githubusercontent.com/8125524/34082647-14cef474-e35a-11e7-90e4-8fb8e3db7288.png)
