### PR TITLE
Add ca-certificates to kubectl-service.

### DIFF
--- a/kubectl-service/Dockerfile
+++ b/kubectl-service/Dockerfile
@@ -6,6 +6,8 @@ LABEL org.label-schema.name="kubectl-service" \
         org.label-schema.vendor="Weaveworks" \
         org.label-schema.schema-version="1.0"
 
+RUN apk add --no-cache -q ca-certificates
+
 RUN mkdir kubectl
 WORKDIR /kubectl
 


### PR DESCRIPTION
Fixes errors like:
```
Unable to connect to the server: x509: failed to load system roots and no roots provided"
```
happening when running `kubectl` commands to remote GKE clusters.
Indeed, these calls are done over HTTPS and:

- Alpine doesn't come with ca-certificates by default
- `kubectl` is written in Go
- Go doesn't ship with these either, but looks for some on the OS (which were missing prior to this commit).

Improves on #1685.
Related to #1431.