### PR TITLE
authfe: Log orgID in launcherRequests

### DIFF
--- a/authfe/logger.go
+++ b/authfe/logger.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/weaveworks/common/logging"
+	"github.com/weaveworks/common/user"
+	"github.com/weaveworks/service/users"
+)
+
+// ifEmpty(a,b) returns b iff a is empty
+func ifEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}
+
+func newLauncherServiceLogger(usersClient users.UsersClient) HTTPEventExtractor {
+	return func(r *http.Request) (Event, bool) {
+		var orgID string
+
+		externalID := r.URL.Query().Get("instanceID")
+		if externalID != "" {
+			// Lookup the internal OrgID
+			response, err := usersClient.GetOrganization(r.Context(), &users.GetOrganizationRequest{
+				ID: &users.GetOrganizationRequest_ExternalID{ExternalID: externalID},
+			})
+			if err != nil {
+				logging.With(r.Context()).Errorf("launcherServiceLogger: Failed to lookup externalID: %s", externalID)
+			} else {
+				orgID = response.Organization.ID
+			}
+		}
+
+		event := Event{
+			ID:             r.URL.Path,
+			Product:        "launcher-service",
+			UserAgent:      r.UserAgent(),
+			OrganizationID: orgID,
+			IPAddress:      mustSplitHostname(r),
+		}
+		return event, true
+	}
+}
+
+func newProbeRequestLogger() HTTPEventExtractor {
+	return func(r *http.Request) (Event, bool) {
+		orgID, err := user.ExtractOrgID(r.Context())
+		if err != nil {
+			return Event{}, false
+		}
+
+		event := Event{
+			ID:             r.URL.Path,
+			Product:        "scope-probe",
+			Version:        r.Header.Get(probeVersionHeader),
+			UserAgent:      r.UserAgent(),
+			ClientID:       r.Header.Get(probeIDHeader),
+			OrganizationID: orgID,
+			IPAddress:      mustSplitHostname(r),
+		}
+		return event, true
+	}
+}
+
+func newUIRequestLogger(userIDHeader string) HTTPEventExtractor {
+	return func(r *http.Request) (Event, bool) {
+		sessionCookie, err := r.Cookie(sessionCookieKey)
+		var sessionID string
+		if err == nil {
+			sessionID = sessionCookie.Value
+		}
+
+		orgID, _ := user.ExtractOrgID(r.Context())
+
+		event := Event{
+			ID:             r.URL.Path,
+			SessionID:      sessionID,
+			Product:        "scope-ui",
+			UserAgent:      r.UserAgent(),
+			OrganizationID: orgID,
+			UserID:         r.Header.Get(userIDHeader),
+			IPAddress:      mustSplitHostname(r),
+		}
+		return event, true
+	}
+}
+
+func newAnalyticsLogger(userIDHeader string) HTTPEventExtractor {
+	return func(r *http.Request) (Event, bool) {
+		sessionCookie, err := r.Cookie(sessionCookieKey)
+		var sessionID string
+		if err == nil {
+			sessionID = sessionCookie.Value
+		}
+
+		values, err := ioutil.ReadAll(&io.LimitedReader{
+			R: r.Body,
+			N: maxAnalyticsPayloadSize,
+		})
+		if err != nil {
+			return Event{}, false
+		}
+
+		event := Event{
+			ID:        r.URL.Path,
+			SessionID: sessionID,
+			Product:   "scope-ui",
+			UserAgent: r.UserAgent(),
+			UserID:    r.Header.Get(userIDHeader),
+			Values:    string(values),
+			IPAddress: mustSplitHostname(r),
+		}
+		return event, true
+	}
+}

--- a/authfe/logger_test.go
+++ b/authfe/logger_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/weaveworks/service/users"
+	"github.com/weaveworks/service/users/mock_users"
+)
+
+func TestNewLauncherServiceLogger(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	u := mock_users.NewMockUsersClient(ctrl)
+	u.EXPECT().
+		GetOrganization(gomock.Any(), &users.GetOrganizationRequest{
+			ID: &users.GetOrganizationRequest_ExternalID{ExternalID: "external-id-1"},
+		}).
+		Return(&users.GetOrganizationResponse{
+			Organization: users.Organization{ID: "2"},
+		}, nil)
+
+	logger := newLauncherServiceLogger(u)
+	req, err := http.NewRequest("GET", "https://get.weave.works/k8s/example.yaml?foo=1&instanceID=external-id-1", nil)
+	assert.NoError(t, err)
+
+	event, success := logger(req)
+	assert.Equal(t, event, Event{
+		ID:             "/k8s/example.yaml",
+		Product:        "launcher-service",
+		UserAgent:      "",
+		OrganizationID: "2",
+		IPAddress:      "",
+	})
+	assert.Equal(t, success, true)
+}


### PR DESCRIPTION
Log orgID in launcherRequests so we can calculate agent adoption and have been logs for the agent.

If no `instanceID` query parameter exists, continue as usual.

PR which starts sending this queryParam: https://github.com/weaveworks/launcher/pull/113