### PR TITLE
Inject long git revision in Dockerfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 # All this must go at top of file I'm afraid.
 IMAGE_PREFIX := quay.io/weaveworks
 IMAGE_TAG := $(shell ./tools/image-tag)
-GIT_REVISION := $(shell git rev-parse --short HEAD)
+GIT_REVISION := $(shell git rev-parse HEAD)
 UPTODATE := .uptodate
 
 # Building Docker images is now automated. The convention is every directory


### PR DESCRIPTION
Why? What?

- Follows up on #2023, as it has since been decided that we'd go for long hashes.
- **Long** Git revision (`git rev-parse HEAD`) is now injected at `docker build` time.

Testing:

```console
$ docker inspect quay.io/weaveworks/users
[
    {
        [...]
        "ContainerConfig": {
            [...]
            "Labels": {
                "maintainer": "Weaveworks <help@weave.works>",
                "org.opencontainers.image.revision": "9ce0e92a13d558c9ff6342c2251aeb51a8de3a63",
                "org.opencontainers.image.source": "https://github.com/weaveworks/service/tree/master/users",
                "org.opencontainers.image.title": "users",
                "org.opencontainers.image.vendor": "Weaveworks"
            }
[...]
```

