### PR TITLE
Pass "keyname" down to the next layer of the go web framework

### DIFF
--- a/flux-api/http/server.go
+++ b/flux-api/http/server.go
@@ -318,7 +318,7 @@ func (s httpService) PostIntegrationsGithub(w http.ResponseWriter, r *http.Reque
 		vars    = mux.Vars(r)
 		owner   = vars["owner"]
 		repo    = vars["repository"]
-		keyname = vars["keyname"]
+		keyname = r.FormValue("keyname")
 		tok     = r.Header.Get("GithubToken")
 	)
 


### PR DESCRIPTION
Then it will send it off to github. And we won't have any more keyname clashes!