### PR TITLE
Don't trimPrefix /admin/jaeger routes

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -326,7 +326,7 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 				{"/cortex/alertmanager/status", trimPrefix("/admin/cortex/alertmanager", c.promAlertmanagerHost)},
 				{"/cortex/ring", trimPrefix("/admin/cortex", c.promDistributorHost)},
 				{"/loki", trimPrefix("/admin/loki", c.lokiHost)},
-				{"/jaeger", trimPrefix("/admin/jaeger", c.jaegerHost)},
+				{"/jaeger", c.jaegerHost},
 				{"/kibana", trimPrefix("/admin/kibana", c.kibanaHost)},
 				{"/elasticsearch", trimPrefix("/admin/elasticsearch", c.elasticsearchHost)},
 				{"/esh", trimPrefix("/admin/esh", c.eshHost)},


### PR DESCRIPTION
jaeger-query:1.3.0 now supports a `query.base-path` parameter, but it does not expect the reverse proxy to strip the prefix from the request before forwarding. There will be a companion PR in service-conf that switches to the official image.