### PR TITLE
Allow github deploy key to have custom name

### DIFF
--- a/flux-api/http/server.go
+++ b/flux-api/http/server.go
@@ -314,11 +314,12 @@ func (s httpService) History(w http.ResponseWriter, r *http.Request) {
 
 func (s httpService) PostIntegrationsGithub(w http.ResponseWriter, r *http.Request) {
 	var (
-		ctx   = getRequestContext(r)
-		vars  = mux.Vars(r)
-		owner = vars["owner"]
-		repo  = vars["repository"]
-		tok   = r.Header.Get("GithubToken")
+		ctx     = getRequestContext(r)
+		vars    = mux.Vars(r)
+		owner   = vars["owner"]
+		repo    = vars["repository"]
+		keyname = vars["keyname"]
+		tok     = r.Header.Get("GithubToken")
 	)
 
 	if repo == "" || owner == "" || tok == "" {
@@ -338,7 +339,7 @@ func (s httpService) PostIntegrationsGithub(w http.ResponseWriter, r *http.Reque
 	// clean way of injecting without significantly altering
 	// the initialisation (at the top)
 	gh := github.NewGithubClient(tok)
-	err = gh.InsertDeployKey(owner, repo, publicKey.Key)
+	err = gh.InsertDeployKey(owner, repo, publicKey.Key, keyname)
 	if err != nil {
 		httpErr, isHTTPErr := err.(*httperror.APIError)
 		code := http.StatusInternalServerError

--- a/flux-api/integrations/github/github.go
+++ b/flux-api/integrations/github/github.go
@@ -12,9 +12,9 @@ import (
 )
 
 var (
-	deployKeyName   = "flux-generated"
-	errUnauthorized = httperror.APIError{
-		Body: "Unable to list deploy keys. Permission deined. Check user token.",
+	defaultDeployKeyName = "flux-generated"
+	errUnauthorized      = httperror.APIError{
+		Body: "Unable to list deploy keys. Permission denied. Check user token.",
 	}
 	errNotFound = httperror.APIError{
 		Body: "Cannot find owner or repository. Check spelling.",
@@ -41,10 +41,14 @@ func NewGithubClient(token string) *Github {
 	}
 }
 
-// InsertDeployKey will create a new deploy key for the given owner,
-// repo, token using the key deployKey.
-// If a key already exists with that name it will be deleted.
-func (g *Github) InsertDeployKey(ownerName string, repoName string, deployKey string) error {
+// InsertDeployKey will create a new deploy key titled `deployKeyName`
+// (or defaultDeployKeyName if that argument is empty) for the given
+// owner, repo, token, containing the public key `deployKey`.  If a
+// key already exists with that title it will be deleted first.
+func (g *Github) InsertDeployKey(ownerName string, repoName string, deployKey, deployKeyName string) error {
+	if deployKeyName == "" {
+		deployKeyName = defaultDeployKeyName
+	}
 	// Get list of keys
 	keys, resp, err := g.client.Repositories.ListKeys(ownerName, repoName, nil)
 	if err != nil {

--- a/flux-api/integrations/github/github_test.go
+++ b/flux-api/integrations/github/github_test.go
@@ -70,7 +70,7 @@ func TestInsertDeployKey_KeyDoesntExist(t *testing.T) {
 		client: client,
 	}
 
-	err := g.InsertDeployKey("o", "r", "ssh-rsa AAA")
+	err := g.InsertDeployKey("o", "r", "ssh-rsa AAA", "test-deploy-key")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,13 +88,13 @@ func TestInsertDeployKey_KeyDoesntExist(t *testing.T) {
 func TestInsertDeployKey_KeyDoesExist(t *testing.T) {
 	setup()
 	defer teardown()
-	initHandlers(t, deployKeyName)
+	initHandlers(t, "test-deploy-key")
 
 	g := Github{
 		client: client,
 	}
 
-	err := g.InsertDeployKey("o", "r", "ssh-rsa AAA")
+	err := g.InsertDeployKey("o", "r", "ssh-rsa AAA", "test-deploy-key")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
If more than one cluster is using the same github repo, using the button to install the deploy key will overwrite one of them.

To avoid this, we can name the keys for the instances; this adds an optional argument to the github integration endpoint to do just that.
