### PR TITLE
dashboard-api: add logging to /dashboards endpoints

### DIFF
--- a/dashboard-api/dashboards.go
+++ b/dashboard-api/dashboards.go
@@ -81,7 +81,7 @@ func (api *API) getAWSDashboards(ctx context.Context, r *http.Request, startTime
 	awsType := aws.Type(mux.Vars(r)["type"])
 	resourceName := mux.Vars(r)["name"]
 	id := awsType.ToDashboardID()
-	log.WithFields(log.Fields{"type": awsType, "name": resourceName, "id": id, "from": startTime, "to": endTime}).Info("get AWS dashboard")
+	log.WithFields(log.Fields{"type": awsType, "name": resourceName, "id": id, "from": startTime, "to": endTime, "ctx": ctx, "req": *r}).Info("get AWS dashboard")
 
 	board := dashboard.GetDashboardByID(id, map[string]string{
 		"namespace":  aws.Namespace,


### PR DESCRIPTION
This is to help investigate a conflict in the arguments passed to our service.
There is probably a bug in how we extract the path params using `mux.Vars(r)["name"]` as even https://frontend.dev.weave.works/api/app/proud-wind-05/api/dashboard/aws/rds/foobar/dashboards (notice `foobar`) returns a dashboard with queries containing `dbinstance_identifier='prod-billing-db'`.