### PR TITLE
authfe: Support Bearer token authentication for push endpoints

### DIFF
--- a/users/tokens/generate.go
+++ b/users/tokens/generate.go
@@ -11,6 +11,7 @@ import (
 const (
 	AuthHeaderName = "Authorization"
 	Prefix         = "Scope-Probe token="
+	BearerPrefix   = "Bearer "
 )
 
 var (
@@ -41,6 +42,13 @@ func ExtractToken(r *http.Request) (string, bool) {
 	authHeader := r.Header.Get(AuthHeaderName)
 	if strings.HasPrefix(authHeader, Prefix) {
 		return strings.TrimPrefix(authHeader, Prefix), true
+	}
+
+	// Prometheus can use a bearer token for remote_writes. We use bearer_token_file
+	// as it allows us to not encode the instance token in the prometheus.
+	// https://prometheus.io/docs/prometheus/1.8/configuration/configuration/#<remote_write>
+	if strings.HasPrefix(authHeader, BearerPrefix) {
+		return strings.TrimPrefix(authHeader, BearerPrefix), true
 	}
 
 	// To allow grafana to talk to the service, we also accept basic auth,

--- a/users/tokens/tokens_test.go
+++ b/users/tokens/tokens_test.go
@@ -18,6 +18,7 @@ func Test_ExtractToken(t *testing.T) {
 		{``, "", false},
 		{`Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==`, "open sesame", true},
 		{`Scope-Probe token=oiu38ufoialsmlsi913`, "oiu38ufoialsmlsi913", true},
+		{`Bearer dga91iexj5c751hnnyhhnc9y5a1q19ta`, "dga91iexj5c751hnnyhhnc9y5a1q19ta", true},
 		{`Digest username=Mufasa,qop=auth`, "", false},
 		{`APIKey apiKeyHere`, "", false},
 	}


### PR DESCRIPTION
Bearer tokens are quite widely used for API authentications. The first word of
the Authorization header is then "Bearer" and most APIs don't expect a base64
encoded token in this case.

Prometheus can use a bearer token for remote_writes. We'd like to use
bearer_token_file as it allows us to store the Weave Cloud token in a k8s
Secret and expose it as a file in the prometheus pod.

https://prometheus.io/docs/prometheus/1.8/configuration/configuration/#<remote_write>