### PR TITLE
Remove teamExternalId from organization response

### DIFF
--- a/users/api/org.go
+++ b/users/api/org.go
@@ -39,27 +39,8 @@ type OrgView struct {
 	ZuoraAccountNumber    string     `json:"zuoraAccountNumber"`
 	ZuoraAccountCreatedAt *time.Time `json:"zuoraAccountCreatedAt"`
 	BillingProvider       string     `json:"billingProvider"`
-	// Deprecated. Use TeamExternalID.
-	TeamID         string `json:"teamId,omitempty"`         // TODO(rndstr): remove this once ui-server uses `teamId` as external
-	TeamExternalID string `json:"teamExternalId,omitempty"` // TODO(rndstr): rename json output to `teamId`
-	TeamName       string `json:"teamName,omitempty"`
-}
-
-// UnmarshalJSON does some postprocessing to support `teamExternalId` in JSON usage temporarily.
-// TODO(rndstr): remove once ui-server` uses `teamId`.
-func (o *OrgView) UnmarshalJSON(b []byte) error {
-	// Prevent recursive loop
-	type alias *OrgView
-	var tmp alias = o
-	if err := json.Unmarshal(b, &tmp); err != nil {
-		return err
-	}
-	// For now we support teamId as well as teamExternalId to pass in the external id.
-	// Internally we only use the variable TeamExternalID
-	if tmp.TeamExternalID == "" {
-		tmp.TeamExternalID = tmp.TeamID
-	}
-	return nil
+	TeamExternalID        string     `json:"teamId,omitempty"`
+	TeamName              string     `json:"teamName,omitempty"`
 }
 
 func (a *API) org(currentUser *users.User, w http.ResponseWriter, r *http.Request) {
@@ -103,7 +84,6 @@ func (a *API) createOrgView(currentUser *users.User, org *users.Organization) Or
 		TrialExpiresAt:       org.TrialExpiresAt,
 		BillingProvider:      org.BillingProvider(),
 		TeamExternalID:       org.TeamExternalID,
-		TeamID:               org.TeamExternalID,
 	}
 }
 

--- a/users/api/org_test.go
+++ b/users/api/org_test.go
@@ -21,27 +21,6 @@ import (
 	"github.com/weaveworks/service/users/api"
 )
 
-func TestOrgView_UnmarshalJSON(t *testing.T) {
-	{
-		ov := api.OrgView{}
-		err := json.Unmarshal([]byte(`{"teamId": "team-id"}`), &ov)
-		assert.NoError(t, err)
-		assert.Equal(t, "team-id", ov.TeamExternalID)
-	}
-	{
-		ov := api.OrgView{}
-		err := json.Unmarshal([]byte(`{"teamExternalId": "team-external-id"}`), &ov)
-		assert.NoError(t, err)
-		assert.Equal(t, "team-external-id", ov.TeamExternalID)
-	}
-	{
-		ov := api.OrgView{}
-		err := json.Unmarshal([]byte(`{"teamExternalId": "team-external-id", "teamId": "team-id"}`), &ov)
-		assert.NoError(t, err)
-		assert.Equal(t, "team-external-id", ov.TeamExternalID)
-	}
-}
-
 func Test_Org(t *testing.T) {
 	setup(t)
 	defer cleanup(t)


### PR DESCRIPTION
The frontend no longer uses `teamExternalId` now:
https://github.com/weaveworks/service-ui/pull/2639

(ui-server needs to be deployed before users)