### PR TITLE
Add domain scope to csrf and auth cookies for easier UI previewing

### DIFF
--- a/authfe/config.go
+++ b/authfe/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	sendCSPHeader         bool
 	targetOrigin          string
 	allowedOriginSuffixes common.ArrayFlags
+	cookieDomain          string
 
 	// External hostnames
 	launcherServiceExternalHost string
@@ -168,6 +169,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&c.sendCSPHeader, "send-csp-header", false, "Send \"Content-Security-Policy: default-src https:\" in all responses.")
 	f.StringVar(&c.targetOrigin, "hostname", "", "Hostname through which this server is accessed, for same-origin checks (CSRF protection)")
 	f.Var(&c.allowedOriginSuffixes, "allowed-origin-suffix", "Hostname suffix to permit through same-origin checks (CSRF protection).")
+	f.StringVar(&c.cookieDomain, "cookie-domain", "", "Domain to which cookies will be scoped")
 
 	// External hostnames
 	f.StringVar(&c.launcherServiceExternalHost, "launcher-service-external-host", "get.weave.works", "External hostname used for the launcher service")

--- a/users/api/gcp_test.go
+++ b/users/api/gcp_test.go
@@ -253,7 +253,7 @@ func gcpSubscribe(t *testing.T, database db.DB, a *api.API, client *mock_partner
 }
 
 func createAPI(client partner.API, accessor partner.Accessor) *api.API {
-	sessionStore = sessions.MustNewStore("Test-Session-Secret-Which-Is-64-Bytes-Long-aa1a166556cb719f531cd", false)
+	sessionStore = sessions.MustNewStore("Test-Session-Secret-Which-Is-64-Bytes-Long-aa1a166556cb719f531cd", false, "")
 	return api.New(
 		false,
 		nil,

--- a/users/api/helpers_test.go
+++ b/users/api/helpers_test.go
@@ -49,7 +49,7 @@ func setupWithMockServices(t *testing.T, fluxAPI, scopeAPI, cortexAPI, netAPI st
 	var directLogin = false
 
 	database = dbtest.Setup(t)
-	sessionStore = sessions.MustNewStore("Test-Session-Secret-Which-Is-64-Bytes-Long-aa1a166556cb719f531cd", false)
+	sessionStore = sessions.MustNewStore("Test-Session-Secret-Which-Is-64-Bytes-Long-aa1a166556cb719f531cd", false, "")
 	templates := templates.MustNewEngine("../templates")
 	logins = login.NewProviders()
 	mixpanelClient := marketing.NewMixpanelClient("")
@@ -111,7 +111,7 @@ func testEmailSender(e *email.Email) error {
 // RequestAs makes a request as the given user.
 func requestAs(t *testing.T, u *users.User, method, endpoint string, body io.Reader) *http.Request {
 	impersonatingUserID := "" // this test doesn't involve impersonation
-	cookie, err := sessionStore.Cookie(u.ID, impersonatingUserID)
+	cookie, err := sessionStore.Cookie(u.ID, impersonatingUserID, "")
 	assert.NoError(t, err)
 
 	r, err := http.NewRequest(method, endpoint, body)

--- a/users/cmd/users/main.go
+++ b/users/cmd/users/main.go
@@ -52,6 +52,7 @@ func main() {
 		sessionSecret = flag.String("session-secret", "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "Secret used validate sessions")
 		directLogin   = flag.Bool("direct-login", false, "Send login token in the signup response (DEV only)")
 		secureCookie  = flag.Bool("secure-cookie", false, "Set secure flag on cookies (so they only get used on HTTPS connections.)")
+		cookieDomain  = flag.String("cookie-domain", "", "The domain to which the authentication cookie will be scoped.")
 
 		fluxStatusAPI  = flag.String("flux-status-api", "", "Hostname and port for flux V6 service. e.g. http://fluxsvc.flux.svc.cluster.local:80/api/flux/v6/status")
 		scopeProbesAPI = flag.String("scope-probes-api", "", "Hostname and port for scope query. e.g. http://query.scope.svc.cluster.local:80/api/probes")
@@ -159,7 +160,7 @@ func main() {
 	emailer := emailer.MustNew(*emailURI, *emailFromAddress, templates, *domain)
 	db := db.MustNew(dbCfg)
 	defer db.Close(context.Background())
-	sessions := sessions.MustNewStore(*sessionSecret, *secureCookie)
+	sessions := sessions.MustNewStore(*sessionSecret, *secureCookie, *cookieDomain)
 
 	orgCleaner := cleaner.New(cleanupURLs, db)
 	log.Debug("Debug logging enabled")

--- a/users/grpc/lookup_test.go
+++ b/users/grpc/lookup_test.go
@@ -30,7 +30,7 @@ var (
 
 func setup(t *testing.T) {
 	database = dbtest.Setup(t)
-	sessionStore = sessions.MustNewStore("Test-Session-Secret-Which-Is-64-Bytes-Long-aa1a166556cb719f531cd", false)
+	sessionStore = sessions.MustNewStore("Test-Session-Secret-Which-Is-64-Bytes-Long-aa1a166556cb719f531cd", false, "")
 	templates := templates.MustNewEngine("../templates")
 	smtp = emailer.SMTPEmailer{
 		Templates:   templates,


### PR DESCRIPTION
Fixes https://github.com/weaveworks/service-ui/issues/2601

Allow for our CSRF and authentication cookies to be scoped to a domain. This will allow us to re-use the same cookies for both frontend.dev.weave.works and 1234.build.dev.weave.works.

Previews should be much easier to use and share after this.

If the `cookie-domain` arg is blank, the domain is ignored and the behavior doesn't change.

Used in conjunction with: https://github.com/weaveworks/service-conf/pull/2269