### PR TITLE
Give admins a button to remove user from org

### DIFF
--- a/users/api/routes.go
+++ b/users/api/routes.go
@@ -70,6 +70,7 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 		{"admin_users_organizations", "GET", "/admin/users/organizations", a.listOrganizations},
 		{"admin_users_gcp_externalAccoutnID_subscriptions", "GET", "/admin/users/gcp/{externalAccountID}/subscriptions", a.gcpListSubscriptions},
 		{"admin_users_organizations_orgExternalID_users", "GET", "/admin/users/organizations/{orgExternalID}/users", a.listUsersForOrganization},
+		{"admin_users_organizations_orgExternalID_users_userID", "POST", "/admin/users/organizations/{orgExternalID}/users/{userID}/remove", a.removeUserFromOrganization},
 		{"admin_users_organizations_orgExternalID", "POST", "/admin/users/organizations/{orgExternalID}", a.changeOrgFields},
 		{"admin_users_users", "GET", "/admin/users/users", a.listUsers},
 		{"admin_users_users_userID_admin", "POST", "/admin/users/users/{userID}/admin", a.makeUserAdmin},

--- a/users/db/db.go
+++ b/users/db/db.go
@@ -47,7 +47,7 @@ type DB interface {
 	// Invite a user to access an existing organization.
 	InviteUser(ctx context.Context, email, orgExternalID string) (*users.User, bool, error)
 
-	// Remove a user from an organization. If they do not exist (ctx context.Context, or are not a member of the org), return success.
+	// Remove a user from an organization. If they do not exist (or are not a member of the org), return success.
 	RemoveUserFromOrganization(ctx context.Context, orgExternalID, email string) error
 
 	ListUsers(ctx context.Context, f filter.User, page uint64) ([]*users.User, error)

--- a/users/templates/list_users.html
+++ b/users/templates/list_users.html
@@ -92,6 +92,15 @@
                    type="submit" value="Become User" />
           </form>
         </td>
+        {{if $.OrgExternalID}}
+        <td>
+          <form action="organizations/{{$.OrgExternalID}}/users/{{.ID}}/remove" method="POST">
+            <input type="hidden" name="csrf_token" value="$__CSRF_TOKEN_PLACEHOLDER__">
+            <input class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored"
+                   type="submit" value="Remove from Org" />
+          </form>
+        <td>
+        {{end}}
         <td>
           <a href="users/{{.ID}}/organizations">Organizations</a>
         </td>


### PR DESCRIPTION
Occasionally we may need to intervene to remove a (bogus) account from
an instance. This commit adds a means of doing this through the admin
interface.

It's already possible to remove a user from an instance by becoming a
user in that instance; however, one of the reasons we may need to
intervene is if this doesn't work for whatever reason.

The admin version of this function uses the ID of the user rather than
the email address, since the latter might be the cause of the problem.

Will help address weaveworks/service-conf#1692.