### PR TITLE
Fix incorrect error handling in notification eventmanager

### DIFF
--- a/notification-eventmanager/eventmanager/http_helpers.go
+++ b/notification-eventmanager/eventmanager/http_helpers.go
@@ -24,7 +24,7 @@ func (j jsonWrapper) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	result, code, err := j.wrapped(r)
 	if err != nil {
 		log.WithError(err).Error("Request error")
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(code)
 		return
 	}
 	encoded := []byte{}


### PR DESCRIPTION
Fixes the issue raised here: https://github.com/weaveworks/service/pull/2041#issuecomment-390954232

The errors were being mis-classified by the middleware that was recently applied to all routes. Nice catch @marccarre and thanks for the thorough write-up.

I'm thinking that the spike in overall errors was due to the rollout, since the amount of 200s stayed constant. @rndstr WDYT?