### PR TITLE
billing-api's gRPC tests now use random ports

### DIFF
--- a/billing-api/grpc/common_test.go
+++ b/billing-api/grpc/common_test.go
@@ -1,7 +1,6 @@
 package grpc_test
 
 import (
-	"fmt"
 	"net"
 	"testing"
 
@@ -12,15 +11,13 @@ import (
 	google_grpc "google.golang.org/grpc"
 )
 
-var ready = make(chan bool)
-
-func startNewServer(t *testing.T, port int, database db.DB) {
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+func startNewServer(t *testing.T, database db.DB) net.Listener {
+	listener, err := net.Listen("tcp", ":0") // Listens on a random, free port.
 	assert.NoError(t, err)
 	grpcServer := google_grpc.NewServer()
 	common_grpc.RegisterBillingServer(grpcServer, grpc.Server{DB: database})
-	ready <- true
-	grpcServer.Serve(lis) // Blocks.
+	go grpcServer.Serve(listener) // Blocks.
+	return listener
 }
 
 func newClient(t *testing.T, hostPort string) *common_grpc.Client {

--- a/billing-api/grpc/server_integration_test.go
+++ b/billing-api/grpc/server_integration_test.go
@@ -4,27 +4,22 @@ package grpc_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/weaveworks/service/billing-api/db/dbtest"
-	commongrpc "github.com/weaveworks/service/common/billing/grpc"
+	common_grpc "github.com/weaveworks/service/common/billing/grpc"
 )
 
 func TestFindBillingAccountByTeamID_NotFound(t *testing.T) {
-	grpcPort := 9097
 	database := dbtest.Setup(t)
-	go startNewServer(t, grpcPort, database)
-
-	client := newClient(t, fmt.Sprintf("localhost:%v", grpcPort))
+	listener := startNewServer(t, database)
+	client := newClient(t, listener.Addr().String())
 	defer client.Close()
 
-	<-ready // Wait for the server to be ready.
-
-	billingAccount, err := client.FindBillingAccountByTeamID(context.Background(), &commongrpc.BillingAccountByTeamIDRequest{
+	billingAccount, err := client.FindBillingAccountByTeamID(context.Background(), &common_grpc.BillingAccountByTeamIDRequest{
 		TeamID: "456",
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, &commongrpc.BillingAccount{}, billingAccount)
+	assert.Equal(t, &common_grpc.BillingAccount{}, billingAccount)
 }

--- a/billing-api/grpc/server_test.go
+++ b/billing-api/grpc/server_test.go
@@ -1,41 +1,37 @@
 package grpc_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/weaveworks/service/billing-api/db/mock_db"
-	commongrpc "github.com/weaveworks/service/common/billing/grpc"
+	common_grpc "github.com/weaveworks/service/common/billing/grpc"
 	"github.com/weaveworks/service/common/billing/provider"
 	"golang.org/x/net/context"
 )
 
 func TestFindBillingAccountByTeamID_AgainstMockDB(t *testing.T) {
-	grpcPort := 9096
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock_db.NewMockDB(ctrl)
 	teamID := "123"
 	database.EXPECT().FindBillingAccountByTeamID(gomock.Any(), teamID).Return(expectedBillingAccount(), nil)
-	go startNewServer(t, grpcPort, database)
 
-	client := newClient(t, fmt.Sprintf("localhost:%v", grpcPort))
+	listener := startNewServer(t, database)
+	client := newClient(t, listener.Addr().String())
 	defer client.Close()
 
-	<-ready // Wait for the server to be ready.
-
-	billingAccount, err := client.FindBillingAccountByTeamID(context.Background(), &commongrpc.BillingAccountByTeamIDRequest{
+	billingAccount, err := client.FindBillingAccountByTeamID(context.Background(), &common_grpc.BillingAccountByTeamIDRequest{
 		TeamID: teamID,
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, expectedBillingAccount(), billingAccount)
 }
 
-func expectedBillingAccount() *commongrpc.BillingAccount {
-	return &commongrpc.BillingAccount{
+func expectedBillingAccount() *common_grpc.BillingAccount {
+	return &common_grpc.BillingAccount{
 		ID:        1,
 		CreatedAt: time.Date(2018, 04, 13, 0, 0, 0, 0, time.UTC),
 		Provider:  provider.External,


### PR DESCRIPTION
This should hopefully decrease the chance of a port conflict and therefore, build failures.

The goroutine used to run the server in the background is also lighter than it was previously, and just runs the blocking `Serve` call in the background, removing the need for synchronization.

Follows up on #1955.