### PR TITLE
Use proper github/google corp identity (text/color)

### DIFF
--- a/users/login/github.go
+++ b/users/login/github.go
@@ -23,7 +23,7 @@ type github struct {
 func NewGithubProvider() Provider {
 	return &github{
 		OAuth: OAuth{
-			name: "Github",
+			name: "GitHub",
 			Config: oauth2.Config{
 				Endpoint: githubOauth.Endpoint,
 				Scopes:   []string{"user:email", "repo", "write:public_key", "read:public_key"},

--- a/users/login/google.go
+++ b/users/login/google.go
@@ -49,7 +49,7 @@ func (g *google) Link(r *http.Request) (Link, bool) {
 	if isSubscribingFromGCP(r) {
 		l.Href = addGCPSubscriptionScope(l.Href)
 	}
-	l.BackgroundColor = "#dd4b39"
+	l.BackgroundColor = "#4285F4"
 	return l, ok
 }
 


### PR DESCRIPTION
Changes

- `GitHub` capitalization
- Google brand color (which we currently override in the frontend anyway)

Related to https://github.com/weaveworks/service-ui/issues/2467