### PR TITLE
Revendor flux to get read-only fields in API

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -748,7 +748,7 @@
     "ssh",
     "update"
   ]
-  revision = "1a860b16de3eb86f4a17c088a805da61c7bc8e4c"
+  revision = "3d56be4d4bdd5e06246b62f0421943568ae85220"
 
 [[projects]]
   branch = "master"
@@ -985,6 +985,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9f1c7cbbfe1760557ef0fb68624cdccc07e0200c825156b520cbed9f5b32143c"
+  inputs-digest = "f8c0b0733897389842a99f70798ae78206a15fbfbc6a80bba81ac5a7eac31962"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/weaveworks/flux/api/v6/api.go
+++ b/vendor/github.com/weaveworks/flux/api/v6/api.go
@@ -16,9 +16,24 @@ type ImageStatus struct {
 	Containers []Container
 }
 
+// ReadOnlyReason enumerates the reasons that a controller is
+// considered read-only. The zero value is considered "OK", since the
+// zero value is what prior versions of the daemon will effectively
+// send.
+type ReadOnlyReason string
+
+const (
+	ReadOnlyOK       ReadOnlyReason = ""
+	ReadOnlyMissing  ReadOnlyReason = "NotInRepo"
+	ReadOnlySystem   ReadOnlyReason = "System"
+	ReadOnlyNoRepo   ReadOnlyReason = "NoRepo"
+	ReadOnlyNotReady ReadOnlyReason = "NotReady"
+)
+
 type ControllerStatus struct {
 	ID         flux.ResourceID
 	Containers []Container
+	ReadOnly   ReadOnlyReason
 	Status     string
 	Automated  bool
 	Locked     bool

--- a/vendor/github.com/weaveworks/flux/cluster/cluster.go
+++ b/vendor/github.com/weaveworks/flux/cluster/cluster.go
@@ -29,6 +29,10 @@ type Cluster interface {
 type Controller struct {
 	ID     flux.ResourceID
 	Status string // A status summary for display
+	// Is the controller considered read-only because it's under the
+	// control of the platform. In the case of Kubernetes, we simply
+	// omit these controllers; but this may not always be the case.
+	IsSystem bool
 
 	Containers ContainersOrExcuse
 }

--- a/vendor/github.com/weaveworks/flux/git/operations.go
+++ b/vendor/github.com/weaveworks/flux/git/operations.go
@@ -68,7 +68,7 @@ func checkPush(ctx context.Context, workingDir, upstream string) error {
 	return execGitCmd(ctx, workingDir, nil, "push", "--delete", upstream, "tag", CheckPushTag)
 }
 
-func commit(ctx context.Context, workingDir string, commitAction *CommitAction) error {
+func commit(ctx context.Context, workingDir string, commitAction CommitAction) error {
 	commitAuthor := commitAction.Author
 	if commitAuthor != "" {
 		if err := execGitCmd(ctx,

--- a/vendor/github.com/weaveworks/flux/git/working.go
+++ b/vendor/github.com/weaveworks/flux/git/working.go
@@ -9,13 +9,14 @@ import (
 // Config holds some values we use when working in the working clone of
 // a repo.
 type Config struct {
-	Branch    string // branch we're syncing to
-	Path      string // path within the repo containing files we care about
-	SyncTag   string
-	NotesRef  string
-	UserName  string
-	UserEmail string
-	SetAuthor bool
+	Branch      string // branch we're syncing to
+	Path        string // path within the repo containing files we care about
+	SyncTag     string
+	NotesRef    string
+	UserName    string
+	UserEmail   string
+	SetAuthor   bool
+	SkipMessage string
 }
 
 // Checkout is a local working clone of the remote repo. It is
@@ -45,7 +46,7 @@ func (r *Repo) Clone(ctx context.Context, conf Config) (*Checkout, error) {
 	upstream := r.Origin()
 	repoDir, err := r.workingClone(ctx, conf.Branch)
 	if err != nil {
-		return nil, CloningError(upstream.URL, err)
+		return nil, err
 	}
 
 	if err := config(ctx, repoDir, conf.UserName, conf.UserEmail); err != nil {
@@ -96,10 +97,13 @@ func (c *Checkout) ManifestDir() string {
 
 // CommitAndPush commits changes made in this checkout, along with any
 // extra data as a note, and pushes the commit and note to the remote repo.
-func (c *Checkout) CommitAndPush(ctx context.Context, commitAction *CommitAction, note *Note) error {
+func (c *Checkout) CommitAndPush(ctx context.Context, commitAction CommitAction, note *Note) error {
 	if !check(ctx, c.dir, c.config.Path) {
 		return ErrNoChanges
 	}
+
+	commitAction.Message += c.config.SkipMessage
+
 	if err := commit(ctx, c.dir, commitAction); err != nil {
 		return err
 	}

--- a/vendor/github.com/weaveworks/flux/ssh/keygen.go
+++ b/vendor/github.com/weaveworks/flux/ssh/keygen.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os/exec"
@@ -156,9 +157,9 @@ type PublicKey struct {
 // ExtractPublicKey extracts and returns the public key from the specified
 // private key, along with its fingerprint hashes.
 func ExtractPublicKey(privateKeyPath string) (PublicKey, error) {
-	keyBytes, err := exec.Command("ssh-keygen", "-y", "-f", privateKeyPath).Output()
+	keyBytes, err := exec.Command("ssh-keygen", "-y", "-f", privateKeyPath).CombinedOutput()
 	if err != nil {
-		return PublicKey{}, err
+		return PublicKey{}, errors.New(string(keyBytes))
 	}
 
 	md5Print, err := ExtractFingerprint(privateKeyPath, "md5")

--- a/vendor/github.com/weaveworks/flux/update/release.go
+++ b/vendor/github.com/weaveworks/flux/update/release.go
@@ -59,6 +59,7 @@ type ReleaseSpec struct {
 	ImageSpec    ImageSpec
 	Kind         ReleaseKind
 	Excludes     []flux.ResourceID
+	Force        bool
 }
 
 // ReleaseType gives a one-word description of the release, mainly


### PR DESCRIPTION
This revendoring also includes the `Force` flag and some changes in the git and ssh packages, harmlessly.