### PR TITLE
Forward launcher service hostname to launcher-service

### DIFF
--- a/authfe/config.go
+++ b/authfe/config.go
@@ -3,10 +3,11 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/weaveworks/service/common"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/weaveworks/service/common"
 )
 
 // Config is all the config we need to build the routes
@@ -33,6 +34,9 @@ type Config struct {
 	targetOrigin          string
 	allowedOriginSuffixes common.ArrayFlags
 
+	// External hostnames
+	launcherServiceExternalHost string
+
 	// User-visible services - keep alphabetically sorted pls
 	billingAPIHost         proxyConfig
 	billingUIHost          proxyConfig
@@ -44,6 +48,7 @@ type Config struct {
 	gcpWebhookHost         proxyConfig
 	githubReceiverHost     proxyConfig
 	launchGeneratorHost    proxyConfig
+	launcherServiceHost    proxyConfig
 	notificationConfigHost proxyConfig
 	notificationEventHost  proxyConfig
 	notificationSenderHost proxyConfig
@@ -93,10 +98,11 @@ func (c *Config) proxies() map[string]*proxyConfig {
 		"gcp-launcher-webhook": &c.gcpWebhookHost,
 		"github-receiver":      &c.githubReceiverHost,
 		"launch-generator":     &c.launchGeneratorHost,
+		"launcher-service":     &c.launcherServiceHost,
 		"notebooks":            &c.notebooksHost,
 		"notification-configs": &c.notificationConfigHost,
-		"notification-sender":  &c.notificationSenderHost,
 		"notification-events":  &c.notificationEventHost,
+		"notification-sender":  &c.notificationSenderHost,
 		"peer-discovery":       &c.peerDiscoveryHost,
 		"pipe":                 &c.pipeHost,
 		"prom-alertmanager":    &c.promAlertmanagerHost,
@@ -156,6 +162,9 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&c.sendCSPHeader, "send-csp-header", false, "Send \"Content-Security-Policy: default-src https:\" in all responses.")
 	f.StringVar(&c.targetOrigin, "hostname", "", "Hostname through which this server is accessed, for same-origin checks (CSRF protection)")
 	f.Var(&c.allowedOriginSuffixes, "allowed-origin-suffix", "Hostname suffix to permit through same-origin checks (CSRF protection).")
+
+	// External hostnames
+	f.StringVar(&c.launcherServiceExternalHost, "launcher-service-external-host", "get.weave.works", "External hostname used for the launcher service")
 
 	for name, proxyCfg := range c.proxies() {
 		proxyCfg.RegisterFlags(name, f)

--- a/authfe/proxy.go
+++ b/authfe/proxy.go
@@ -34,6 +34,8 @@ func newProxy(cfg proxyConfig) (http.Handler, error) {
 			Director:  func(*http.Request) {},
 			Transport: proxyTransport,
 		}}, nil
+	case "mock":
+		return &mockProxy{cfg}, nil
 	}
 	return nil, fmt.Errorf("Unknown protocol %q for service %s", cfg.protocol, cfg.name)
 }
@@ -175,4 +177,13 @@ func copyStream(dst io.WriteCloser, src io.Reader, wg *sync.WaitGroup, tag strin
 		log.Warningf("%s: error closing connection: %s", tag, err)
 	}
 	log.Debugf("%s: copier exited", tag)
+}
+
+// mockProxy wrties the proxy name in the body for testing
+type mockProxy struct {
+	proxyConfig
+}
+
+func (p *mockProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, p.name)
 }

--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -263,6 +263,15 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 	}
 
 	for _, route := range []Routable{
+		// Launcher service catch-all
+		HostnameSpecific{
+			c.launcherServiceExternalHost,
+			[]PrefixRoutable{
+				Prefix{"/", c.launcherServiceHost},
+			},
+			nil,
+		},
+
 		// special case /demo redirect, which can't be inside a prefix{} rule as otherwise it matches /demo/
 		Path{"/demo", redirect("/demo/")},
 

--- a/authfe/routes_test.go
+++ b/authfe/routes_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	users "github.com/weaveworks/service/users/client"
+)
+
+func TestRoutes(t *testing.T) {
+	// Create mock config
+	cfg := Config{
+		launcherServiceExternalHost: "get.weave.works",
+	}
+	authenticator, err := users.New("mock", "users:4772", users.CachingClientConfig{})
+	assert.NoError(t, err, "Error creating the authenticator")
+
+	// Initialize all of the proxies with mock which wrties the proxy name in the body
+	for name, proxyCfg := range cfg.proxies() {
+		mockProxyCfg := &proxyConfig{
+			name:     name,
+			protocol: "mock",
+		}
+		handler, err := newProxy(*mockProxyCfg)
+		assert.NoError(t, err, "Error creating the proxy")
+		proxyCfg.Handler = handler
+	}
+
+	// Create the routes handler
+	handler, err := routes(cfg, authenticator, nil, nil)
+	assert.NoError(t, err, "Error creating the routes handler")
+
+	tests := []struct {
+		url               string
+		expectedProxyName string
+	}{
+		// HostnameSpecific
+		{"https://get.weave.works/", "launcher-service"},
+		{"https://get.weave.works/bootstrap", "launcher-service"},
+
+		// Weave Cloud
+		{"/", "ui-server"},
+		{"/launch/k8s", "launch-generator"},
+		{"/k8s", "launch-generator"},
+		{"/api/ui/metrics", "ui-metrics"},
+		{"/api/users", "users"},
+	}
+
+	for _, tc := range tests {
+		req, err := http.NewRequest("GET", tc.url, nil)
+		assert.NoError(t, err, "Error creating the request")
+
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, tc.expectedProxyName, rr.Body.String())
+	}
+}

--- a/authfe/routing_utils.go
+++ b/authfe/routing_utils.go
@@ -133,3 +133,20 @@ func (p MiddlewarePrefix) AbsolutePrefixes() []string {
 	}
 	return result
 }
+
+// HostnameSpecific says "only match when the hostname matches"
+type HostnameSpecific struct {
+	hostname string
+	routes   []PrefixRoutable
+	mid      middleware.Interface
+}
+
+// RegisterRoutes adds routes to a router
+func (h HostnameSpecific) RegisterRoutes(r *mux.Router) {
+	if h.mid == nil {
+		h.mid = middleware.Identity
+	}
+	for _, route := range h.routes {
+		r.Host(h.hostname).Handler(h.mid.Wrap(route.Handler()))
+	}
+}


### PR DESCRIPTION
Note: Do not merge until launcher-service in prod https://github.com/weaveworks/service-conf/pull/1825

Forward external hostname request which match the launcher-service hostname (get.weave.works).

- Create HostnameSpecific helper for future use + readability
- Create a route handler for the launcher-service hostname
- Create tests for authfe route handling
