### PR TITLE
Revendor flux to get fix for ListImagesWithOptions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -755,7 +755,7 @@
     "ssh",
     "update"
   ]
-  revision = "b7b1a51349d01e608cac5a166f2c957acf148ea7"
+  revision = "72c9e3b09c669a66a289ed3b080f83966cc89bfb"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/weaveworks/flux/cluster/cluster.go
+++ b/vendor/github.com/weaveworks/flux/cluster/cluster.go
@@ -8,11 +8,6 @@ import (
 	"github.com/weaveworks/flux/ssh"
 )
 
-var (
-	ErrNoResourceFilesFoundForService       = errors.New("no resource file found for service")
-	ErrMultipleResourceFilesFoundForService = errors.New("multiple resource files found for service")
-)
-
 // The things we can get from the running cluster. These used to form
 // the remote.Platform interface; but now we do more in the daemon so they
 // are distinct interfaces.

--- a/vendor/github.com/weaveworks/flux/cluster/manifests.go
+++ b/vendor/github.com/weaveworks/flux/cluster/manifests.go
@@ -1,8 +1,10 @@
 package cluster
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/image"
@@ -10,14 +12,18 @@ import (
 	"github.com/weaveworks/flux/resource"
 )
 
+type ManifestError struct {
+	error
+}
+
+func ErrResourceNotFound(name string) error {
+	return ManifestError{fmt.Errorf("manifest for resource %s not found under manifests path", name)}
+}
+
 // Manifests represents how a set of files are used as definitions of
 // resources, e.g., in Kubernetes, YAML files describing Kubernetes
 // resources.
 type Manifests interface {
-	// Given a directory with manifest files, find which files define
-	// which services.
-	// FIXME(michael): remove when redundant
-	FindDefinedServices(path string) (map[flux.ResourceID][]string, error)
 	// Update the image in a manifest's bytes to that given
 	UpdateImage(def []byte, resourceID flux.ResourceID, container string, newImageID image.Ref) ([]byte, error)
 	// Load all the resource manifests under the path given. `baseDir`
@@ -33,23 +39,22 @@ type Manifests interface {
 	ServicesWithPolicies(path string) (policy.ResourceMap, error)
 }
 
-// UpdateManifest looks for the manifest for a given service, reads
-// its contents, applies f(contents), and writes the results back to
-// the file.
-func UpdateManifest(m Manifests, root string, serviceID flux.ResourceID, f func(manifest []byte) ([]byte, error)) error {
-	services, err := m.FindDefinedServices(root)
+// UpdateManifest looks for the manifest for the identified resource,
+// reads its contents, applies f(contents), and writes the results
+// back to the file.
+func UpdateManifest(m Manifests, root string, id flux.ResourceID, f func(manifest []byte) ([]byte, error)) error {
+	resources, err := m.LoadManifests(root, root)
 	if err != nil {
 		return err
 	}
-	paths := services[serviceID]
-	if len(paths) == 0 {
-		return ErrNoResourceFilesFoundForService
-	}
-	if len(paths) > 1 {
-		return ErrMultipleResourceFilesFoundForService
+
+	resource, ok := resources[id.String()]
+	if !ok {
+		return ErrResourceNotFound(id.String())
 	}
 
-	def, err := ioutil.ReadFile(paths[0])
+	path := filepath.Join(root, resource.Source())
+	def, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err
 	}
@@ -59,9 +64,9 @@ func UpdateManifest(m Manifests, root string, serviceID flux.ResourceID, f func(
 		return err
 	}
 
-	fi, err := os.Stat(paths[0])
+	fi, err := os.Stat(path)
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(paths[0], newDef, fi.Mode())
+	return ioutil.WriteFile(path, newDef, fi.Mode())
 }

--- a/vendor/github.com/weaveworks/flux/cluster/mock.go
+++ b/vendor/github.com/weaveworks/flux/cluster/mock.go
@@ -16,7 +16,6 @@ type Mock struct {
 	ExportFunc               func() ([]byte, error)
 	SyncFunc                 func(SyncDef) error
 	PublicSSHKeyFunc         func(regenerate bool) (ssh.PublicKey, error)
-	FindDefinedServicesFunc  func(path string) (map[flux.ResourceID][]string, error)
 	UpdateImageFunc          func(def []byte, id flux.ResourceID, container string, newImageID image.Ref) ([]byte, error)
 	LoadManifestsFunc        func(base, first string, rest ...string) (map[string]resource.Resource, error)
 	ParseManifestsFunc       func([]byte) (map[string]resource.Resource, error)
@@ -47,10 +46,6 @@ func (m *Mock) Sync(c SyncDef) error {
 
 func (m *Mock) PublicSSHKey(regenerate bool) (ssh.PublicKey, error) {
 	return m.PublicSSHKeyFunc(regenerate)
-}
-
-func (m *Mock) FindDefinedServices(path string) (map[flux.ResourceID][]string, error) {
-	return m.FindDefinedServicesFunc(path)
 }
 
 func (m *Mock) UpdateImage(def []byte, id flux.ResourceID, container string, newImageID image.Ref) ([]byte, error) {

--- a/vendor/github.com/weaveworks/flux/git/operations.go
+++ b/vendor/github.com/weaveworks/flux/git/operations.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"context"
@@ -32,7 +31,7 @@ func config(ctx context.Context, workingDir, user, email string) error {
 }
 
 func clone(ctx context.Context, workingDir, repoURL, repoBranch string) (path string, err error) {
-	repoPath := filepath.Join(workingDir, "repo")
+	repoPath := workingDir
 	args := []string{"clone"}
 	if repoBranch != "" {
 		args = append(args, "--branch", repoBranch)
@@ -45,7 +44,7 @@ func clone(ctx context.Context, workingDir, repoURL, repoBranch string) (path st
 }
 
 func mirror(ctx context.Context, workingDir, repoURL string) (path string, err error) {
-	repoPath := filepath.Join(workingDir, "repo")
+	repoPath := workingDir
 	args := []string{"clone", "--mirror"}
 	args = append(args, repoURL, repoPath)
 	if err := execGitCmd(ctx, workingDir, nil, args...); err != nil {

--- a/vendor/github.com/weaveworks/flux/git/repo.go
+++ b/vendor/github.com/weaveworks/flux/git/repo.go
@@ -101,6 +101,18 @@ func (r *Repo) Dir() string {
 	return r.dir
 }
 
+// Clean removes the mirrored repo. Syncing may continue with a new
+// directory, so you may need to stop that first.
+func (r *Repo) Clean() {
+	r.mu.Lock()
+	if r.dir != "" {
+		os.RemoveAll(r.dir)
+	}
+	r.dir = ""
+	r.status = RepoNew
+	r.mu.Unlock()
+}
+
 // Status reports that readiness status of this Git repo: whether it
 // has been cloned, whether it is writable, and if not, the error
 // stopping it getting to the next state.

--- a/vendor/github.com/weaveworks/flux/http/daemon/upstream.go
+++ b/vendor/github.com/weaveworks/flux/http/daemon/upstream.go
@@ -52,7 +52,7 @@ func NewUpstream(client *http.Client, ua string, t fluxclient.Token, router *mux
 		return nil, errors.Wrap(err, "inferring WS/HTTP endpoints")
 	}
 
-	u, err := transport.MakeURL(wsEndpoint, router, "RegisterDaemonV9")
+	u, err := transport.MakeURL(wsEndpoint, router, transport.RegisterDaemonV10)
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing URL")
 	}

--- a/vendor/github.com/weaveworks/flux/remote/rpc/clientV6.go
+++ b/vendor/github.com/weaveworks/flux/remote/rpc/clientV6.go
@@ -148,7 +148,7 @@ func listImagesWithOptions(ctx context.Context, client listImagesWithOptionsClie
 
 	policyMap := make(policy.ResourceMap)
 	for _, service := range services {
-		var s policy.Set
+		s := policy.Set{}
 		for k, v := range service.Policies {
 			s[policy.Policy(k)] = v
 		}


### PR DESCRIPTION
The backfilled implementation of ListImagesWithOptions in the flux RPC client had a failure-to-initialise error. This revendors weaveworks/flux after the merged weaveworks/flux#1153.