### PR TITLE
Add email wrapper and convert existing emails to partials

### DIFF
--- a/users/emailer/smtp.go
+++ b/users/emailer/smtp.go
@@ -25,6 +25,7 @@ type SMTPEmailer struct {
 
 // Date format to use in email templates
 const dateFormat = "January 2 2006"
+const emailWrapperFilename = "wrapper.html"
 
 // Takes a uri of the form smtp://username:password@hostname:port
 func smtpEmailSender(u *url.URL) (func(e *email.Email) error, error) {
@@ -58,7 +59,7 @@ func (s SMTPEmailer) LoginEmail(u *users.User, token string, queryParams map[str
 		"RootURL":  s.Domain,
 	}
 	e.Text = s.Templates.QuietBytes("login_email.text", data)
-	e.HTML = s.Templates.QuietBytes("login_email.html", data)
+	e.HTML = s.Templates.EmbedHTML("login_email.html", emailWrapperFilename, e.Subject, data)
 	return s.Sender(e)
 }
 
@@ -75,7 +76,7 @@ func (s SMTPEmailer) InviteEmail(inviter, invited *users.User, orgExternalID, or
 		"OrganizationName": orgName,
 	}
 	e.Text = s.Templates.QuietBytes("invite_email.text", data)
-	e.HTML = s.Templates.QuietBytes("invite_email.html", data)
+	e.HTML = s.Templates.EmbedHTML("invite_email.html", emailWrapperFilename, e.Subject, data)
 	return s.Sender(e)
 }
 
@@ -91,7 +92,7 @@ func (s SMTPEmailer) GrantAccessEmail(inviter, invited *users.User, orgExternalI
 		"OrganizationURL":  organizationURL(s.Domain, orgExternalID),
 	}
 	e.Text = s.Templates.QuietBytes("grant_access_email.text", data)
-	e.HTML = s.Templates.QuietBytes("grant_access_email.html", data)
+	e.HTML = s.Templates.EmbedHTML("grant_access_email.html", emailWrapperFilename, e.Subject, data)
 	return s.Sender(e)
 }
 
@@ -109,7 +110,7 @@ func (s SMTPEmailer) TrialPendingExpiryEmail(members []*users.User, orgExternalI
 		"TrialLeft":        trialLeft(trialExpiresAt),
 	}
 	e.Text = s.Templates.QuietBytes("trial_pending_expiry_email.text", data)
-	e.HTML = s.Templates.QuietBytes("trial_pending_expiry_email.html", data)
+	e.HTML = s.Templates.EmbedHTML("trial_pending_expiry_email.html", emailWrapperFilename, e.Subject, data)
 
 	return s.Sender(e)
 }
@@ -126,7 +127,7 @@ func (s SMTPEmailer) TrialExpiredEmail(members []*users.User, orgExternalID, org
 		"BillingURL":       billingURL(s.Domain, orgExternalID),
 	}
 	e.Text = s.Templates.QuietBytes("trial_expired_email.text", data)
-	e.HTML = s.Templates.QuietBytes("trial_expired_email.html", data)
+	e.HTML = s.Templates.EmbedHTML("trial_expired_email.html", emailWrapperFilename, e.Subject, data)
 
 	return s.Sender(e)
 }
@@ -146,7 +147,7 @@ func (s SMTPEmailer) TrialExtendedEmail(members []*users.User, orgExternalID, or
 	e.To = collectEmails(members)
 	e.Subject = fmt.Sprintf("%s left of your free trial", left)
 	e.Text = s.Templates.QuietBytes("trial_extended_email.text", data)
-	e.HTML = s.Templates.QuietBytes("trial_extended_email.html", data)
+	e.HTML = s.Templates.EmbedHTML("trial_extended_email.html", emailWrapperFilename, e.Subject, data)
 
 	return s.Sender(e)
 }

