### PR TITLE
Add a memcached dashboard

### DIFF
--- a/dashboard-api/dashboard/dashboard.go
+++ b/dashboard-api/dashboard/dashboard.go
@@ -139,6 +139,7 @@ func GetServiceDashboards(metrics []string, namespace, workload string) ([]Dashb
 func Init() {
 	registerProviders(
 		cadvisor,
+		memcached,
 		goRuntime,
 	)
 }

--- a/dashboard-api/dashboard/memcached.go
+++ b/dashboard-api/dashboard/memcached.go
@@ -1,0 +1,91 @@
+package dashboard
+
+var memcachedDashboard = Dashboard{
+	ID:   "memcached",
+	Name: "memcached",
+	Sections: []Section{{
+		Name: "Cache",
+		Rows: []Row{{
+			Panels: []Panel{{
+				Title: "Hit Rate",
+				Type:  PanelLine,
+				Unit:  Unit{Format: UnitPercent},
+				Query: `sum(rate(memcached_commands_total{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}',command=~'get|delete|incr|decr|cas|touch',status='hit'}[{{range}}])) / sum(rate(memcached_commands_total{kubernetes_namespace='{{namespace}}', _weave_service='{{workload}}',command=~'get|delete|incr|decr|cas|touch'}[{{range}}]))`,
+			}},
+		}, {
+			Panels: []Panel{{
+				Title: "Items in Cache",
+				Type:  PanelLine,
+				Unit:  Unit{Format: UnitNumeric},
+				Query: `sum(memcached_current_items{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'})`,
+			}, {
+				Title: "Used Cache Memory",
+				Type:  PanelLine,
+				Unit:  Unit{Format: UnitPercent},
+				Query: `sum(memcached_current_bytes{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}) / sum(memcached_limit_bytes{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'})`,
+			}},
+		}, {
+			Panels: []Panel{{
+				Title: "Evicted Items per Second",
+				Type:  PanelLine,
+				Unit:  Unit{Format: UnitNumeric},
+				Query: `sum(rate(memcached_items_evicted_total{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}]))`,
+			}, {
+				Title: "Reclaimed Items per Second",
+				Type:  PanelLine,
+				Unit:  Unit{Format: UnitNumeric},
+				Query: `sum(rate(memcached_items_reclaimed_total{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}]))`,
+			}},
+		}},
+	}, {
+		Name: "Commands",
+		Rows: []Row{{
+			Panels: []Panel{{
+				Title: "Operations per Second",
+				Type:  PanelLine,
+				Unit:  Unit{Format: UnitNumeric},
+				Query: `sum(rate(memcached_commands_total{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}])) by (command)`,
+			}, {
+				Title: "Get/Set Ratio",
+				Type:  PanelLine,
+				Unit:  Unit{Format: UnitNumeric},
+				Query: `sum(rate(memcached_commands_total{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}',command='get'}[{{range}}])) / sum(rate(memcached_commands_total{kubernetes_namespace='{{namespace}}', _weave_service='{{workload}}',command='set'}[{{range}}]))`,
+			}},
+		}},
+	}, {
+		Name: "Network",
+		Rows: []Row{{
+			Panels: []Panel{{
+				Title: "Bytes Read from Network per Second",
+				Type:  PanelLine,
+				Unit:  Unit{Format: UnitBytes},
+				Query: `sum(rate(memcached_read_bytes_total{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}])) by (kubernetes_pod_name)`,
+			}, {
+				Title: "Bytes Written to Network per Second",
+				Type:  PanelLine,
+				Unit:  Unit{Format: UnitBytes},
+				Query: `sum(rate(memcached_written_bytes_total{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}])) by (kubernetes_pod_name)`,
+			}, {
+				Title: "Number of Connections",
+				Type:  PanelLine,
+				Unit:  Unit{Format: UnitNumeric},
+				Query: `sum(memcached_current_connections{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}) by (kubernetes_pod_name)`,
+			}},
+		}},
+	}},
+}
+
+var memcached = &staticProvider{
+	requiredMetrics: []string{
+		"memcached_commands_total",
+		"memcached_items_evicted_total",
+		"memcached_items_reclaimed_total",
+		"memcached_current_items",
+		"memcached_current_bytes",
+		"memcached_limit_bytes",
+		"memcached_read_bytes_total",
+		"memcached_written_bytes_total",
+		"memcached_current_connections",
+	},
+	dashboard: memcachedDashboard,
+}

--- a/dashboard-api/dashboard/testdata/TestGolden-memcached.golden
+++ b/dashboard-api/dashboard/testdata/TestGolden-memcached.golden
@@ -1,0 +1,121 @@
+{
+  "id": "memcached",
+  "name": "memcached",
+  "sections": [
+    {
+      "name": "Cache",
+      "rows": [
+        {
+          "panels": [
+            {
+              "title": "Hit Rate",
+              "type": "line",
+              "unit": {
+                "format": "percent"
+              },
+              "query": "sum(rate(memcached_commands_total{kubernetes_namespace='default',_weave_service='authfe',command=~'get|delete|incr|decr|cas|touch',status='hit'}[2m])) / sum(rate(memcached_commands_total{kubernetes_namespace='default', _weave_service='authfe',command=~'get|delete|incr|decr|cas|touch'}[2m]))"
+            }
+          ]
+        },
+        {
+          "panels": [
+            {
+              "title": "Items in Cache",
+              "type": "line",
+              "unit": {
+                "format": "numeric"
+              },
+              "query": "sum(memcached_current_items{kubernetes_namespace='default',_weave_service='authfe'})"
+            },
+            {
+              "title": "Used Cache Memory",
+              "type": "line",
+              "unit": {
+                "format": "percent"
+              },
+              "query": "sum(memcached_current_bytes{kubernetes_namespace='default',_weave_service='authfe'}) / sum(memcached_limit_bytes{kubernetes_namespace='default',_weave_service='authfe'})"
+            }
+          ]
+        },
+        {
+          "panels": [
+            {
+              "title": "Evicted Items per Second",
+              "type": "line",
+              "unit": {
+                "format": "numeric"
+              },
+              "query": "sum(rate(memcached_items_evicted_total{kubernetes_namespace='default',_weave_service='authfe'}[2m]))"
+            },
+            {
+              "title": "Reclaimed Items per Second",
+              "type": "line",
+              "unit": {
+                "format": "numeric"
+              },
+              "query": "sum(rate(memcached_items_reclaimed_total{kubernetes_namespace='default',_weave_service='authfe'}[2m]))"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Commands",
+      "rows": [
+        {
+          "panels": [
+            {
+              "title": "Operations per Second",
+              "type": "line",
+              "unit": {
+                "format": "numeric"
+              },
+              "query": "sum(rate(memcached_commands_total{kubernetes_namespace='default',_weave_service='authfe'}[2m])) by (command)"
+            },
+            {
+              "title": "Get/Set Ratio",
+              "type": "line",
+              "unit": {
+                "format": "numeric"
+              },
+              "query": "sum(rate(memcached_commands_total{kubernetes_namespace='default',_weave_service='authfe',command='get'}[2m])) / sum(rate(memcached_commands_total{kubernetes_namespace='default', _weave_service='authfe',command='set'}[2m]))"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Network",
+      "rows": [
+        {
+          "panels": [
+            {
+              "title": "Bytes Read from Network per Second",
+              "type": "line",
+              "unit": {
+                "format": "bytes"
+              },
+              "query": "sum(rate(memcached_read_bytes_total{kubernetes_namespace='default',_weave_service='authfe'}[2m])) by (kubernetes_pod_name)"
+            },
+            {
+              "title": "Bytes Written to Network per Second",
+              "type": "line",
+              "unit": {
+                "format": "bytes"
+              },
+              "query": "sum(rate(memcached_written_bytes_total{kubernetes_namespace='default',_weave_service='authfe'}[2m])) by (kubernetes_pod_name)"
+            },
+            {
+              "title": "Number of Connections",
+              "type": "line",
+              "unit": {
+                "format": "numeric"
+              },
+              "query": "sum(memcached_current_connections{kubernetes_namespace='default',_weave_service='authfe'}) by (kubernetes_pod_name)"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
A new dashboard for memcached Deployments. Has stats about the cache (!), operations done on the cache and network usage.

![screenshot from 2018-03-15 15-07-30](https://user-images.githubusercontent.com/7986/37472018-f1340dda-2862-11e8-9472-d60290c2baea.png)
