### PR TITLE
Proper markdown code fences for slack notifications

### DIFF
--- a/flux-api/notifications/slack.go
+++ b/flux-api/notifications/slack.go
@@ -214,13 +214,15 @@ func getUpdatePolicyMessage(revision string, resource flux.ResourceID, upd polic
 
 func slackResultAttachment(res update.Result) slackAttachment {
 	buf := &bytes.Buffer{}
+	fmt.Fprintln(buf, "```")
 	update.PrintResults(buf, res, 0)
+	fmt.Fprintln(buf, "```")
 	c := "good"
 	if res.Error() != "" {
 		c = "warning"
 	}
 	return slackAttachment{
-		Text:     "```" + buf.String() + "```",
+		Text:     buf.String(),
 		Markdown: []string{"text"},
 		Color:    c,
 	}

--- a/flux-api/notifications/slack_test.go
+++ b/flux-api/notifications/slack_test.go
@@ -54,7 +54,8 @@ func TestSlackNotifier(t *testing.T) {
 				"color":    "warning",
 			},
 			map[string]interface{}{
-				"text":      "```" + resultOut.String() + "```",
+				"text": "```\n" + resultOut.String() + "```\n" +
+					"",
 				"color":     "warning",
 				"mrkdwn_in": []interface{}{"text"},
 			},


### PR DESCRIPTION
The unofficial [markdown spec][0] says that a code fence's content block
starts on the next line.

[0]: http://spec.commonmark.org/0.28/#fenced-code-blocks

---
We do a workaround in `service-ui` currently because the missing newline leads to unexpected HTML:
https://github.com/weaveworks/service-ui/blob/fed5a682de6e0554bcf9e116d1dd660341a29bd8/client/src/components/markdown.jsx#L18-L25 
NOTE that the comment there is wrong. It does not render the `<pre>` tag because there is no newline after the opening fence. 

The hack will no longer be required with this PR and after some adjustments in https://github.com/weaveworks/service-ui/issues/2287