### PR TITLE
flux-api: Don't show skipped resources in slack notifications

### DIFF
--- a/flux-api/notifications/slack.go
+++ b/flux-api/notifications/slack.go
@@ -231,7 +231,7 @@ func getUpdatePolicyMessage(revision string, resource flux.ResourceID, upd polic
 
 func slackResultAttachment(res update.Result) slackAttachment {
 	buf := &bytes.Buffer{}
-	update.PrintResults(buf, res, 1)
+	update.PrintResults(buf, res, 0)
 	c := "good"
 	if res.Error() != "" {
 		c = "warning"


### PR DESCRIPTION
We were missing a part in the Big Flux Output Cleanup. Telling the slack code
to not include the skipped resources in the notification text.