### PR TITLE
dashboard: Make the RDS CPU utilization a numeric unit

### DIFF
--- a/dashboard-api/dashboard/aws.go
+++ b/dashboard-api/dashboard/aws.go
@@ -13,7 +13,7 @@ var awsRDSDashboard = Dashboard{
 			Panels: []Panel{{
 				Title: "CPU utilization",
 				Type:  PanelLine,
-				Unit:  Unit{Format: UnitPercent},
+				Unit:  Unit{Format: UnitNumeric},
 				Query: `sum(aws_rds_cpuutilization_average{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}',dbinstance_identifier='{{identifier}}'}) by (dbinstance_identifier)`,
 			}, {
 				Title: "Available RAM",

--- a/dashboard-api/dashboard/testdata/TestGolden-aws-rds.golden
+++ b/dashboard-api/dashboard/testdata/TestGolden-aws-rds.golden
@@ -11,7 +11,7 @@
               "title": "CPU utilization",
               "type": "line",
               "unit": {
-                "format": "percent"
+                "format": "numeric"
               },
               "query": "sum(aws_rds_cpuutilization_average{kubernetes_namespace='default',_weave_service='authfe',dbinstance_identifier='prod-users-vpc-database'}) by (dbinstance_identifier)"
             },


### PR DESCRIPTION
The metric was documented as percent, so I put percent. We receive 1.5 to say
1.5 CPUs, which we then convert to 150%. We think 1.5 CPUs look better (and
that's also what the AWS console shows).