### PR TITLE
dashboard-api: AWS resources payload is now an array of type-names maps

### DIFF
--- a/dashboard-api/aws_test.go
+++ b/dashboard-api/aws_test.go
@@ -13,17 +13,20 @@ func TestGetAWSResources(t *testing.T) {
 	req := httptest.NewRequest("GET", "http://api.dashboard.svc.cluster.local/api/dashboard/aws/resources", nil)
 	w := httptest.NewRecorder()
 	api.handler.ServeHTTP(w, req)
-	var resp resourcesByType
+	var resp []resources
 	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, resourcesByType(map[string][]string{
-		"RDS": {
-			"prod-billing-db",
-			"prod-configs-vpc-database",
-			"prod-fluxy-vpc-database",
-			"prod-notification-configs-vpc-database",
-			"prod-users-vpc-database",
+	assert.Equal(t, []resources{
+		{
+			Type: "RDS",
+			Names: []string{
+				"prod-billing-db",
+				"prod-configs-vpc-database",
+				"prod-fluxy-vpc-database",
+				"prod-notification-configs-vpc-database",
+				"prod-users-vpc-database",
+			},
 		},
-	}), resp)
+	}, resp)
 }
 
 func TestToSnakeCase(t *testing.T) {


### PR DESCRIPTION
Changes the format of the payload from:
```json
{
  "RDS": [
    "prod-billing-db",
    "prod-configs-vpc-database",
    "prod-fluxy-vpc-database",
    "prod-notification-configs-vpc-database",
    "prod-users-vpc-database"
  ]
}
```
to:
```json
[
  {
    "type": "RDS",
    "names": [
      "prod-billing-db",
      "prod-configs-vpc-database",
      "prod-fluxy-vpc-database",
      "prod-notification-configs-vpc-database",
      "prod-users-vpc-database"
    ]
  }
]
```
This allows to present resources, ordered by type (e.g. have all database types next to each others), and name (alphabetical order ).

Follows up on #2060 to fix #2049.
Impacts @fbarl.