### PR TITLE
Bill in any currency

### DIFF
--- a/billing-api/routes/accounts_test.go
+++ b/billing-api/routes/accounts_test.go
@@ -161,7 +161,11 @@ func TestEstimatedMonthlyUsage(t *testing.T) {
 	ti := date(2017, time.December, 21)
 	start := date(2017, time.December, 1)
 	now := time.Date(2017, 12, 21, 12, 0, 0, 0, time.UTC)
-	var usage float64
+	currency := "USD"
+	rates := map[string]float64{
+		currency: float64(1),
+	}
+	var usage string
 	daily := map[string]int64{
 		"2017-12-01": 400,
 		"2017-12-20": 600,
@@ -182,31 +186,31 @@ func TestEstimatedMonthlyUsage(t *testing.T) {
 	{ // same day
 		aggs[0].BucketStart = ti
 		aggs[1].BucketStart = ti.Add(time.Hour)
-		usage = estimatedMonthlyUsage(daily, start, aggs, 1, 1, now)
-		assert.Equal(t, float64(1330), usage)
+		usage = estimatedMonthlyUsages(daily, start, aggs, 1, rates, now)[currency]
+		assert.Equal(t, "1330", usage)
 
 		// two days, second day had no usage
-		usage = estimatedMonthlyUsage(daily, start, aggs, 2, 1, now)
-		assert.Equal(t, float64(1165), usage)
+		usage = estimatedMonthlyUsages(daily, start, aggs, 2, rates, now)[currency]
+		assert.Equal(t, "1165", usage)
 	}
 	{ // consecutive day
 		aggs[0].BucketStart = ti
 		aggs[1].BucketStart = ti.Add(24 * time.Hour)
-		usage = estimatedMonthlyUsage(daily, start, aggs, 2, 1, now)
-		assert.Equal(t, float64(1165), usage)
+		usage = estimatedMonthlyUsages(daily, start, aggs, 2, rates, now)[currency]
+		assert.Equal(t, "1165", usage)
 
 		// third day empty
-		usage = estimatedMonthlyUsage(daily, start, aggs, 3, 1, now)
-		assert.Equal(t, float64(1110), usage)
+		usage = estimatedMonthlyUsages(daily, start, aggs, 3, rates, now)[currency]
+		assert.Equal(t, "1110", usage)
 	}
 	{ // skip day
 		aggs[0].BucketStart = ti
 		aggs[1].BucketStart = ti.Add(2 * 24 * time.Hour)
-		usage = estimatedMonthlyUsage(daily, start, aggs, 3, 1, now)
-		assert.Equal(t, float64(1110), usage)
+		usage = estimatedMonthlyUsages(daily, start, aggs, 3, rates, now)[currency]
+		assert.Equal(t, "1110", usage)
 
 		// fourth day empty
-		usage = estimatedMonthlyUsage(daily, start, aggs, 4, 1, now)
-		assert.Equal(t, float64(1082.5), usage)
+		usage = estimatedMonthlyUsages(daily, start, aggs, 4, rates, now)[currency]
+		assert.Equal(t, "1083", usage)
 	}
 }

--- a/billing-api/routes/e2etest/billing_test.go
+++ b/billing-api/routes/e2etest/billing_test.go
@@ -192,7 +192,7 @@ func TestTrialExpiresPaymentNextMonth(t *testing.T) {
 	if len(invoices) != 1 {
 		t.Errorf("Expected exactly one invoice, got: %v", len(invoices))
 	}
-	unitPrice := unitPrice(ctx, z, t)
+	unitPrice := unitPrices(ctx, z, t)["USD"]
 	expectedAmount := float64(usageA+usageB+usageC) * unitPrice
 	invoiceAmount := invoices[0].Amount
 	if !routes.FloatEqual(invoiceAmount, routes.RoundHalfUp(expectedAmount)) {
@@ -251,7 +251,7 @@ func TestTrialExpiresPaymentNextTwoMonth(t *testing.T) {
 	if len(invoices) != 1 {
 		t.Errorf("Expected exactly one invoice, got: %v", len(invoices))
 	}
-	unitPrice := unitPrice(ctx, z, t)
+	unitPrice := unitPrices(ctx, z, t)["USD"]
 	expectedAmount := float64(usageA+usageB+usageC+usageD) * unitPrice
 	invoiceAmount := invoices[0].Amount
 	if !routes.FloatEqual(invoiceAmount, routes.RoundHalfUp(expectedAmount)) {
@@ -269,13 +269,13 @@ func zuoraClient() *zuora.Zuora {
 	return zuora.New(mockzuora.Config, nil)
 }
 
-func unitPrice(ctx context.Context, z *zuora.Zuora, t *testing.T) float64 {
+func unitPrices(ctx context.Context, z *zuora.Zuora, t *testing.T) map[string]float64 {
 	rates, err := z.GetCurrentRates(ctx)
 	if err != nil {
 		t.Errorf("Failed to fetch price: %v", err)
 	}
-	price := rates["node-seconds"]
-	return price
+	prices := rates["node-seconds"]
+	return prices
 }
 
 func createZuoraAccount(ctx context.Context, z *zuora.Zuora, externalID string, trialExpiry time.Time, BillCycleDay int) (*zuora.Account, error) {

--- a/billing-api/routes/invoice_verify.go
+++ b/billing-api/routes/invoice_verify.go
@@ -104,7 +104,12 @@ func assertInvoiceVerified(ctx context.Context, a *API, weaveOrgID string, numIn
 	if err != nil {
 		return err
 	}
-	price := rates[billing.UsageNodeSeconds]
+	zuoraAccount, err := a.Zuora.GetAccount(ctx, zuoraAccountNumber)
+	if err != nil {
+		return err
+	}
+	currency := zuoraAccount.Subscription.Currency
+	price := rates[billing.UsageNodeSeconds][currency]
 
 	for _, invoice := range invoices {
 		invoiceStatus := invoice.Status

--- a/common/zuora/products_test.go
+++ b/common/zuora/products_test.go
@@ -41,7 +41,7 @@ func TestGetCurrentRates(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Contains(t, rates, "node-seconds")
-	assert.Equal(t, 0.000011416, rates["node-seconds"])
+	assert.Equal(t, 0.000011416, rates["node-seconds"]["USD"])
 	assert.Contains(t, rates, "container-seconds")
-	assert.Equal(t, 0.00000278, rates["container-seconds"])
+	assert.Equal(t, 0.00000278, rates["container-seconds"]["USD"])
 }


### PR DESCRIPTION
Fixes #1833.
Depends on weaveworks/service-ui/pull/2101.

----

N.B.: I initially was managing supported currencies via the `billing-db`, but eventually decided that was unnecessarily complex, and that we could just leverage Zuora and the users' browser instead, which is less state to manage, and a lot simpler overall.
Should someone want to look or eventually re-use this older version, it is available here:
- https://github.com/weaveworks/service/tree/issues/1833-bill-in-any-currency-in-db 
- https://github.com/weaveworks/service-ui/tree/service/issues/1833-bill-in-any-currency-in-db