### PR TITLE
dashboard-api: improve logging for /dashboards endpoints

### DIFF
--- a/dashboard-api/dashboards.go
+++ b/dashboard-api/dashboards.go
@@ -110,7 +110,8 @@ func (api *API) getAWSDashboard(ctx context.Context, r *http.Request, logger *lo
 	awsType := aws.Type(mux.Vars(r)["type"])
 	resourceName := mux.Vars(r)["name"]
 	id := awsType.ToDashboardID()
-	logger.WithFields(log.Fields{"type": awsType, "name": resourceName, "id": id}).Debug("get AWS dashboard")
+	logger = logger.WithFields(log.Fields{"type": awsType, "name": resourceName, "id": id})
+	logger.Debug("get AWS dashboard")
 
 	board, err := dashboard.GetDashboardByID(id, map[string]string{
 		"namespace":  aws.Namespace,
@@ -118,6 +119,7 @@ func (api *API) getAWSDashboard(ctx context.Context, r *http.Request, logger *lo
 		"identifier": resourceName,
 	})
 	if err != nil {
+		logger.WithField("err", err).Error("failed to get AWS dashboard")
 		return nil, err
 	}
 	return &getDashboardsResponse{


### PR DESCRIPTION
Changelog: address the below two issues:
* `/aws/{type}/dashboards` currently returns `"not found"` in `dev`:
  ```
  ERRO: GET /api/dashboard/aws/rds/dashboards: not found
  ```
  and there is little information in the logs to help debug this, which suggests we should improve on our logging overall. 
* Moreover, more fields were supposed to be logged with this statement, an omission on my end:
  ```
  INFO: get AWS dashboards type=rds
  ```