### PR TITLE
Remove differentiated flux v6 routes

### DIFF
--- a/authfe/config.go
+++ b/authfe/config.go
@@ -44,7 +44,6 @@ type Config struct {
 	controlHost            proxyConfig
 	demoHost               proxyConfig
 	fluxHost               proxyConfig
-	fluxV6Host             proxyConfig
 	gcpServiceHost         proxyConfig
 	gcpWebhookHost         proxyConfig
 	githubReceiverHost     proxyConfig
@@ -95,7 +94,6 @@ func (c *Config) proxies() map[string]*proxyConfig {
 		"control":              &c.controlHost,
 		"demo":                 &c.demoHost,
 		"flux":                 &c.fluxHost,
-		"flux-v6":              &c.fluxV6Host,
 		"gcp-launcher-webhook": &c.gcpWebhookHost,
 		"gcp-service":          &c.gcpServiceHost,
 		"github-receiver":      &c.githubReceiverHost,
@@ -171,6 +169,9 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	for name, proxyCfg := range c.proxies() {
 		proxyCfg.RegisterFlags(name, f)
 	}
+
+	// Deprecated
+	_ = f.String("flux-v6", "", "deprecated: set -flux to point to the flux-api service instead")
 }
 
 // ReadEnvVars loads environment variables.

--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -221,8 +221,7 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 			Prefix{"/report", c.collectionHost},
 			Prefix{"/prom/push", c.promDistributorHost},
 			Prefix{"/net/peer", c.peerDiscoveryHost},
-			PrefixMethods{"/flux/{flux_vsn:v[345]}", []string{"POST", "PATCH"}, c.fluxHost},
-			PrefixMethods{"/flux", []string{"POST", "PATCH"}, c.fluxV6Host},
+			PrefixMethods{"/flux", []string{"POST", "PATCH"}, c.fluxHost},
 			PrefixMethods{"/prom/alertmanager/alerts", []string{"POST"}, c.promAlertmanagerHost},
 			PrefixMethods{"/prom/alertmanager/v1/alerts", []string{"POST"}, c.promAlertmanagerHost},
 		},
@@ -240,8 +239,7 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 		Matchables([]Prefix{
 			{"/control", c.controlHost},
 			{"/pipe", c.pipeHost},
-			{"/flux/{flux_vsn:v[345]}", c.fluxHost},
-			{"/flux", c.fluxV6Host},
+			{"/flux", c.fluxHost},
 			{"/prom/alertmanager", c.promAlertmanagerHost},
 			{"/prom/configs", c.promConfigsHost},
 			{"/prom", c.promQuerierHost},
@@ -287,13 +285,10 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 				Prefix{"/api/control", c.controlHost},
 				Prefix{"/api/pipe", c.pipeHost},
 				// API to insert deploy key requires GH token. Insert token with middleware.
-				Prefix{"/api/flux/v5/integrations/github",
-					fluxGHTokenMiddleware.Wrap(c.fluxHost)},
 				Prefix{"/api/flux/{flux_vsn}/integrations/github",
-					fluxGHTokenMiddleware.Wrap(c.fluxV6Host)},
+					fluxGHTokenMiddleware.Wrap(c.fluxHost)},
 				// While we transition to newer Flux API
-				Prefix{"/api/flux/{flux_vsn:v[345]}", c.fluxHost},
-				Prefix{"/api/flux", c.fluxV6Host},
+				Prefix{"/api/flux", c.fluxHost},
 				Prefix{"/api/prom/alertmanager", c.promAlertmanagerHost},
 				Prefix{"/api/prom/configs", c.promConfigsHost},
 				Prefix{"/api/prom/notebooks", c.notebooksHost},
@@ -368,10 +363,10 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 		},
 
 		MiddlewarePrefix{
-			"/api/flux/v6/integrations",
+			"/api/flux/{flux_vsn}/integrations",
 			[]PrefixRoutable{
-				PrefixMethods{"/dockerhub/image", []string{"POST"}, c.fluxV6Host},
-				PrefixMethods{"/quay/image", []string{"POST"}, c.fluxV6Host},
+				PrefixMethods{"/dockerhub/image", []string{"POST"}, c.fluxHost},
+				PrefixMethods{"/quay/image", []string{"POST"}, c.fluxHost},
 			},
 			nil,
 		},


### PR DESCRIPTION
Flux API up to v5 is now deprecated, and all flux routes can point to
the new service (which will handle all the requests correctly).

This commit removes the differentiated routes, and the extra host
argument `-flux-v6`, in favour of all routes pointing to the new
service, as supplied in the argument `-flux`.

The argument `-flux-v6` will still be accepted (in case it lingers in
config), but only `-flux` will be used.