### PR TITLE
Send Activated_on_GCP__c to Marketo as a string (instead of a boolean).

### DIFF
--- a/users/marketing/marketo.go
+++ b/users/marketing/marketo.go
@@ -2,6 +2,7 @@ package marketing
 
 import (
 	"encoding/json"
+	"strconv"
 	"time"
 
 	"github.com/FrenchBen/goketo"
@@ -65,7 +66,7 @@ type marketoResponse struct {
 type marketoProspect struct {
 	Email          string `json:"email"`
 	SignupSource   string `json:"Weave_Cloud_Signup_Source__c,omitempty"`
-	ActivatedOnGCP bool   `json:"Activated_on_GCP__c"`
+	ActivatedOnGCP string `json:"Activated_on_GCP__c"`
 	CreatedAt      string `json:"Weave_Cloud_Created_On__c,omitempty"`
 	LastAccess     string `json:"Weave_Cloud_Last_Active__c,omitempty"`
 }
@@ -100,7 +101,7 @@ func (c *MarketoClient) batchUpsertProspect(prospects []prospect) error {
 		leads.Input = append(leads.Input, marketoProspect{
 			Email:          p.Email,
 			SignupSource:   p.SignupSource,
-			ActivatedOnGCP: p.SignupSource == SignupSourceGCP,
+			ActivatedOnGCP: strconv.FormatBool(p.SignupSource == SignupSourceGCP),
 			CreatedAt:      nilTime(p.ServiceCreatedAt),
 			LastAccess:     nilTime(p.ServiceLastAccess),
 		})


### PR DESCRIPTION
Follows-up on #1687.