### PR TITLE
Refuse events for feature flagged types

### DIFF
--- a/notification-eventmanager/db/db.go
+++ b/notification-eventmanager/db/db.go
@@ -38,7 +38,7 @@ type DB interface {
 	GetReceiversForEvent(event types.Event) ([]types.Receiver, error)
 	ListReceivers(instanceID string) ([]types.Receiver, error)
 
-	CreateEvent(event types.Event) error
+	CreateEvent(event types.Event, featureFlags []string) error
 	GetEvents(instanceID string, fields, eventTypes []string, before, after time.Time, limit, offset int) ([]*types.Event, error)
 }
 

--- a/notification-eventmanager/eventmanager/configmanager.go
+++ b/notification-eventmanager/eventmanager/configmanager.go
@@ -245,7 +245,7 @@ func (em *EventManager) createConfigChangedEvent(ctx context.Context, instanceID
 	}
 
 	go func() {
-		if err := em.storeAndSend(ctx, event); err != nil {
+		if err := em.storeAndSend(ctx, event, instanceData.Organization.FeatureFlags); err != nil {
 			log.Warnf("failed to store in DB or send to SQS config change event")
 		}
 	}()

--- a/notification-eventmanager/integrationtest/main.go
+++ b/notification-eventmanager/integrationtest/main.go
@@ -237,8 +237,9 @@ func main() {
 	assertNoError(err, "cannot get events")
 	log.Debugf("Events for instanceID = %s:\n%s", orgID, listEvents)
 
-	if len(listEvents) != len(originEvents)+1 {
-		log.Fatalf("Wrong number of events, expected %d, got %d", len(originEventList)+1, len(listEvents))
+	totalEvents := len(originEvents) + 1 /* test event */ - 2 /* flagged originEvents */
+	if len(listEvents) != totalEvents {
+		log.Fatalf("Wrong number of events, expected %d, got %d", len(originEventList)-1, len(listEvents))
 	}
 
 	listEventTypes, err := listEventTypes()
@@ -278,9 +279,9 @@ func main() {
 	assertNoError(err, "cannot get events")
 	log.Debugf("Events for instanceID = %s:\n%s", orgID, listEvents)
 
-	totalEvents := len(originEvents) + 1 + len(originSlackEvents)
+	totalEvents = len(originEvents) + 1 /* test event */ + len(originSlackEvents) - 2 /* flagged originEvents */
 	if len(listEvents) != totalEvents {
-		log.Fatalf("Wrong number of events, expected %d, got %d", totalEvents, len(listEvents))
+		log.Fatalf("Wrong number of events, expected %d, got %d", len(originEventList)-1, len(listEvents))
 	}
 
 	var originAllEmails []emailNotif


### PR DESCRIPTION
Feature flagged event types require the instance to have that feature
flag. In case they are missing it, the event will  be ignored.

Relates to #1839