### PR TITLE
Fix saving receiver if no event types attached

### DIFF
--- a/notification-eventmanager/db/postgres/receiver.go
+++ b/notification-eventmanager/db/postgres/receiver.go
@@ -155,8 +155,9 @@ func (d DB) GetReceiver(instanceID string, receiverID string, featureFlags []str
 		FROM receivers r
 		LEFT JOIN receiver_event_types rt ON (r.receiver_id = rt.receiver_id)
 		LEFT JOIN event_types et ON (rt.event_type = et.name)
-		WHERE r.receiver_id = $1 AND r.instance_id = $2 AND (et.feature_flag IS NULL OR et.feature_flag = ANY ($3))
-			AND ($4 = false OR et.hide_ui_config = false)
+									AND (et.feature_flag IS NULL OR et.feature_flag = ANY ($3))
+									AND ($4 = false OR et.hide_ui_config = false)
+		WHERE r.receiver_id = $1 AND r.instance_id = $2
 		GROUP BY r.receiver_id`,
 		receiverID,
 		instanceID,


### PR DESCRIPTION
Receivers accessed through

    GET /api/notification/config/receivers/{id}
    PUT /api/notification/config/receivers/{id}

returned 404 Not Found if the receiver had no event types enabled.

https://github.com/weaveworks/service-ui/issues/2432