### PR TITLE
Mark GPU stats as optional in resources dashboard

### DIFF
--- a/dashboard-api/dashboard/cadvisor.go
+++ b/dashboard-api/dashboard/cadvisor.go
@@ -28,17 +28,19 @@ var cadvisorDashboard = Dashboard{
 		Name: "GPU",
 		Rows: []Row{{
 			Panels: []Panel{{
-				Title: "GPU Usage",
-				Type:  PanelLine,
-				Unit:  Unit{Format: UnitNumeric, Explanation: "GPU seconds / second"},
+				Title:    "GPU Usage",
+				Type:     PanelLine,
+				Optional: true,
+				Unit:     Unit{Format: UnitNumeric, Explanation: "GPU seconds / second"},
 				// Already a rate: "Percent of time over the past sample period during which the accelerator was actively processing."
 				// See also: https://github.com/google/cadvisor/blob/08f0c239/metrics/prometheus.go#L334-L335
 				Query: `sum (container_accelerator_duty_cycle{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}) by (pod_name)`,
 			}, {
-				Title: "GPU Memory Usage",
-				Type:  PanelLine,
-				Unit:  Unit{Format: UnitBytes},
-				Query: `sum (container_accelerator_memory_used_bytes{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}) by (pod_name)`,
+				Title:    "GPU Memory Usage",
+				Type:     PanelLine,
+				Optional: true,
+				Unit:     Unit{Format: UnitBytes},
+				Query:    `sum (container_accelerator_memory_used_bytes{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}) by (pod_name)`,
 			}},
 		}},
 	}, {

--- a/dashboard-api/dashboard/testdata/TestGolden-cadvisor-resources.golden
+++ b/dashboard-api/dashboard/testdata/TestGolden-cadvisor-resources.golden
@@ -38,32 +38,6 @@
       ]
     },
     {
-      "name": "GPU",
-      "rows": [
-        {
-          "panels": [
-            {
-              "title": "GPU Usage",
-              "type": "line",
-              "unit": {
-                "format": "numeric",
-                "explanation": "GPU seconds / second"
-              },
-              "query": "sum (container_accelerator_duty_cycle{image!='',namespace='default',_weave_pod_name='authfe'}) by (pod_name)"
-            },
-            {
-              "title": "GPU Memory Usage",
-              "type": "line",
-              "unit": {
-                "format": "bytes"
-              },
-              "query": "sum (container_accelerator_memory_used_bytes{image!='',namespace='default',_weave_pod_name='authfe'}) by (pod_name)"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "name": "Network",
       "rows": [
         {

--- a/dashboard-api/dashboard/testdata/TestGoldenWithOptionalPanels-cadvisor-resources-with-optional-panels.golden
+++ b/dashboard-api/dashboard/testdata/TestGoldenWithOptionalPanels-cadvisor-resources-with-optional-panels.golden
@@ -44,6 +44,7 @@
           "panels": [
             {
               "title": "GPU Usage",
+              "optional": true,
               "type": "line",
               "unit": {
                 "format": "numeric",
@@ -53,6 +54,7 @@
             },
             {
               "title": "GPU Memory Usage",
+              "optional": true,
               "type": "line",
               "unit": {
                 "format": "bytes"


### PR DESCRIPTION
If it's not optional, the whole dashboard will disappear if those metrics are missing!