### PR TITLE
dashboard-api: requestcount can also be the number of connections

### DIFF
--- a/dashboard-api/dashboard/aws.go
+++ b/dashboard-api/dashboard/aws.go
@@ -61,7 +61,7 @@ var awsClassicELBDashboard = Dashboard{
 		Name: "Requests",
 		Rows: []Row{{
 			Panels: []Panel{{
-				Title: "Number of requests",
+				Title: "Number of requests / connections",
 				Type:  PanelLine,
 				Unit:  Unit{Format: UnitNumeric},
 				Query: `sum(aws_elb_request_count_sum{kubernetes_namespace='{{namespace}}',_weave_service='{{workload}}',load_balancer_name='{{identifier}}'}) by (load_balancer_name)`,

--- a/dashboard-api/dashboard/testdata/TestGolden-aws-elb.golden
+++ b/dashboard-api/dashboard/testdata/TestGolden-aws-elb.golden
@@ -8,7 +8,7 @@
         {
           "panels": [
             {
-              "title": "Number of requests",
+              "title": "Number of requests / connections",
               "type": "line",
               "unit": {
                 "format": "numeric"


### PR DESCRIPTION
When using HTTP, the count is the number of requets but, when configured with
TCP instances, the count is the number of connections.

Fixes: #2078