### PR TITLE
ensure securecookies don't expire before the app expects them to

### DIFF
--- a/users/sessions/store.go
+++ b/users/sessions/store.go
@@ -24,9 +24,11 @@ func MustNewStore(validationSecret string, secure bool) Store {
 	}
 
 	return Store{
-		secret:  validationSecret,
-		encoder: securecookie.New(secretBytes, nil).SetSerializer(securecookie.JSONEncoder{}),
-		secure:  secure,
+		secret: validationSecret,
+		encoder: securecookie.New(secretBytes, nil).
+			SetSerializer(securecookie.JSONEncoder{}).
+			MaxAge(int(SessionDuration.Seconds())),
+		secure: secure,
 	}
 }
 


### PR DESCRIPTION
The app has its own cookie expiration and, importantly, renewal logic. So we need to make sure the underlying `securecookie` doesn't expire before the app-determined expiry. The default for the former is 30 days, whereas the current cookie expiry setting in the app is 60 days. Since the app renews cookies only after 40 days, users get bounced to to signup/login after 30 days.

We could simply set the `securecookie` to never expire, but it seems neater to align it with the app-determined expiry. (The values won't be exactly the same, because of independent calls to determine the current time, but such small discrepancies are not a problem.)

Side note: `securecookie` does not provide access to the timestamp it embeds in the cookie, which is why the app needs to do its own tracking in `Session.CreatedAt`.

Fixes #1663