### PR TITLE
flux-api: send notification for commit events

### DIFF
--- a/flux-api/notifications/notifications.go
+++ b/flux-api/notifications/notifications.go
@@ -28,9 +28,9 @@ func Event(cfg instance.Config, e event.Event) error {
 			case update.Policy:
 				return slackNotifyCommitPolicyChange(cfg.Settings.Slack, commitMetadata)
 			case update.Images:
-				//TODO release
+				return slackNotifyCommitRelease(cfg.Settings.Slack, commitMetadata)
 			case update.Auto:
-				//TODO autorelease
+				return slackNotifyCommitAutoRelease(cfg.Settings.Slack, commitMetadata)
 			}
 		default:
 			return errors.Errorf("cannot notify for event, unknown event type %s", e.Type)

--- a/flux-api/notifications/slack_test.go
+++ b/flux-api/notifications/slack_test.go
@@ -59,10 +59,6 @@ func TestSlackNotifier(t *testing.T) {
 				"color":    "warning",
 			},
 			map[string]interface{}{
-				"text":        "this was to test notifications",
-				"author_name": "test-user",
-			},
-			map[string]interface{}{
 				"text":      "```" + resultOut.String() + "```",
 				"color":     "warning",
 				"mrkdwn_in": []interface{}{"text"},


### PR DESCRIPTION
 - fixes https://github.com/weaveworks/service/issues/1787
 - move info about username from release event to commit event
 - commit event types:
    - for dev: https://github.com/weaveworks/service-conf/pull/2029
    - for prod: https://github.com/weaveworks/service-conf/pull/2060