### PR TITLE
Marketo client should not unset Activated_on_GCP__c

### DIFF
--- a/users/marketing/marketo.go
+++ b/users/marketing/marketo.go
@@ -67,7 +67,7 @@ type marketoResponse struct {
 type marketoProspect struct {
 	Email          string `json:"email"`
 	SignupSource   string `json:"Weave_Cloud_Signup_Source__c,omitempty"`
-	ActivatedOnGCP int    `json:"Activated_on_GCP__c"`
+	ActivatedOnGCP int    `json:"Activated_on_GCP__c,omitempty"`
 	CreatedAt      string `json:"Weave_Cloud_Created_On__c,omitempty"`
 	LastAccess     string `json:"Weave_Cloud_Last_Active__c,omitempty"`
 	LeadSource     string `json:"Lead_Source__c,omitempty"`

--- a/users/marketing/marketo_test.go
+++ b/users/marketing/marketo_test.go
@@ -25,7 +25,7 @@ func (m *mockGoketoClient) Post(resource string, data []byte) ([]byte, error) {
 
 var today = time.Date(2018, time.February, 12, 0, 0, 0, 0, time.UTC)
 
-func TestBatchUpsertOneProspect(t *testing.T) {
+func TestBatchUpsertOneProspectComingFromGCPShouldSet_Activated_on_GCP__c(t *testing.T) {
 	mock := &mockGoketoClient{}
 	client := marketing.NewMarketoClient(mock, "test")
 	client.BatchUpsertProspect([]marketing.Prospect{
@@ -39,6 +39,23 @@ func TestBatchUpsertOneProspect(t *testing.T) {
 		},
 	})
 	expectedReq := "{\"programName\":\"test\",\"lookupField\":\"email\",\"input\":[{\"email\":\"foo@bar.com\",\"Weave_Cloud_Signup_Source__c\":\"gcp\",\"Activated_on_GCP__c\":1,\"Weave_Cloud_Created_On__c\":\"2018-02-12\",\"Weave_Cloud_Last_Active__c\":\"2018-02-12\",\"Lead_Source__c\":\"baz\",\"salesforceCampaignID\":\"123\"}]}"
+	assert.Equal(t, expectedReq, string(mock.LatestReq))
+}
+
+func TestBatchUpsertOneProspectNotComingFromGCPShouldNotUnset_Activated_on_GCP__c(t *testing.T) {
+	mock := &mockGoketoClient{}
+	client := marketing.NewMarketoClient(mock, "test")
+	client.BatchUpsertProspect([]marketing.Prospect{
+		{
+			Email:             "foo@bar.com",
+			SignupSource:      "earth",
+			ServiceCreatedAt:  today,
+			ServiceLastAccess: today,
+			CampaignID:        "123",
+			LeadSource:        "baz",
+		},
+	})
+	expectedReq := "{\"programName\":\"test\",\"lookupField\":\"email\",\"input\":[{\"email\":\"foo@bar.com\",\"Weave_Cloud_Signup_Source__c\":\"earth\",\"Weave_Cloud_Created_On__c\":\"2018-02-12\",\"Weave_Cloud_Last_Active__c\":\"2018-02-12\",\"Lead_Source__c\":\"baz\",\"salesforceCampaignID\":\"123\"}]}"
 	assert.Equal(t, expectedReq, string(mock.LatestReq))
 }
 
@@ -63,6 +80,6 @@ func TestBatchUpsertManyProspects(t *testing.T) {
 			LeadSource:        "pretzel",
 		},
 	})
-	expectedReq := "{\"programName\":\"test\",\"lookupField\":\"email\",\"input\":[{\"email\":\"foo@bar.com\",\"Weave_Cloud_Signup_Source__c\":\"gcp\",\"Activated_on_GCP__c\":1,\"Weave_Cloud_Created_On__c\":\"2018-02-12\",\"Weave_Cloud_Last_Active__c\":\"2018-02-12\",\"Lead_Source__c\":\"baz\",\"salesforceCampaignID\":\"123\"},{\"email\":\"donald@trump.com\",\"Weave_Cloud_Signup_Source__c\":\"whitehouse\",\"Activated_on_GCP__c\":0,\"Weave_Cloud_Created_On__c\":\"2018-02-12\",\"Weave_Cloud_Last_Active__c\":\"2018-02-12\",\"Lead_Source__c\":\"pretzel\",\"salesforceCampaignID\":\"US presidential 456\"}]}"
+	expectedReq := "{\"programName\":\"test\",\"lookupField\":\"email\",\"input\":[{\"email\":\"foo@bar.com\",\"Weave_Cloud_Signup_Source__c\":\"gcp\",\"Activated_on_GCP__c\":1,\"Weave_Cloud_Created_On__c\":\"2018-02-12\",\"Weave_Cloud_Last_Active__c\":\"2018-02-12\",\"Lead_Source__c\":\"baz\",\"salesforceCampaignID\":\"123\"},{\"email\":\"donald@trump.com\",\"Weave_Cloud_Signup_Source__c\":\"whitehouse\",\"Weave_Cloud_Created_On__c\":\"2018-02-12\",\"Weave_Cloud_Last_Active__c\":\"2018-02-12\",\"Lead_Source__c\":\"pretzel\",\"salesforceCampaignID\":\"US presidential 456\"}]}"
 	assert.Equal(t, expectedReq, string(mock.LatestReq))
 }


### PR DESCRIPTION
Prior to this PR, having no signup source would have proactively unset `Activated_on_GCP__c`, while the intended behaviour is to just set it to `true` if the source is `"gcp"`, but ignore otherwise.

This PR also:

- adds tests to cover for this bug,
- reverts a previous commit introduced to debug this issue.

Fixes #1754.