--- a/users/templates/engine.go
+++ b/users/templates/engine.go
@@ -45,6 +45,7 @@ type Engine interface {
 	Lookup(name string) (Executor, error)
 	Bytes(name string, data interface{}) ([]byte, error)
 	QuietBytes(name string, data interface{}) []byte
+	EmbedHTML(name string, wrapper string, title string, data interface{}) []byte
 }
 
 type extensionsTemplateEngine struct {
@@ -85,4 +86,26 @@ func (l *extensionsTemplateEngine) QuietBytes(name string, data interface{}) []b
 		log.Error(err)
 	}
 	return b
+}
+
+// Embed HTML content in a wrapper HTML page. This keeps emails looking consistent.
+func (l *extensionsTemplateEngine) EmbedHTML(name, wrapper, title string, data interface{}) []byte {
+	content, err := l.Bytes(name, data)
+
+	if err != nil {
+		log.Error(err)
+		return nil
+	}
+
+	h, err := l.Bytes(wrapper, map[string]html.HTML{
+		"Content": html.HTML(content),
+		"Title":   html.HTML(title),
+	})
+
+	if err != nil {
+		log.Error(err)
+		return nil
+	}
+
+	return h
 }

--- a/users/templates/engine_test.go
+++ b/users/templates/engine_test.go
@@ -1,0 +1,35 @@
+package templates_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/weaveworks/service/users/templates"
+)
+
+func TestEmbedHTML__Login(t *testing.T) {
+	templates := templates.MustNewEngine(".")
+	data := map[string]interface{}{
+		"LoginURL": "cloud.weave.works/login",
+		"RootURL":  "cloud.weave.works",
+	}
+	rendered := string(templates.EmbedHTML("login_email.html", "wrapper.html", "Login Title", data))
+
+	assert.Contains(t, rendered, "Login Title")
+	assert.Contains(t, rendered, "Log in to Weave Cloud")
+	assert.Contains(t, rendered, data["LoginURL"])
+}
+
+func TestEmbedHTML__Invite(t *testing.T) {
+	templates := templates.MustNewEngine(".")
+	data := map[string]interface{}{
+		"LoginURL":         "cloud.weave.works/login",
+		"RootURL":          "cloud.weave.works",
+		"OrganizationName": "local-test-org",
+	}
+	rendered := string(templates.EmbedHTML("invite_email.html", "wrapper.html", "Invite Title", data))
+
+	assert.Contains(t, rendered, "Invite Title")
+	assert.Contains(t, rendered, "has invited you to access the \"local-test-org\"")
+	assert.Contains(t, rendered, data["LoginURL"])
+}

--- a/users/templates/grant_access_email.html
+++ b/users/templates/grant_access_email.html
@@ -1,15 +1,14 @@
-<html>
-<head>
-	<title></title>
-</head>
-<body>
-<div>{{.InviterName}} has granted you access to the ‘{{.OrganizationName}}’ monitoring instance on Weave Cloud.</div>
-
+<div>{{.InviterName}} has granted you access to the ‘{{.OrganizationName}}’ instance on Weave Cloud.</div>
 <div><br />
-View <a href="{{.OrganizationURL}}">{{.OrganizationName}}</a><br />
+  <div>
+     <p style="margin-bottom: 24px">
+      <a href="{{.LoginURL}}">
+        <button style="background-color: transparent; outline: none; border: 0; cursor: pointer; background: #049CD7; height: 48px; color: white; padding: 16px;  text-transform: uppercase; border-radius: 4px; border: 1px solid #007EB1; line-height: 1em; font-size: 1em;">
+          Log in to Weave Cloud
+        </button>
+      </a>
+    </p>
+  </div>
 <br />
 Thanks, the Weaveworks team<br />
 &nbsp;</div>
-
-</body>
-</html>

--- a/users/templates/grant_access_email.text
+++ b/users/templates/grant_access_email.text
@@ -1,4 +1,4 @@
-{{.InviterName}} has granted you access to the ‘{{.OrganizationName}}’ monitoring instance on Weave Cloud.
+{{.InviterName}} has granted you access to the ‘{{.OrganizationName}}’ instance on Weave Cloud.
 
 View «{{.OrganizationName}}»:
 

