### PR TITLE
Add OpenFaaS workload dashboard

### DIFF
--- a/dashboard-api/dashboard/dashboard.go
+++ b/dashboard-api/dashboard/dashboard.go
@@ -272,10 +272,10 @@ func GetServiceDashboards(metrics []string, namespace, workload string) ([]Dashb
 func Init() error {
 	registerProviders(
 		cadvisor,
+		openfaas,
 		memcached,
 		jvm,
 		goRuntime,
-		openfaas,
 	)
 
 	for _, provider := range providers {

--- a/dashboard-api/dashboard/openfaas.go
+++ b/dashboard-api/dashboard/openfaas.go
@@ -8,7 +8,7 @@ var openfaasDashboard = Dashboard{
 		Name: "Traffic",
 		Rows: []Row{{
 			Panels: []Panel{{
-				Title: "Function req/sec",
+				Title: "Function Requests per Second",
 				Type:  PanelLine,
 				Unit:  Unit{Format: UnitNumeric},
 				Query: `sum(rate(gateway_function_invocation_total{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}])) by (function_name)`,
@@ -22,23 +22,23 @@ var openfaasDashboard = Dashboard{
 				Type:     PanelLine,
 				Optional: true,
 				Unit:     Unit{Format: UnitSeconds},
-				Query:    `(rate(gateway_functions_seconds_sum{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}])) / (rate(gateway_functions_seconds_count{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}]))`,
+				Query:    `sum(rate(gateway_functions_seconds_sum{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}]) / rate(gateway_functions_seconds_count{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}])) by (function_name)`,
 			}},
 		}, {
 			Panels: []Panel{{
-				Title: "Successful req/sec",
+				Title: "Successful Requests per Second",
 				Type:  PanelLine,
 				Unit:  Unit{Format: UnitNumeric},
-				Query: `rate(gateway_function_invocation_total{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}',code='200'}[{{range}}])`,
+				Query: `sum(rate(gateway_function_invocation_total{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}',code='200'}[{{range}}])) by (function_name)`,
 			}, {
-				Title: "Failed req/sec",
+				Title: "Failed Requests per Second",
 				Type:  PanelLine,
 				Unit:  Unit{Format: UnitNumeric},
-				Query: `rate(gateway_function_invocation_total{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}',code!='200'}[{{range}}])`,
+				Query: `sum(rate(gateway_function_invocation_total{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}',code!='200'}[{{range}}])) by (function_name)`,
 			}},
 		}, {
 			Panels: []Panel{{
-				Title: "Replicas per function",
+				Title: "Replicas per Function",
 				Type:  PanelLine,
 				Unit:  Unit{Format: UnitNumeric},
 				Query: `sum(gateway_service_count{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}) by (function_name)`,

--- a/dashboard-api/dashboard/testdata/TestGolden-openfaas.golden
+++ b/dashboard-api/dashboard/testdata/TestGolden-openfaas.golden
@@ -8,7 +8,7 @@
         {
           "panels": [
             {
-              "title": "Function req/sec",
+              "title": "Function Requests per Second",
               "type": "line",
               "unit": {
                 "format": "numeric"
@@ -25,27 +25,27 @@
         {
           "panels": [
             {
-              "title": "Successful req/sec",
+              "title": "Successful Requests per Second",
               "type": "line",
               "unit": {
                 "format": "numeric"
               },
-              "query": "rate(gateway_function_invocation_total{kubernetes_namespace='default',_weave_service='authfe',code='200'}[2m])"
+              "query": "sum(rate(gateway_function_invocation_total{kubernetes_namespace='default',_weave_service='authfe',code='200'}[2m])) by (function_name)"
             },
             {
-              "title": "Failed req/sec",
+              "title": "Failed Requests per Second",
               "type": "line",
               "unit": {
                 "format": "numeric"
               },
-              "query": "rate(gateway_function_invocation_total{kubernetes_namespace='default',_weave_service='authfe',code!='200'}[2m])"
+              "query": "sum(rate(gateway_function_invocation_total{kubernetes_namespace='default',_weave_service='authfe',code!='200'}[2m])) by (function_name)"
             }
           ]
         },
         {
           "panels": [
             {
-              "title": "Replicas per function",
+              "title": "Replicas per Function",
               "type": "line",
               "unit": {
                 "format": "numeric"

--- a/dashboard-api/dashboard/testdata/TestGoldenWithOptionalPanels-openfaas-with-optional-panels.golden
+++ b/dashboard-api/dashboard/testdata/TestGoldenWithOptionalPanels-openfaas-with-optional-panels.golden
@@ -8,7 +8,7 @@
         {
           "panels": [
             {
-              "title": "Function req/sec",
+              "title": "Function Requests per Second",
               "type": "line",
               "unit": {
                 "format": "numeric"
@@ -31,34 +31,34 @@
               "unit": {
                 "format": "seconds"
               },
-              "query": "(rate(gateway_functions_seconds_sum{kubernetes_namespace='default',_weave_service='authfe'}[2m])) / (rate(gateway_functions_seconds_count{kubernetes_namespace='default',_weave_service='authfe'}[2m]))"
+              "query": "sum(rate(gateway_functions_seconds_sum{kubernetes_namespace='default',_weave_service='authfe'}[2m]) / rate(gateway_functions_seconds_count{kubernetes_namespace='default',_weave_service='authfe'}[2m])) by (function_name)"
             }
           ]
         },
         {
           "panels": [
             {
-              "title": "Successful req/sec",
+              "title": "Successful Requests per Second",
               "type": "line",
               "unit": {
                 "format": "numeric"
               },
-              "query": "rate(gateway_function_invocation_total{kubernetes_namespace='default',_weave_service='authfe',code='200'}[2m])"
+              "query": "sum(rate(gateway_function_invocation_total{kubernetes_namespace='default',_weave_service='authfe',code='200'}[2m])) by (function_name)"
             },
             {
-              "title": "Failed req/sec",
+              "title": "Failed Requests per Second",
               "type": "line",
               "unit": {
                 "format": "numeric"
               },
-              "query": "rate(gateway_function_invocation_total{kubernetes_namespace='default',_weave_service='authfe',code!='200'}[2m])"
+              "query": "sum(rate(gateway_function_invocation_total{kubernetes_namespace='default',_weave_service='authfe',code!='200'}[2m])) by (function_name)"
             }
           ]
         },
         {
           "panels": [
             {
-              "title": "Replicas per function",
+              "title": "Replicas per Function",
               "type": "line",
               "unit": {
                 "format": "numeric"


### PR DESCRIPTION
This PR adds an OpenFaaS dashboard to the workload UI. The dashboard contains RED metrics and function replicas graphs.