### PR TITLE
dashboard: Rename Go dashboard to Go Runtime

### DIFF
--- a/dashboard-api/dashboard/go.go
+++ b/dashboard-api/dashboard/go.go
@@ -3,7 +3,7 @@ package dashboard
 // This dashboard displays metrics "by pod", all line graphs, a line per pod.
 var goRuntimeDashboard = Dashboard{
 	ID:   "go-runtime",
-	Name: "Go",
+	Name: "Go Runtime",
 	Sections: []Section{{
 		Name: "Concurrency",
 		Rows: []Row{{


### PR DESCRIPTION
Go may be a bit confusing, who thought such a generic name wouldn't be! Go
Runtime should hopefully be easier to grasp at a glance.