### PR TITLE
Forward campaign and lead source GET params to Marketo when signing up

### DIFF
--- a/users/api/login.go
+++ b/users/api/login.go
@@ -310,7 +310,7 @@ func (a *API) Signup(ctx context.Context, req SignupRequest) (*SignupResponse, *
 		}
 		user, err = a.db.CreateUser(ctx, email)
 		if err == nil {
-			a.marketingQueues.UserCreated(user.Email, user.CreatedAt, nil)
+			a.marketingQueues.UserCreated(user.Email, user.CreatedAt, req.QueryParams)
 			if a.mixpanel != nil {
 				go func() {
 					if err := a.mixpanel.TrackSignup(email); err != nil {

--- a/users/marketing/marketo.go
+++ b/users/marketing/marketo.go
@@ -69,6 +69,8 @@ type marketoProspect struct {
 	ActivatedOnGCP string `json:"Activated_on_GCP__c"`
 	CreatedAt      string `json:"Weave_Cloud_Created_On__c,omitempty"`
 	LastAccess     string `json:"Weave_Cloud_Last_Active__c,omitempty"`
+	LeadSource     string `json:"Lead_Source__c,omitempty"`
+	CampaignID     string `json:"salesforceCampaignID,omitempty"`
 }
 
 func (m *marketoResponse) Error() string {
@@ -104,6 +106,8 @@ func (c *MarketoClient) batchUpsertProspect(prospects []prospect) error {
 			ActivatedOnGCP: strconv.FormatBool(p.SignupSource == SignupSourceGCP),
 			CreatedAt:      nilTime(p.ServiceCreatedAt),
 			LastAccess:     nilTime(p.ServiceLastAccess),
+			LeadSource:     p.LeadSource,
+			CampaignID:     p.CampaignID,
 		})
 	}
 	req, err := json.Marshal(leads)

--- a/users/marketing/queue.go
+++ b/users/marketing/queue.go
@@ -32,6 +32,8 @@ type prospect struct {
 	SignupSource      string    `json:"signupSource"`
 	ServiceCreatedAt  time.Time `json:"createdAt"`
 	ServiceLastAccess time.Time `json:"lastAccess"`
+	CampaignID        string    `json:"campaignId"`
+	LeadSource        string    `json:"leadSource"`
 }
 
 func (p1 prospect) merge(p2 prospect) prospect {
@@ -50,12 +52,22 @@ func (p1 prospect) merge(p2 prospect) prospect {
 	if signupSource == "" {
 		signupSource = p2.SignupSource
 	}
+	leadSource := p1.LeadSource
+	if leadSource == "" {
+		leadSource = p2.LeadSource
+	}
+	campaignID := p1.CampaignID
+	if campaignID == "" {
+		campaignID = p2.CampaignID
+	}
 
 	return prospect{
 		Email:             email,
 		SignupSource:      signupSource,
 		ServiceCreatedAt:  latest(p1.ServiceCreatedAt, p2.ServiceCreatedAt),
 		ServiceLastAccess: latest(p1.ServiceLastAccess, p2.ServiceLastAccess),
+		CampaignID:        campaignID,
+		LeadSource:        leadSource,
 	}
 }
 
@@ -201,6 +213,8 @@ func (c *Queue) UserCreated(email string, createdAt time.Time, params map[string
 		Email:            email,
 		SignupSource:     signupSource(params),
 		ServiceCreatedAt: createdAt,
+		CampaignID:       params["CampaignID"],
+		LeadSource:       params["LeadSource"],
 	})
 	c.cond.Broadcast()
 }


### PR DESCRIPTION
This sends the `CampaignID` and `LeadSource` GET parameter passed to `/login?CampaignID=123&LeadSource=foo` and `/signup?CampaignID=123&LeadSource=foo` to Marketo if the user creates a new account.

Fixes #1710