### PR TITLE
dashboards: Add a Go runtime dashboard

### DIFF
--- a/dashboard-api/dashboard/dashboard.go
+++ b/dashboard-api/dashboard/dashboard.go
@@ -116,6 +116,7 @@ func GetServiceDashboards(metrics []string, namespace, workload string) ([]Dashb
 func Init() {
 	registerProviders(
 		cadvisor,
+		goRuntime,
 	)
 }
 

--- a/dashboard-api/dashboard/go.go
+++ b/dashboard-api/dashboard/go.go
@@ -1,0 +1,73 @@
+package dashboard
+
+// This dashboard displays metrics "by pod", all line graphs, a line per pod.
+var goRuntimeDashboard = Dashboard{
+	ID:   "go-runtime",
+	Name: "Go",
+	Sections: []Section{{
+		Name: "Concurrency",
+		Rows: []Row{{
+			Panels: []Panel{{
+				Title: "Number of Goroutines",
+				Type:  PanelLine,
+				Query: `go_goroutines{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}`,
+			}},
+		}},
+	}, {
+		Name: "Memory",
+		Rows: []Row{{
+			Panels: []Panel{{
+				Title: "Heap Size",
+				Type:  PanelLine,
+				Query: `go_memstats_heap_alloc_bytes{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}`,
+			}, {
+				Title: "Number of Heap Objects",
+				Type:  PanelLine,
+				Query: `go_memstats_heap_objects{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}`,
+			}},
+		}, {
+			Panels: []Panel{{
+				Title: "Number of Heap Objects Allocated per Second",
+				Type:  PanelLine,
+				Query: `rate(go_memstats_mallocs_total{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}])`,
+			}, {
+				Title: "Number of Heap Objects Freed per Second",
+				Type:  PanelLine,
+				Query: `rate(go_memstats_frees_total{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}])`,
+			}},
+		}},
+	}, {
+		Name: "Garbage Collector",
+		Rows: []Row{{
+			Panels: []Panel{{
+				Title: "Time spent in GC each Second",
+				Type:  PanelLine,
+				Query: `irate(go_gc_duration_seconds_sum{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}])`,
+			}},
+		}, {
+			Panels: []Panel{{
+				Title: "Number of GC Cycles per Second",
+				Type:  PanelLine,
+				Query: `irate(go_gc_duration_seconds_count{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}])`,
+			}, {
+				Title: "Duration (75 percentile)",
+				Type:  PanelLine,
+				Query: `go_gc_duration_seconds{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}',quantile='0.75'}`,
+			}},
+		}},
+	}},
+}
+
+var goRuntime = &staticProvider{
+	requiredMetrics: []string{
+		"go_goroutines",
+		"go_memstats_heap_alloc_bytes",
+		"go_memstats_heap_objects",
+		"go_memstats_mallocs_total",
+		"go_memstats_frees_total",
+		"go_gc_duration_seconds_sum",
+		"go_gc_duration_seconds_count",
+		"go_gc_duration_seconds",
+	},
+	dashboard: goRuntimeDashboard,
+}

--- a/dashboard-api/dashboard/testdata/TestGolden-go-runtime.golden
+++ b/dashboard-api/dashboard/testdata/TestGolden-go-runtime.golden
@@ -1,0 +1,81 @@
+{
+  "id": "go-runtime",
+  "name": "Go",
+  "sections": [
+    {
+      "name": "Concurrency",
+      "rows": [
+        {
+          "panels": [
+            {
+              "title": "Number of Goroutines",
+              "type": "line",
+              "query": "go_goroutines{kubernetes_namespace='default',_weave_service='authfe'}"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Memory",
+      "rows": [
+        {
+          "panels": [
+            {
+              "title": "Heap Size",
+              "type": "line",
+              "query": "go_memstats_heap_alloc_bytes{kubernetes_namespace='default',_weave_service='authfe'}"
+            },
+            {
+              "title": "Number of Heap Objects",
+              "type": "line",
+              "query": "go_memstats_heap_objects{kubernetes_namespace='default',_weave_service='authfe'}"
+            }
+          ]
+        },
+        {
+          "panels": [
+            {
+              "title": "Number of Heap Objects Allocated per Second",
+              "type": "line",
+              "query": "rate(go_memstats_mallocs_total{kubernetes_namespace='default',_weave_service='authfe'}[2m])"
+            },
+            {
+              "title": "Number of Heap Objects Freed per Second",
+              "type": "line",
+              "query": "rate(go_memstats_frees_total{kubernetes_namespace='default',_weave_service='authfe'}[2m])"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Garbage Collector",
+      "rows": [
+        {
+          "panels": [
+            {
+              "title": "Time spent in GC each Second",
+              "type": "line",
+              "query": "irate(go_gc_duration_seconds_sum{kubernetes_namespace='default',_weave_service='authfe'}[2m])"
+            }
+          ]
+        },
+        {
+          "panels": [
+            {
+              "title": "Number of GC Cycles per Second",
+              "type": "line",
+              "query": "irate(go_gc_duration_seconds_count{kubernetes_namespace='default',_weave_service='authfe'}[2m])"
+            },
+            {
+              "title": "Duration (75 percentile)",
+              "type": "line",
+              "query": "go_gc_duration_seconds{kubernetes_namespace='default',_weave_service='authfe',quantile='0.75'}"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Something basic, so we can show off a second dashboard.

![screenshot from 2018-03-09 15-34-41](https://user-images.githubusercontent.com/7986/37215308-7ffa72b0-23af-11e8-9424-e821ca38610a.png)

Fixes: #1819