### PR TITLE
Hide gcpAccountId in error message

### DIFF
--- a/users/api/gcp.go
+++ b/users/api/gcp.go
@@ -158,8 +158,7 @@ func (a *API) getPendingSubscriptionName(ctx context.Context, logger *log.Entry,
 	if externalAccountID == testingExternalAccountID {
 		return getTestSubscriptionName(externalAccountID, subs)
 	}
-	err = fmt.Errorf("no pending subscription found for account: %v", externalAccountID)
-	return "", users.NewMalformedInputError(err)
+	return "", users.NewMalformedInputError(fmt.Errorf("no pending subscription found"))
 }
 
 func getTestSubscriptionName(externalAccountID string, subs []partner.Subscription) (string, error) {


### PR DESCRIPTION
There is not much benefit for the user to know about his gcp account id
but at the same time it allows someone to pass in a custom messages that
will be displayed in the FE.

Fixes https://github.com/weaveworks/service-ui/issues/2801