### PR TITLE
Provide event ID when sending to SQS

### DIFF
--- a/notification-eventmanager/db/db.go
+++ b/notification-eventmanager/db/db.go
@@ -38,7 +38,7 @@ type DB interface {
 	GetReceiversForEvent(event types.Event) ([]types.Receiver, error)
 	ListReceivers(instanceID string) ([]types.Receiver, error)
 
-	CreateEvent(event types.Event, featureFlags []string) error
+	CreateEvent(event types.Event, featureFlags []string) (eventID string, err error)
 	GetEvents(instanceID string, fields, eventTypes []string, before, after time.Time, limit, offset int) ([]*types.Event, error)
 }
 

--- a/notification-eventmanager/db/postgres/event.go
+++ b/notification-eventmanager/db/postgres/event.go
@@ -18,12 +18,12 @@ import (
 )
 
 // CreateEvent inserts event in DB
-func (d DB) CreateEvent(event types.Event, featureFlags []string) error {
+func (d DB) CreateEvent(event types.Event, featureFlags []string) (string, error) {
 	var eventID string
 	// Re-encode the message data because the sql driver doesn't understand json columns
 	encodedMessages, err := json.Marshal(event.Messages)
 	if err != nil {
-		return err // This is a server error, because this round-trip *should* work.
+		return "", err // This is a server error, because this round-trip *should* work.
 	}
 
 	err = d.withTx("add_event_tx", func(tx *utils.Tx) error {
@@ -98,9 +98,9 @@ func (d DB) CreateEvent(event types.Event, featureFlags []string) error {
 		return err
 	})
 	if err != nil {
-		return errors.Wrap(err, "cannot insert event")
+		return "", errors.Wrap(err, "cannot insert event")
 	}
-	return nil
+	return eventID, nil
 }
 
 // GetEvents returns list of events


### PR DESCRIPTION
This will provide the event ID in the message received by the
`sender`.

Relates to #1979