### PR TITLE
dashboard-api: Keep go test ./dashboard-api/... -args -update happy

### DIFF
--- a/dashboard-api/aws/main_test.go
+++ b/dashboard-api/aws/main_test.go
@@ -1,0 +1,14 @@
+package aws
+
+import (
+	"flag"
+	"os"
+	"testing"
+)
+
+var update = flag.Bool("update", false, "update .golden files")
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
That command is used to update golden files in every dashboard-api package,
doing it is now producing an error in the AWS package.

For that, we just need a dummy update flag in the test binary of the aws package.