### PR TITLE
dashboard: IOPS are unitless

### DIFF
--- a/dashboard-api/dashboard/cadvisor.go
+++ b/dashboard-api/dashboard/cadvisor.go
@@ -57,12 +57,12 @@ var cadvisorDashboard = Dashboard{
 			Panels: []Panel{{
 				Title: "I/O Operations per Second (Read)",
 				Type:  PanelLine,
-				Unit:  Unit{Format: UnitBytes},
+				Unit:  Unit{Format: UnitNumeric},
 				Query: `sum (rate(container_fs_reads_total{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}[{{range}}])) by (pod_name)`,
 			}, {
 				Title: "I/O Operations per Second (Write)",
 				Type:  PanelLine,
-				Unit:  Unit{Format: UnitBytes},
+				Unit:  Unit{Format: UnitNumeric},
 				Query: `sum (rate(container_fs_writes_total{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}[{{range}}])) by (pod_name)`,
 			}},
 		}},

--- a/dashboard-api/dashboard/testdata/TestGolden-cadvisor-resources.golden
+++ b/dashboard-api/dashboard/testdata/TestGolden-cadvisor-resources.golden
@@ -91,7 +91,7 @@
               "title": "I/O Operations per Second (Read)",
               "type": "line",
               "unit": {
-                "format": "bytes"
+                "format": "numeric"
               },
               "query": "sum (rate(container_fs_reads_total{image!='',namespace='default',_weave_pod_name='authfe'}[2m])) by (pod_name)"
             },
@@ -99,7 +99,7 @@
               "title": "I/O Operations per Second (Write)",
               "type": "line",
               "unit": {
-                "format": "bytes"
+                "format": "numeric"
               },
               "query": "sum (rate(container_fs_writes_total{image!='',namespace='default',_weave_pod_name='authfe'}[2m])) by (pod_name)"
             }


### PR DESCRIPTION
The number of I/O Operations per Second is just a number, not something in
bytes.