### PR TITLE
lint: Fix new and exciting lint error

### DIFF
--- a/users/db/memory/organization.go
+++ b/users/db/memory/organization.go
@@ -13,7 +13,7 @@ import (
 	timeutil "github.com/weaveworks/service/common/time"
 	"github.com/weaveworks/service/users"
 	"github.com/weaveworks/service/users/db/filter"
-	"github.com/weaveworks/service/users/externalIDs"
+	"github.com/weaveworks/service/users/externalids"
 )
 
 // RemoveUserFromOrganization removes the user from the organiation. If they
@@ -191,7 +191,7 @@ func (d *DB) GenerateOrganizationExternalID(_ context.Context) (string, error) {
 	var externalID string
 	var err error
 	for used := true; used && err == nil; {
-		externalID = externalIDs.Generate()
+		externalID = externalids.Generate()
 		used, err = d.organizationExists(externalID, true)
 	}
 	return externalID, err

--- a/users/db/memory/team.go
+++ b/users/db/memory/team.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/weaveworks/service/users"
 
-	"github.com/weaveworks/service/users/externalIDs"
+	"github.com/weaveworks/service/users/externalids"
 )
 
 // ListTeamsForUserID lists the teams these users belong to
@@ -61,7 +61,7 @@ func (d *DB) generateTeamExternalID(_ context.Context) (string, error) {
 	// no lock needed: called by createTeam which acquired the lock
 	var externalID string
 	for used := true; used; {
-		externalID = externalIDs.Generate()
+		externalID = externalids.Generate()
 		if len(d.teams) == 0 {
 			break
 		}

--- a/users/db/postgres/organization.go
+++ b/users/db/postgres/organization.go
@@ -14,7 +14,7 @@ import (
 	timeutil "github.com/weaveworks/service/common/time"
 	"github.com/weaveworks/service/users"
 	"github.com/weaveworks/service/users/db/filter"
-	"github.com/weaveworks/service/users/externalIDs"
+	"github.com/weaveworks/service/users/externalids"
 )
 
 // RemoveUserFromOrganization removes the user from the organiation. If they
@@ -272,7 +272,7 @@ func (d DB) GenerateOrganizationExternalID(ctx context.Context) (string, error) 
 	)
 	err = d.Transaction(func(tx DB) error {
 		for used := true; used; {
-			externalID = externalIDs.Generate()
+			externalID = externalids.Generate()
 			used, terr = tx.ExternalIDUsed(ctx, externalID)
 			if terr != nil {
 				return terr

--- a/users/db/postgres/team.go
+++ b/users/db/postgres/team.go
@@ -11,7 +11,7 @@ import (
 	"github.com/lib/pq"
 
 	"github.com/weaveworks/service/users"
-	"github.com/weaveworks/service/users/externalIDs"
+	"github.com/weaveworks/service/users/externalids"
 )
 
 // ListTeamsForUserID returns all teams belonging to userId
@@ -113,7 +113,7 @@ func (d DB) teamExternalIDUsed(ctx context.Context, externalID string) (bool, er
 }
 
 // generateTeamExternalID generates a new team externalID.
-// This function slows down the more externalIDs are stored in the database
+// This function slows down the more externalids are stored in the database
 func (d DB) generateTeamExternalID(ctx context.Context) (string, error) {
 	var (
 		externalID string
@@ -122,7 +122,7 @@ func (d DB) generateTeamExternalID(ctx context.Context) (string, error) {
 	)
 	err = d.Transaction(func(tx DB) error {
 		for used := true; used; {
-			externalID = externalIDs.Generate()
+			externalID = externalids.Generate()
 			used, terr = tx.teamExternalIDUsed(ctx, externalID)
 			if terr != nil {
 				return terr

--- a/users/externalids/generate.go
+++ b/users/externalids/generate.go
@@ -1,4 +1,4 @@
-package externalIDs
+package externalids
 
 import (
 	"fmt"


### PR DESCRIPTION
Trying to build PR https://github.com/weaveworks/service/pull/1863 leads to a newly introduced linter error:

```
./tools/lint .
./users/externalIDs/generate.go:1:1: don't use MixedCaps in package name; externalIDs should be externalids
Makefile:211: recipe for target 'lint' failed
```

This was introduced by:

  https://github.com/golang/lint/commit/3ea3fa98a8104b2c8f8a7bffaebc7e54dddf99e1