### PR TITLE
Run flux-api integration tests against postgres

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
           make RM= users-integration-test
           make RM= billing-integration-test
           make RM= pubsub-integration-test
-          make RM= flux-nats-tests
+          make RM= flux-integration-test
           make RM= kubectl-service-integration-test
           make RM= gcp-service-integration-test
           make RM= notification-integration-test

--- a/flux-api/main_test.go
+++ b/flux-api/main_test.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -62,7 +63,10 @@ const (
 	id            = service.InstanceID("californian-hotel-76")
 )
 
-var testNATS = flag.String("nats-url", "", "NATS connection URL; use NATS' default if empty")
+var (
+	testNATS     = flag.String("nats-url", "", "NATS connection URL; use NATS' default if empty")
+	testPostgres = flag.String("postgres-url", "postgres://postgres@postgres:5432?sslmode=disable", "Postgres connection string")
+)
 
 func setup(t *testing.T) {
 	flag.Parse()
@@ -70,12 +74,15 @@ func setup(t *testing.T) {
 		*testNATS = gnats.DefaultURL
 	}
 
-	databaseSource := "file://fluxy.db"
+	u, err := url.Parse(*testPostgres)
+	if err != nil {
+		t.Fatal(err)
+	}
 	databaseMigrationsDir, _ := filepath.Abs("db/migrations")
 	var dbDriver string
 	{
-		db.Migrate(databaseSource, databaseMigrationsDir)
-		dbDriver = db.DriverForScheme("file")
+		db.Migrate(*testPostgres, databaseMigrationsDir)
+		dbDriver = db.DriverForScheme(u.Scheme)
 	}
 
 	// Message bus
@@ -134,11 +141,14 @@ func setup(t *testing.T) {
 	}
 
 	// History
-	hDb, _ := historysql.NewSQL(dbDriver, databaseSource)
+	hDb, _ := historysql.NewSQL(dbDriver, *testPostgres)
 	historyDB := history.InstrumentedDB(hDb)
 
 	// Instancer
-	db, _ := instancedb.New(dbDriver, databaseSource)
+	db, err := instancedb.New(dbDriver, *testPostgres)
+	if err != nil {
+		t.Fatal(err)
+	}
 	instanceDB = instance.InstrumentedDB(db)
 
 	var instancer instance.Instancer
@@ -313,7 +323,9 @@ func TestFluxsvc_History(t *testing.T) {
 		ServiceIDs: []flux.ResourceID{
 			flux.MustParseResourceID(helloWorldSvc),
 		},
-		Message: "default/helloworld locked.",
+		Message:   "default/helloworld locked.",
+		StartedAt: time.Now().UTC(),
+		EndedAt:   time.Now().UTC(),
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The motivation behind this change was automatically cleaning up the temporary
files generated in running `make flux-nats-tests`. Considering we're already
spinning up a NATS container, I figured we can throw in postgres too.

None of our environments - local, dev, or prod - use anything other than
postgres for history storage, and it turns out the `ql` database doesn't behave
identically to that.

Specifically, the non-postgres option allows an event lacking `EndedAt` to be
written, whereas postgres does not, instead failing with:

```
--- FAIL: TestFluxsvc_History (0.09s)
        main_test.go:327: executing HTTP request: logging event: pq: null value in column "ended_at" violates not-null constraint
```