### PR TITLE
Increase BI event buffer from 100 to 1000 

### DIFF
--- a/authfe/event.go
+++ b/authfe/event.go
@@ -121,6 +121,7 @@ func (el *EventLogger) LogEvent(ev Event) error {
 	default:
 		// full
 	}
+	eventsDiscardedCount.Inc()
 	return fmt.Errorf("Reached event buffer limit (%d), discarding event: %v", maxBufferedEvents, ev)
 }
 

--- a/authfe/main.go
+++ b/authfe/main.go
@@ -42,12 +42,18 @@ var (
 		Name:      "websocket_request_count",
 		Help:      "Total number of websocket requests received.",
 	})
+	eventsDiscardedCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: common.PrometheusNamespace,
+		Name:      "bi_events_discarded_count",
+		Help:      "Total number BI events discarded.",
+	})
 	orgPrefix = regexp.MustCompile("^/api/app/[^/]+")
 )
 
 func init() {
 	prometheus.MustRegister(wsConnections)
 	prometheus.MustRegister(wsRequestCount)
+	prometheus.MustRegister(eventsDiscardedCount)
 	prometheus.MustRegister(common.RequestDuration)
 }
 


### PR DESCRIPTION
Towards: https://github.com/weaveworks/service/issues/1665

Previously the timestamp on an event was taken when it was given to the fluentd client.