### PR TITLE
Fix panic for`fields` in /api/notification/events/

### DIFF
--- a/notification-eventmanager/eventmanager/event.go
+++ b/notification-eventmanager/eventmanager/event.go
@@ -425,7 +425,7 @@ func (em *EventManager) handleGetEvents(r *http.Request, instanceID string) (int
 		eventTypes = strings.Split(params.Get("event_type"), ",")
 	}
 	if params.Get("fields") != "" {
-		var fieldsMap map[string]struct{}
+		fieldsMap := map[string]struct{}{}
 		for _, f := range fields {
 			fieldsMap[f] = struct{}{}
 		}


### PR DESCRIPTION
Panics with `assignment to entry in nil map` when using `?fields=type`