### PR TITLE
 Fix billing e2e test

### DIFF
--- a/common/time/time.go
+++ b/common/time/time.go
@@ -86,7 +86,7 @@ func MonthlyIntervalsWithinRange(from, to time.Time, cycleDay int) ([]Interval, 
 	if !from.Before(to) {
 		return nil, errors.New("from must be lower than to")
 	}
-	if cycleDay < 1 && cycleDay > 31 {
+	if cycleDay < 1 || cycleDay > 31 {
 		return nil, errors.New("day must be within [1, 31]")
 	}
 	var intervals []Interval
@@ -98,6 +98,7 @@ func MonthlyIntervalsWithinRange(from, to time.Time, cycleDay int) ([]Interval, 
 	return intervals, nil
 }
 
+// IsEndOfMonth checks whether the given date is the last day of this month.
 func IsEndOfMonth(t time.Time) bool {
 	return DaysIn(t.Month(), t.Year()) == t.Day()
 }

--- a/common/time/time_test.go
+++ b/common/time/time_test.go
@@ -263,7 +263,7 @@ func TestNextCycleDay(t *testing.T) {
 		{dateStr: "2016-02-13 23:59:59", cycleDay: 28}: "2016-02-28 00:00:00",
 		{dateStr: "2017-12-13 11:45:12", cycleDay: 31}: "2017-12-31 00:00:00",
 		{dateStr: "2017-12-13 23:00:00", cycleDay: 6}:  "2018-01-06 00:00:00",
-		{dateStr: "2017-11-30 00:00:00", cycleDay: 31}:  "2017-12-31 00:00:00",
+		{dateStr: "2017-11-30 00:00:00", cycleDay: 31}: "2017-12-31 00:00:00",
 	} {
 		reference := ts(t, input.dateStr)
 		expected := ts(t, expectedStr)


### PR DESCRIPTION
This commit fixes the case for a billing cycle day of 31 while we
are computing the start of the next cycle when looking at the last day
of a month with 30 days.

NextCycleStart(2017-11-30, 31) did previously return 2017-11-30 and it
now returns 2017-12-31.


Fixes #1719