### PR TITLE
smoother http dashboard graphs with `rate`

### DIFF
--- a/dashboard-api/dashboard/go-kit.go
+++ b/dashboard-api/dashboard/go-kit.go
@@ -10,7 +10,7 @@ var goKitDashboard = Dashboard{
 				Title: "Requests per second",
 				Type:  PanelStackedArea,
 				Unit:  Unit{Format: UnitNumeric},
-				Query: `sum by (method)(irate(request_latency_microseconds_count{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}]))`,
+				Query: `sum by (method)(rate(request_latency_microseconds_count{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}]))`,
 			}, {
 				Title: "Latency",
 				Type:  PanelLine,

--- a/dashboard-api/dashboard/http.go
+++ b/dashboard-api/dashboard/http.go
@@ -10,7 +10,7 @@ var httpDashboard = Dashboard{
 				Title: "Requests per second",
 				Type:  PanelStackedArea,
 				Unit:  Unit{Format: UnitNumeric},
-				Query: `sum by (status_code)(irate(http_request_duration_seconds_count{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}]))`,
+				Query: `sum by (status_code)(rate(http_request_duration_seconds_count{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}'}[{{range}}]))`,
 			}, {
 				Title: "Latency",
 				Type:  PanelLine,

--- a/dashboard-api/dashboard/testdata/TestGolden-go-kit.golden
+++ b/dashboard-api/dashboard/testdata/TestGolden-go-kit.golden
@@ -13,7 +13,7 @@
               "unit": {
                 "format": "numeric"
               },
-              "query": "sum by (method)(irate(request_latency_microseconds_count{kubernetes_namespace='default',_weave_service='authfe'}[2m]))"
+              "query": "sum by (method)(rate(request_latency_microseconds_count{kubernetes_namespace='default',_weave_service='authfe'}[2m]))"
             },
             {
               "title": "Latency",

--- a/dashboard-api/dashboard/testdata/TestGolden-http.golden
+++ b/dashboard-api/dashboard/testdata/TestGolden-http.golden
@@ -13,7 +13,7 @@
               "unit": {
                 "format": "numeric"
               },
-              "query": "sum by (status_code)(irate(http_request_duration_seconds_count{kubernetes_namespace='default',_weave_service='authfe'}[2m]))"
+              "query": "sum by (status_code)(rate(http_request_duration_seconds_count{kubernetes_namespace='default',_weave_service='authfe'}[2m]))"
             },
             {
               "title": "Latency",


### PR DESCRIPTION
...instead of `irate`.

See also #1935.