### PR TITLE
dashboard: Use the 'service' prefix for RED metrics

### DIFF
--- a/dashboard-api/main.go
+++ b/dashboard-api/main.go
@@ -32,7 +32,7 @@ func main() {
 	cfg := &config{}
 	cfg.registerFlags(flag.CommandLine)
 	flag.Parse()
-	cfg.server.MetricsNamespace = "dashboard_api"
+	cfg.server.MetricsNamespace = "service"
 
 	if err := logging.Setup(cfg.logLevel); err != nil {
 		log.Fatalf("error initializing logging: %v", err)


### PR DESCRIPTION
I'd like to use recording rules already defined in service-conf for the
dashboard-api grafana dashboards.

The recording rules are done on "service_request_duration_seconds" histogram,
might as well use the same instead of having to define a new recording rule
when using our own prefix.