### PR TITLE
dashboard-api: Change 404 errors to 204 (NoContent)

### DIFF
--- a/dashboard-api/dashboards_test.go
+++ b/dashboard-api/dashboards_test.go
@@ -24,5 +24,5 @@ func TestGetServiceDashboardsNoMetrics(t *testing.T) {
 	api.handler.ServeHTTP(w, req)
 
 	resp := w.Result()
-	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }

--- a/dashboard-api/errors.go
+++ b/dashboard-api/errors.go
@@ -22,7 +22,7 @@ func renderError(w http.ResponseWriter, r *http.Request, err error) {
 func errorStatusCode(err error) int {
 	switch err {
 	case errNotFound:
-		return http.StatusNotFound
+		return http.StatusNoContent
 	case errInvalidParameter:
 		return http.StatusBadRequest
 	}

--- a/dashboard-api/errors_test.go
+++ b/dashboard-api/errors_test.go
@@ -15,7 +15,7 @@ func TestErrorStatusCode(t *testing.T) {
 		err      error
 		expected int
 	}{
-		{errNotFound, http.StatusNotFound},
+		{errNotFound, http.StatusNoContent},
 		{errInvalidParameter, http.StatusBadRequest},
 		{fmt.Errorf("foo"), http.StatusInternalServerError},
 	}

--- a/dashboard-api/metrics_test.go
+++ b/dashboard-api/metrics_test.go
@@ -48,7 +48,7 @@ func TestGetServiceMetricsNoMetrics(t *testing.T) {
 	api.handler.ServeHTTP(w, req)
 
 	resp := w.Result()
-	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 }
 
 func TestGetServiceMetrics(t *testing.T) {


### PR DESCRIPTION
We alert on 4xx and 5xx errors and had false positive alerts being fired. When
dashboard-api can't find the workload name, return a 204 status code instead.