### PR TITLE
Revendor weaveworks/flux to get helm bits in the API

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -758,7 +758,7 @@
     "ssh",
     "update"
   ]
-  revision = "72c9e3b09c669a66a289ed3b080f83966cc89bfb"
+  revision = "33408f23f2afe280d39cea85f203bbe4ed70680d"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/weaveworks/flux/api/v6/api.go
+++ b/vendor/github.com/weaveworks/flux/api/v6/api.go
@@ -34,6 +34,7 @@ type ControllerStatus struct {
 	Containers []Container
 	ReadOnly   ReadOnlyReason
 	Status     string
+	Antecedent flux.ResourceID
 	Labels     map[string]string
 	Automated  bool
 	Locked     bool

--- a/vendor/github.com/weaveworks/flux/cluster/cluster.go
+++ b/vendor/github.com/weaveworks/flux/cluster/cluster.go
@@ -29,7 +29,12 @@ type Controller struct {
 	// control of the platform. In the case of Kubernetes, we simply
 	// omit these controllers; but this may not always be the case.
 	IsSystem bool
-	Labels   map[string]string
+	// If this workload was created _because_ of another, antecedent
+	// resource through some mechanism (like an operator, or custom
+	// resource controller), we try to record the ID of that resource
+	// in this field.
+	Antecedent flux.ResourceID
+	Labels     map[string]string
 
 	Containers ContainersOrExcuse
 }


### PR DESCRIPTION
Soon to be released flux daemons mark services/controllers/workloads as having an "antecedent" if they were created via the Helm operator telling Helm to release a chart.

So we can develop UI against this, update the flux API definitions used by flux-api so as to include this field, by revendoring weaveworks/flux.
