### PR TITLE
Remove needless error-wrapping

### DIFF
--- a/flux-api/server/server.go
+++ b/flux-api/server/server.go
@@ -159,12 +159,7 @@ func (s *Server) ListServices(ctx context.Context, namespace string) (res []v6.C
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting instance")
 	}
-
-	services, err := inst.Platform.ListServices(ctx, namespace)
-	if err != nil {
-		return nil, errors.Wrap(err, "getting services from platform")
-	}
-	return services, nil
+	return inst.Platform.ListServices(ctx, namespace)
 }
 
 // ListImages calls ListImages on the given instance.


### PR DESCRIPTION
This brings ListServices into line with other methods.
It will also provoke an image build and push after #2114, which didn't get built and pushed because it included only a revendor.