--- a/users/templates/invite_email.html
+++ b/users/templates/invite_email.html
@@ -1,19 +1,15 @@
-<html>
-<head>
-	<title></title>
-</head>
-<body>
-<div>{{.InviterName}} has invited you to access the ‘{{.OrganizationName}}’ on Weave Cloud.</div>
+<div>{{.InviterName}} has invited you to access the "{{.OrganizationName}}" on Weave Cloud.</div>
 
-<p>Click this link to log in to Weave&nbsp;Cloud:</p>
-
-<p><a href="{{.LoginURL}}">Log in to Weave Cloud</a></p>
+<div>
+   <p style="margin-bottom: 24px">
+    <a href="{{.LoginURL}}">
+      <button style="background-color: transparent; outline: none; border: 0; cursor: pointer; background: #049CD7; height: 48px; color: white; padding: 16px;  text-transform: uppercase; border-radius: 4px; border: 1px solid #007EB1; line-height: 1em; font-size: 1em;">
+        Log in to Weave Cloud
+      </button>
+    </a>
+  </p>
+</div>
 
 <p>This single-use login link is valid for 3 days. You can generate a new one at any time by visiting <a href="{{.RootURL}}">Weave Cloud</a></p>
 
-<p>You need to run probes on your Docker hosts to send information to Weave Cloud. Instructions for that are available once you log in.</p>
-
 <p>Thanks, the Weaveworks&nbsp;team</p>
-
-</body>
-</html>

--- a/users/templates/invite_email.text
+++ b/users/templates/invite_email.text
@@ -6,7 +6,4 @@ Click this link to log in to Weave Cloud:
 
 This single-use login link is valid for 3 days. You can generate a new one at any time by visiting {{.RootURL}}
 
-You need to run probes on your Docker hosts to send information to Weave
-Cloud. Instructions for that are available once you log in.
-
 Thanks, the Weaveworks team

--- a/users/templates/login_email.html
+++ b/users/templates/login_email.html
@@ -1,17 +1,16 @@
-<html>
-<head>
-	<title></title>
-</head>
-<body>
+
 <p>Click this link to login to Weave Cloud:</p>
 
-<p><a href="{{.LoginURL}}">Log in to Weave Cloud</a></p>
+<div>
+   <p style="margin-bottom: 24px">
+    <a href="{{.LoginURL}}">
+      <button style="background-color: transparent; outline: none; border: 0; cursor: pointer; background: #049CD7; height: 48px; color: white; padding: 16px;  text-transform: uppercase; border-radius: 4px; border: 1px solid #007EB1; line-height: 1em; font-size: 1em;">
+        Log in to Weave Cloud
+      </button>
+    </a>
+  </p>
+</div>
 
 <p>This single-use login link is valid for 3 days. You can generate a new one at any time by visiting <a href="{{.RootURL}}">{{.RootURL}}</a></p>
 
-<p>You need to run probes on your Docker hosts to send information to Weave Cloud. Instructions for that are available once you log in.</p>
-
 <p>Thanks, the Weaveworks&nbsp;team</p>
-
-</body>
-</html>

--- a/users/templates/login_email.text
+++ b/users/templates/login_email.text
@@ -4,7 +4,4 @@ Click here to log in to Weave Cloud:
 
 This single-use login link is valid for 3 days. You can generate a new one at any time by visiting {{.RootURL}}
 
-You need to run probes on your Docker hosts to send information to Weave
-Cloud. Instructions are available once you've logged in.
-
 Thanks, the Weaveworks team

--- a/users/templates/trial_expired_email.html
+++ b/users/templates/trial_expired_email.html
@@ -1,13 +1,17 @@
-<html>
-<head>
-	<title></title>
-</head>
-<body>
 <p>Hi,</p>
 
 <p>Your free trial of Weave Cloud for ‘{{.OrganizationName}}’ has now come to an end.</p>
 
