### PR TITLE
dashboard: Fix cadvisor memory query

### DIFF
--- a/dashboard-api/dashboard/cadvisor.go
+++ b/dashboard-api/dashboard/cadvisor.go
@@ -21,7 +21,7 @@ var cadvisorDashboard = Dashboard{
 				Title: "Memory Usage",
 				Type:  PanelLine,
 				Unit:  Unit{Format: UnitBytes},
-				Query: `sum (rate(container_memory_working_set_bytes{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}[{{range}}])) by (pod_name)`,
+				Query: `sum (container_memory_working_set_bytes{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}) by (pod_name)`,
 			}},
 		}},
 	}, {

--- a/dashboard-api/dashboard/testdata/TestGolden-cadvisor-resources.golden
+++ b/dashboard-api/dashboard/testdata/TestGolden-cadvisor-resources.golden
@@ -31,7 +31,7 @@
               "unit": {
                 "format": "bytes"
               },
-              "query": "sum (rate(container_memory_working_set_bytes{image!='',namespace='default',_weave_pod_name='authfe'}[2m])) by (pod_name)"
+              "query": "sum (container_memory_working_set_bytes{image!='',namespace='default',_weave_pod_name='authfe'}) by (pod_name)"
             }
           ]
         }


### PR DESCRIPTION
The memory graphs were looking very wrong. That's because I switch to using the
_working_set metric and didn't remove the rate() function when doing so.