### PR TITLE
Add rbtrace to billing ingester to enable memory leak debugging

### DIFF
--- a/billing-ingester/Dockerfile
+++ b/billing-ingester/Dockerfile
@@ -11,6 +11,13 @@ RUN \
     gem install bigdecimal 'fluent-plugin-bigquery: < 1.0.0' && \
     apk del --no-cache g++ make ruby-dev
 
+# Install & inject rbtrace so that we can debug memory leaks in a running process!
+RUN \
+    apk add --no-cache g++ make ruby-dev autoconf automake libtool && \
+    gem install rbtrace && \
+    sed -i -E "/^load /i require 'rbtrace'" /usr/bin/fluentd && \
+    apk del --no-cache g++ make ruby-dev autoconf automake libtool
+
 # Cleanup
 WORKDIR /home/fluent
 COPY schema_events.json /bigquery/


### PR DESCRIPTION
Context: https://weaveworks.slack.com/archives/C0CG6Q4BG/p1518116180000625

Here's how we'd use it: https://samsaffron.com/archive/2015/03/31/debugging-memory-leaks-in-ruby

Should only be a temporary measure