### PR TITLE
Call users service what it is, in tracing

### DIFF
--- a/users/cmd/users/main.go
+++ b/users/cmd/users/main.go
@@ -36,7 +36,7 @@ func init() {
 
 func main() {
 
-	traceCloser := tracing.Init("users-api")
+	traceCloser := tracing.Init("users")
 	defer traceCloser.Close()
 
 	var (


### PR DESCRIPTION
I find it confusing to see "-api" in the traces - we call this thing "the users service", don't we?