### PR TITLE
Serve GPU usage and memory usage dashboard

### DIFF
--- a/dashboard-api/dashboard/cadvisor.go
+++ b/dashboard-api/dashboard/cadvisor.go
@@ -34,6 +34,11 @@ var cadvisorDashboard = Dashboard{
 				// Already a rate: "Percent of time over the past sample period during which the accelerator was actively processing."
 				// See also: https://github.com/google/cadvisor/blob/08f0c239/metrics/prometheus.go#L334-L335
 				Query: `sum (container_accelerator_duty_cycle{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}) by (pod_name)`,
+			}, {
+				Title: "GPU Memory Usage",
+				Type:  PanelLine,
+				Unit:  Unit{Format: UnitBytes},
+				Query: `sum (container_accelerator_memory_used_bytes{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}) by (pod_name)`,
 			}},
 		}},
 	}, {

--- a/dashboard-api/dashboard/testdata/TestGolden-cadvisor-resources.golden
+++ b/dashboard-api/dashboard/testdata/TestGolden-cadvisor-resources.golden
@@ -50,6 +50,14 @@
                 "explanation": "GPU seconds / second"
               },
               "query": "sum (container_accelerator_duty_cycle{image!='',namespace='default',_weave_pod_name='authfe'}) by (pod_name)"
+            },
+            {
+              "title": "GPU Memory Usage",
+              "type": "line",
+              "unit": {
+                "format": "bytes"
+              },
+              "query": "sum (container_accelerator_memory_used_bytes{image!='',namespace='default',_weave_pod_name='authfe'}) by (pod_name)"
             }
           ]
         }

--- a/dashboard-api/dashboard/testdata/TestGoldenWithOptionalPanels-cadvisor-resources-with-optional-panels.golden
+++ b/dashboard-api/dashboard/testdata/TestGoldenWithOptionalPanels-cadvisor-resources-with-optional-panels.golden
@@ -50,6 +50,14 @@
                 "explanation": "GPU seconds / second"
               },
               "query": "sum (container_accelerator_duty_cycle{image!='',namespace='default',_weave_pod_name='authfe'}) by (pod_name)"
+            },
+            {
+              "title": "GPU Memory Usage",
+              "type": "line",
+              "unit": {
+                "format": "bytes"
+              },
+              "query": "sum (container_accelerator_memory_used_bytes{image!='',namespace='default',_weave_pod_name='authfe'}) by (pod_name)"
             }
           ]
         }


### PR DESCRIPTION
Part of weaveworks/service-ui/issues/1873's resolution.
Front-end will be in a separate PR, once done with local testing pointing to `dev`.