### PR TITLE
Fix Go dashboard aliasing artefacts

### DIFF
--- a/dashboard-api/dashboard/go.go
+++ b/dashboard-api/dashboard/go.go
@@ -21,12 +21,12 @@ var goRuntimeDashboard = Dashboard{
 				Title: "Heap Size",
 				Type:  PanelLine,
 				Unit:  Unit{Format: UnitBytes},
-				Query: `go_memstats_heap_alloc_bytes{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}`,
+				Query: `avg_over_time(go_memstats_heap_alloc_bytes{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}])`,
 			}, {
 				Title: "Number of Heap Objects",
 				Type:  PanelLine,
 				Unit:  Unit{Format: UnitNumeric},
-				Query: `go_memstats_heap_objects{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}`,
+				Query: `avg_over_time(go_memstats_heap_objects{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}])`,
 			}},
 		}, {
 			Panels: []Panel{{

--- a/dashboard-api/dashboard/testdata/TestGolden-go-runtime.golden
+++ b/dashboard-api/dashboard/testdata/TestGolden-go-runtime.golden
@@ -30,7 +30,7 @@
               "unit": {
                 "format": "bytes"
               },
-              "query": "go_memstats_heap_alloc_bytes{kubernetes_namespace='default',_weave_service='authfe'}"
+              "query": "avg_over_time(go_memstats_heap_alloc_bytes{kubernetes_namespace='default',_weave_service='authfe'}[2m])"
             },
             {
               "title": "Number of Heap Objects",
@@ -38,7 +38,7 @@
               "unit": {
                 "format": "numeric"
               },
-              "query": "go_memstats_heap_objects{kubernetes_namespace='default',_weave_service='authfe'}"
+              "query": "avg_over_time(go_memstats_heap_objects{kubernetes_namespace='default',_weave_service='authfe'}[2m])"
             }
           ]
         },


### PR DESCRIPTION
We want to remove as much as we can the aliasing artefacts that sampling every 15 is inevitably going to lead to.
    
- Always using rate() instead of irate().
- Usage avg_over_time with volatile counters

Fixes: https://github.com/weaveworks/service-ui/issues/2256

Before:
![screenshot from 2018-04-09 13-10-29](https://user-images.githubusercontent.com/7986/38497980-dd23a2e6-3bfa-11e8-9919-35b5b94da480.png)
![screenshot from 2018-04-09 13-10-32](https://user-images.githubusercontent.com/7986/38497986-e0619e7c-3bfa-11e8-97c2-e89ef91af420.png)

After:
![screenshot from 2018-04-09 13-28-32](https://user-images.githubusercontent.com/7986/38497992-e449b7a4-3bfa-11e8-8242-f65ad7f5af75.png)
![screenshot from 2018-04-09 13-29-13](https://user-images.githubusercontent.com/7986/38497996-e7c18dd0-3bfa-11e8-9ba8-b110821aaf0d.png)
