### PR TITLE
users: Create org lookup via token

### DIFF
--- a/users/api/org.go
+++ b/users/api/org.go
@@ -386,3 +386,12 @@ func (a *API) extendOrgTrialPeriod(ctx context.Context, org *users.Organization,
 
 	return nil
 }
+
+type orgLookupView struct {
+	ExternalID string `json:"externalID"`
+}
+
+func (a *API) orgLookup(org *users.Organization, w http.ResponseWriter, r *http.Request) {
+	view := orgLookupView{ExternalID: org.ExternalID}
+	render.JSON(w, http.StatusOK, view)
+}

--- a/users/api/org_test.go
+++ b/users/api/org_test.go
@@ -497,3 +497,23 @@ func Test_Organization_CreateTeam(t *testing.T) {
 	assert.Equal(t, body.Teams[0].ExternalID, organizations[0].TeamExternalID)
 	assert.Equal(t, body.Teams[0].Name, teamName)
 }
+
+func Test_Organization_Lookup(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	user := getUser(t)
+	org := createOrgForUser(t, user)
+
+	request, err := http.NewRequest("GET", "/api/users/org/lookup", nil)
+	require.NoError(t, err)
+	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", org.ProbeToken))
+
+	w := httptest.NewRecorder()
+	app.ServeHTTP(w, request)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	body := map[string]interface{}{}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, org.ExternalID, body["externalID"])
+}

--- a/users/api/routes.go
+++ b/users/api/routes.go
@@ -51,6 +51,9 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 
 		{"api_users_teams", "GET", "/api/users/teams", a.authenticateUser(a.listTeams)},
 
+		// Used by the launcher agent to get the external instance ID using a token
+		{"api_users_org_token_lookup", "GET", "/api/users/org/lookup", a.authenticateProbe(a.orgLookup)},
+
 		// Basic view and management of an organization
 		{"api_users_generateOrgName", "GET", "/api/users/generateOrgName", a.authenticateUser(a.generateOrgExternalID)},
 		{"api_users_generateOrgID", "GET", "/api/users/generateOrgID", a.authenticateUser(a.generateOrgExternalID)},


### PR DESCRIPTION
Allow agent to get org ExternalID via token auth.

https://github.com/weaveworks/launcher/issues/25