### PR TITLE
Do not allow joining any team by ext id

### DIFF
--- a/users/api/org_test.go
+++ b/users/api/org_test.go
@@ -576,13 +576,15 @@ func Test_Organization_UserWithExpiredTrialButInTeamBilledExternallyShouldBeAble
 
 	// Create a team, and simulate the fact that team is marked as "billed externally":
 	team := getTeam(t)
+	err := database.AddUserToTeam(context.Background(), user.ID, team.ID)
+	assert.NoError(t, err)
 	billingClient.EXPECT().FindBillingAccountByTeamID(gomock.Any(), &grpc.BillingAccountByTeamIDRequest{TeamID: team.ID}).
 		Return(&grpc.BillingAccount{Provider: provider.External}, nil)
 
 	// Simulate the fact that the organization we're about to create is created by an user whose trial is already expired, i.e. the organization is delinquent:
 	trialExpiresAt := time.Now().Add(-17 * 24 * time.Hour) // more than 15d back to trigger upload refusal
 
-	err := app.CreateOrg(context.Background(), user, api.OrgView{
+	err = app.CreateOrg(context.Background(), user, api.OrgView{
 		ExternalID:     "my-org-id",
 		Name:           "my-org-name",
 		TeamExternalID: team.ExternalID,
@@ -613,13 +615,15 @@ func Test_Organization_UserWithExpiredTrialAndNotInTeamBilledExternallyShouldNot
 
 	// Create a team, and simulate the fact that team is NOT marked as "billed externally":
 	team := getTeam(t)
+	err := database.AddUserToTeam(context.Background(), user.ID, team.ID)
+	assert.NoError(t, err)
 	billingClient.EXPECT().FindBillingAccountByTeamID(gomock.Any(), &grpc.BillingAccountByTeamIDRequest{TeamID: team.ID}).
 		Return(&grpc.BillingAccount{}, nil)
 
 	// Simulate the fact that the organization we're about to create is created by an user whose trial is already expired, i.e. the organization is delinquent:
 	trialExpiresAt := time.Now().Add(-17 * 24 * time.Hour) // more than 15d back to trigger upload refusal
 
-	err := app.CreateOrg(context.Background(), user, api.OrgView{
+	err = app.CreateOrg(context.Background(), user, api.OrgView{
 		ExternalID:     "my-org-id",
 		Name:           "my-org-name",
 		TeamExternalID: team.ExternalID,

--- a/users/db/dbtest/helpers.go
+++ b/users/db/dbtest/helpers.go
@@ -69,6 +69,9 @@ func CreateOrgForTeam(t *testing.T, db db.DB, u *users.User, team *users.Team) *
 	assert.NotEqual(t, nil, team)
 	assert.NotEqual(t, "", team.ID)
 
+	err := db.AddUserToTeam(context.Background(), u.ID, team.ID)
+	require.NoError(t, err)
+
 	externalID, err := db.GenerateOrganizationExternalID(context.Background())
 	require.NoError(t, err)
 

--- a/users/db/memory/organization.go
+++ b/users/db/memory/organization.go
@@ -669,7 +669,7 @@ func (d *DB) CreateOrganizationWithTeam(ctx context.Context, ownerID, externalID
 	var team *users.Team
 	var err error
 	if teamExternalID != "" {
-		team, err = d.ensureUserIsPartOfTeamByExternalID(ctx, ownerID, teamExternalID)
+		team, err = d.getTeamUserIsPartOf(ctx, ownerID, teamExternalID)
 	} else if teamName != "" {
 		team, err = d.ensureUserIsPartOfTeamByName(ctx, ownerID, teamName)
 	}

--- a/users/db/memory/team.go
+++ b/users/db/memory/team.go
@@ -112,8 +112,8 @@ func (d *DB) AddUserToTeam(_ context.Context, userID, teamID string) error {
 	return nil
 }
 
-// ensureUserIsPartOfTeamByExternalID ensures the users is part of an existing team
-func (d DB) ensureUserIsPartOfTeamByExternalID(ctx context.Context, userID, teamExternalID string) (*users.Team, error) {
+// getTeamUserIsPartOf returns the team the user is part of.
+func (d DB) getTeamUserIsPartOf(ctx context.Context, userID, teamExternalID string) (*users.Team, error) {
 	// no lock needed: called by CreateOrganization which acquired the lock
 	if teamExternalID == "" {
 		return nil, errors.New("teamExternalID must be provided")
@@ -138,12 +138,7 @@ func (d DB) ensureUserIsPartOfTeamByExternalID(ctx context.Context, userID, team
 		}
 	}
 
-	err := d.AddUserToTeam(ctx, userID, team.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	return team, nil
+	return nil, users.ErrNotFound
 }
 
 // ensureUserIsPartOfTeamByName ensures the users is part of team by name, the team is created if it does not exist

--- a/users/db/postgres/organization.go
+++ b/users/db/postgres/organization.go
@@ -835,7 +835,7 @@ func (d DB) CreateOrganizationWithTeam(ctx context.Context, ownerID, externalID,
 		var err error
 		// one of two cases must be reached: it is ensured by the validation above
 		if teamExternalID != "" {
-			team, err = d.ensureUserIsPartOfTeamByExternalID(ctx, ownerID, teamExternalID)
+			team, err = d.getTeamUserIsPartOf(ctx, ownerID, teamExternalID)
 		} else if teamName != "" {
 			team, err = d.ensureUserIsPartOfTeamByName(ctx, ownerID, teamName)
 		}

--- a/users/db/postgres/team.go
+++ b/users/db/postgres/team.go
@@ -212,8 +212,8 @@ func (d DB) scanTeam(row squirrel.RowScanner) (*users.Team, error) {
 	return t, nil
 }
 
-// ensureUserIsPartOfTeamByExternalID ensures the users is part of an existing team
-func (d DB) ensureUserIsPartOfTeamByExternalID(ctx context.Context, userID, teamExternalID string) (*users.Team, error) {
+// getTeamUserIsPartOf ensures the users is part of an existing team
+func (d DB) getTeamUserIsPartOf(ctx context.Context, userID, teamExternalID string) (*users.Team, error) {
 	if teamExternalID == "" {
 		return nil, errors.New("teamExternalID must be provided")
 	}
@@ -230,17 +230,7 @@ func (d DB) ensureUserIsPartOfTeamByExternalID(ctx context.Context, userID, team
 		}
 	}
 
-	team, err := d.findTeamByExternalID(ctx, teamExternalID)
-	if err != nil {
-		return nil, err
-	}
-
-	err = d.AddUserToTeam(ctx, userID, team.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	return team, nil
+	return nil, users.ErrNotFound
 }
 
 // ensureUserIsPartOfTeamByName ensures the users is part of team by name, the team is created if it does not exist


### PR DESCRIPTION
There are two ways to create an instance with team. One is assigning a
team by name. This checks whether an accessible team has that name and
if not, creates a new one.

The second way is assigning a team by its teamExternalID. This check
verifies correctly whether an user is already part of it. But if he
isn't, we look for any team by that ID and add the user to that team.

This allows anyone to add himself to any team by just knowing its
external id and therefore gaining access to _all_ the other instances in
that team.

Fixes #2029