### PR TITLE
Add Org name to lookup API

### DIFF
--- a/users/api/org.go
+++ b/users/api/org.go
@@ -389,10 +389,11 @@ func (a *API) extendOrgTrialPeriod(ctx context.Context, org *users.Organization,
 }
 
 type orgLookupView struct {
+	Name       string `json:"name"`
 	ExternalID string `json:"externalID"`
 }
 
 func (a *API) orgLookup(org *users.Organization, w http.ResponseWriter, r *http.Request) {
-	view := orgLookupView{ExternalID: org.ExternalID}
+	view := orgLookupView{Name: org.Name, ExternalID: org.ExternalID}
 	render.JSON(w, http.StatusOK, view)
 }

--- a/users/api/org_test.go
+++ b/users/api/org_test.go
@@ -516,4 +516,5 @@ func Test_Organization_Lookup(t *testing.T) {
 	body := map[string]interface{}{}
 	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
 	assert.Equal(t, org.ExternalID, body["externalID"])
+	assert.Equal(t, org.Name, body["name"])
 }


### PR DESCRIPTION
This will allow us to use the org name in the launcher bootstrap and agent programs, to build more Human-friendly output.