### PR TITLE
Aggregate container_accelerator_duty_cycle using avg instead of sum

### DIFF
--- a/dashboard-api/dashboard/cadvisor.go
+++ b/dashboard-api/dashboard/cadvisor.go
@@ -34,7 +34,7 @@ var cadvisorDashboard = Dashboard{
 				Unit:     Unit{Format: UnitNumeric, Explanation: "GPU seconds / second"},
 				// Already a rate: "Percent of time over the past sample period during which the accelerator was actively processing."
 				// See also: https://github.com/google/cadvisor/blob/08f0c239/metrics/prometheus.go#L334-L335
-				Query: `sum (container_accelerator_duty_cycle{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}) by (pod_name)`,
+				Query: `avg (container_accelerator_duty_cycle{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}) by (pod_name)`,
 			}, {
 				Title:    "GPU Memory Usage",
 				Type:     PanelLine,

--- a/dashboard-api/dashboard/testdata/TestGoldenWithOptionalPanels-cadvisor-resources-with-optional-panels.golden
+++ b/dashboard-api/dashboard/testdata/TestGoldenWithOptionalPanels-cadvisor-resources-with-optional-panels.golden
@@ -50,7 +50,7 @@
                 "format": "numeric",
                 "explanation": "GPU seconds / second"
               },
-              "query": "sum (container_accelerator_duty_cycle{image!='',namespace='default',_weave_pod_name='authfe'}) by (pod_name)"
+              "query": "avg (container_accelerator_duty_cycle{image!='',namespace='default',_weave_pod_name='authfe'}) by (pod_name)"
             },
             {
               "title": "GPU Memory Usage",


### PR DESCRIPTION
This metric is a percentage, e.g. like a gauge, therefore `avg` make more sense.