### PR TITLE
dashboard-api: add AWS resource category (+tests)

### DIFF
--- a/dashboard-api/aws_test.go
+++ b/dashboard-api/aws_test.go
@@ -19,7 +19,8 @@ func TestGetAWSResources(t *testing.T) {
 	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Equal(t, []resources{
 		{
-			Type: "RDS",
+			Type:     "RDS",
+			Category: "Database",
 			Names: []string{
 				"prod-billing-db",
 				"prod-configs-vpc-database",
@@ -45,4 +46,13 @@ func TestTypesToLabelNames(t *testing.T) {
 		"ELB":    model.LabelName("load_balancer_name"),
 		"Lambda": model.LabelName("function_name"),
 	}, typesToLabelNames)
+}
+
+func TestTypesToCategories(t *testing.T) {
+	assert.Equal(t, map[string]string{
+		"RDS":    "Database",
+		"SQS":    "Queue",
+		"ELB":    "Load Balancer",
+		"Lambda": "λ-Function",
+	}, categories)
 }


### PR DESCRIPTION
The category will be used by the front-end to provide more context on the AWS resources listed, e.g. have a drop-down with:
- Database > foo
- Database > bar

Fixes #2069.