### PR TITLE
Add ca-certificates to gcp-service.

### DIFF
--- a/gcp-service/Dockerfile
+++ b/gcp-service/Dockerfile
@@ -6,6 +6,7 @@ LABEL org.label-schema.name="gcp-service" \
         org.label-schema.vendor="Weaveworks" \
         org.label-schema.schema-version="1.0"
 
+RUN apk add --no-cache -q ca-certificates
 WORKDIR /
 COPY gcp-service /
 EXPOSE 80


### PR DESCRIPTION
Fixes errors like:
```
x509: failed to load system roots and no roots provided
```
happening when calling Google's APIs.
Indeed, these calls are done over HTTPS and:

- Alpine doesn't come with ca-certificates by default
- Go doesn't ship with these either (unlike, for example Python's `requests` package), but looks for some on the OS (which were missing prior to this PR).

Improves on #1685.
Related to #1431.