-<p>But don't worry, to continue using Weave Cloud just <a href="{{.BillingURL}}">add a payment method</a>.</p>
+<p>To continue using Weave Cloud, add a payment method:</p>
+<div>
+   <p style="margin-bottom: 24px">
+    <a href="{{.BillingURL}}">
+      <button style="background-color: transparent; outline: none; border: 0; cursor: pointer; background: #049CD7; height: 48px; color: white; padding: 16px;  text-transform: uppercase; border-radius: 4px; border: 1px solid #007EB1; line-height: 1em; font-size: 1em;">
+        Add payment method
+      </button>
+    </a>
+  </p>
+</div>
 
 <p>If you have any questions please contact us via <a href="mailto:billing@weave.works">billing@weave.works</a>
 or through <a href="https://weaveworks.github.io/community-slack/">Slack</a>.</p>

--- a/users/templates/trial_expired_email.text
+++ b/users/templates/trial_expired_email.text
@@ -2,7 +2,7 @@ Hi,
 
 Your free trial of Weave Cloud for ‘{{.OrganizationName}}’ has now come to an end.
 
-But don't worry, to continue using Weave Cloud just add a payment method:
+To continue using Weave Cloud, add a payment method:
 
     {{.BillingURL}}
 

--- a/users/templates/trial_extended_email.html
+++ b/users/templates/trial_extended_email.html
@@ -1,15 +1,19 @@
-<html>
-<head>
-    <title></title>
-</head>
-<body>
 <p>Hi,</p>
 
 <p>Thank you for trying out Weave Cloud! There are just {{.TrialLeft}} left of your trial period for ‘{{.OrganizationName}}’.</p>
 
 <p>Weave Cloud can help you automate, control and monitor your orchestrated applications. If you haven't had a chance to look at it recently, now is a great time to give it another try!</p>
 
-<p>Your free trial period ends on {{.TrialExpiresAt}}. To continue your subscription please <a href="{{.BillingURL}}">add a payment method</a>.
+<p>Your free trial period ends on {{.TrialExpiresAt}}. To continue your subscription please add a payment method:</p>
+<div>
+   <p style="margin-bottom: 24px">
+    <a href="{{.BillingURL}}">
+      <button style="background-color: transparent; outline: none; border: 0; cursor: pointer; background: #049CD7; height: 48px; color: white; padding: 16px;  text-transform: uppercase; border-radius: 4px; border: 1px solid #007EB1; line-height: 1em; font-size: 1em;">
+        Add payment method
+      </button>
+    </a>
+  </p>
+</div>
 
 <p>If you have any questions please contact us via <a href="mailto:billing@weave.works">billing@weave.works</a>
     or through <a href="https://weaveworks.github.io/community-slack/">Slack</a>.</p>

--- a/users/templates/trial_pending_expiry_email.html
+++ b/users/templates/trial_pending_expiry_email.html
@@ -1,13 +1,18 @@
-<html>
-<head>
-    <title></title>
-</head>
-<body>
 <p>Hi,</p>
 
 <p>Your free trial of Weave Cloud for ‘{{.OrganizationName}}’ is almost finished. It will expire in {{.TrialLeft}}, on {{.TrialExpiresAt}}.</p>
 
-<p>To continue your subscription please <a href="{{.BillingURL}}">add a payment method</a>.</p>
+<p>To continue your subscription please add a payment method:</p>
+
+<div>
+   <p style="margin-bottom: 24px">
+    <a href="{{.BillingURL}}">
+      <button style="background-color: transparent; outline: none; border: 0; cursor: pointer; background: #049CD7; height: 48px; color: white; padding: 16px;  text-transform: uppercase; border-radius: 4px; border: 1px solid #007EB1; line-height: 1em; font-size: 1em;">
+        Add payment method
+      </button>
+    </a>
+  </p>
+</div>
 
 <p>If you have any questions please contact us via <a href="mailto:billing@weave.works">billing@weave.works</a>
     or through <a href="https://weaveworks.github.io/community-slack/">Slack</a>.</p>

