### PR TITLE
Add generic HTTP and go-kit HTTP dashboards

### DIFF
--- a/dashboard-api/dashboard/dashboard.go
+++ b/dashboard-api/dashboard/dashboard.go
@@ -271,6 +271,8 @@ func GetServiceDashboards(metrics []string, namespace, workload string) ([]Dashb
 // other API.
 func Init() error {
 	registerProviders(
+		http,
+		goKit,
 		cadvisor,
 		openfaas,
 		memcached,

--- a/dashboard-api/dashboard/go-kit.go
+++ b/dashboard-api/dashboard/go-kit.go
@@ -1,0 +1,26 @@
+package dashboard
+
+var goKitDashboard = Dashboard{
+	ID:   "go-kit",
+	Name: "Go-kit HTTP",
+	Sections: []Section{{
+		Name: "HTTP Request Rate and Latency",
+		Rows: []Row{{
+			Panels: []Panel{{
+				Title: "Requests per second",
+				Type:  PanelStackedArea,
+				Unit:  Unit{Format: UnitNumeric},
+				Query: `sum by (method)(irate(request_latency_microseconds_count{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}]))`,
+			}, {
+				Title: "Latency",
+				Type:  PanelLine,
+				Unit:  Unit{Format: UnitSeconds},
+				Query: `sum by (method)(rate(request_latency_microseconds_sum{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}])) * 1e-6 / sum by (method)(rate(request_latency_microseconds_count{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}]))`,
+			}},
+		}},
+	}},
+}
+
+var goKit = &promqlProvider{
+	dashboard: &goKitDashboard,
+}

--- a/dashboard-api/dashboard/http.go
+++ b/dashboard-api/dashboard/http.go
@@ -1,0 +1,26 @@
+package dashboard
+
+var httpDashboard = Dashboard{
+	ID:   "http",
+	Name: "HTTP",
+	Sections: []Section{{
+		Name: "HTTP Request Rate and Latency",
+		Rows: []Row{{
+			Panels: []Panel{{
+				Title: "Requests per second",
+				Type:  PanelStackedArea,
+				Unit:  Unit{Format: UnitNumeric},
+				Query: `sum by (status_code)(irate(http_request_duration_seconds_count{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}]))`,
+			}, {
+				Title: "Latency",
+				Type:  PanelLine,
+				Unit:  Unit{Format: UnitSeconds},
+				Query: `sum by (path)(rate(http_request_duration_seconds_sum{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}])) / sum by (path)(rate(http_request_duration_seconds_count{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}]))`,
+			}},
+		}},
+	}},
+}
+
+var http = &promqlProvider{
+	dashboard: &httpDashboard,
+}

--- a/dashboard-api/dashboard/testdata/TestGolden-go-kit.golden
+++ b/dashboard-api/dashboard/testdata/TestGolden-go-kit.golden
@@ -1,0 +1,31 @@
+{
+  "id": "go-kit",
+  "name": "Go-kit HTTP",
+  "sections": [
+    {
+      "name": "HTTP Request Rate and Latency",
+      "rows": [
+        {
+          "panels": [
+            {
+              "title": "Requests per second",
+              "type": "stacked-area",
+              "unit": {
+                "format": "numeric"
+              },
+              "query": "sum by (method)(irate(request_latency_microseconds_count{kubernetes_namespace='default',_weave_service='authfe'}[2m]))"
+            },
+            {
+              "title": "Latency",
+              "type": "line",
+              "unit": {
+                "format": "seconds"
+              },
+              "query": "sum by (method)(rate(request_latency_microseconds_sum{kubernetes_namespace='default',_weave_service='authfe'}[2m])) * 1e-6 / sum by (method)(rate(request_latency_microseconds_count{kubernetes_namespace='default',_weave_service='authfe'}[2m]))"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/dashboard-api/dashboard/testdata/TestGolden-http.golden
+++ b/dashboard-api/dashboard/testdata/TestGolden-http.golden
@@ -1,0 +1,31 @@
+{
+  "id": "http",
+  "name": "HTTP",
+  "sections": [
+    {
+      "name": "HTTP Request Rate and Latency",
+      "rows": [
+        {
+          "panels": [
+            {
+              "title": "Requests per second",
+              "type": "stacked-area",
+              "unit": {
+                "format": "numeric"
+              },
+              "query": "sum by (status_code)(irate(http_request_duration_seconds_count{kubernetes_namespace='default',_weave_service='authfe'}[2m]))"
+            },
+            {
+              "title": "Latency",
+              "type": "line",
+              "unit": {
+                "format": "seconds"
+              },
+              "query": "sum by (path)(rate(http_request_duration_seconds_sum{kubernetes_namespace='default',_weave_service='authfe'}[2m])) / sum by (path)(rate(http_request_duration_seconds_count{kubernetes_namespace='default',_weave_service='authfe'}[2m]))"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes https://github.com/weaveworks/service/issues/1869

Adds two experimental HTTP dashboards for Node.js Express and Go-kit microservices:
![screen shot 2018-04-18 at 1 15 59 pm](https://user-images.githubusercontent.com/2802257/38955962-00e2eedc-430b-11e8-8212-70d50c306874.png)

These rely on the EXACT reference implementations from the `go-kit` and `express-prom-bundle` documentation.

There is a possibility that these can throw false positives since they rely on fairly common metric names. They will be hidden in the UI by feature flags.

Thoughts on future improvements:

There are only slight differences between the queries (metric name, scaling factor, `sum by(method|path)`). We can probably wrap these in a function to pass in variables at `Init()` time.

Further, it might be possible to wrap that function in an HTTP handler to render these dashboards ad-hoc.