--- a/users/templates/wrapper.html
+++ b/users/templates/wrapper.html
@@ -1,0 +1,46 @@
+<html>
+
+<head>
+  <title></title>
+</head>
+
+<body style="font-family: Arial, Helvetica, sans-serif; font-size: 16px;">
+  <div style="height: 100%;  display: flex;  flex-direction: column;">
+    <div style="padding: 24px;  background: white;  margin: auto;  margin-top: 48px;  max-width: 600px;  box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24); ">
+      <div style="margin-top: 24px">
+        <img width="213px" height="34px" src="https://s3-us-west-2.amazonaws.com/weaveworks-ui-components/images/weaveworks.png" / />
+      </div>
+      <div>
+        <h2 style="font-size: 28px; line-height: 24px; font-weight: normal">{{.Title}}</h2>
+      </div>
+      <div>
+        {{.Content}}
+      </div>
+      <div style="width: 50%; margin: 0;">
+        <hr style="width: 100%; margin: 16px 0" />
+      </div>
+      <div style="display: inline-block">
+        <a style="text-decoration: none; margin-right: 16px;" href="https://www.facebook.com/WeaveworksInc/" target="_blank">
+          <img style="width: 24px; height: 24px" src="https://s3-us-west-2.amazonaws.com/weaveworks-ui-components/images/facebook-square.png" alt="Facebook_icon_128x128-circle.png" height="32" width="32" constrain="true" imagepreview="false">
+        </a>
+        <a style="text-decoration: none; margin-right: 16px;" href="https://twitter.com/weaveworks?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor" target="_blank">
+          <img style="width: 24px; height: 24px" src="https://s3-us-west-2.amazonaws.com/weaveworks-ui-components/images/twitter-square.png" alt="Twitter_icon_128x128-circle.png" height="32" width="32" constrain="true" imagepreview="false">
+        </a>
+        <a style="text-decoration: none; margin-right: 16px;" href="https://weave-community.slack.com/messages">
+          <img style="width: 24px; height: 24px" src="https://s3-us-west-2.amazonaws.com/weaveworks-ui-components/images/slack.png" alt="googleplus_icon_128x128-circle.png" height="32" width="32" constrain="true" imagepreview="false">
+        </a>
+        <a style="text-decoration: none; margin-right: 16px;" href="https://www.youtube.com/channel/UCmIz9ew1lA3-XDy5FqY-mrA" target="_blank">
+          <img style="width: 24px; height: 24px" src="https://s3-us-west-2.amazonaws.com/weaveworks-ui-components/images/youtube-square.png" alt="Youtube_icon_128x128-circle.png" height="32" width="32" constrain="true" imagepreview="false">
+        </a>
+        <a style="text-decoration: none; margin-right: 16px;" href="https://www.linkedin.com/company-beta/9420084" target="_blank">
+          <img style="width: 24px; height: 24px" src="https://s3-us-west-2.amazonaws.com/weaveworks-ui-components/images/linkedin-square.png" alt="LinkedIn_icon_128x128-circle.png" height="32" width="32" constrain="true" imagepreview="false">
+        </a>
+      </div>
+    </div>
+    <div style="text-align: center; flex-grow: 1; font-size: 9px; margin-top: 24px;">
+      <span>Copyright 2017 Weaveworks</span>
+    </div>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
Fixes #1677 #1377 

Allows for HTML emails to the wrapped for invite, login, and billing emails. The subject line is used as the title.

The primary CTA on each template uses a big blue button. Emails will look similar to this now:
![screen shot 2018-01-10 at 3 43 14 pm](https://user-images.githubusercontent.com/2802257/34801705-ef312656-f61e-11e7-981b-4110643b201c.png)
