### PR TITLE
Run test and build in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,13 +134,12 @@ workflows:
     jobs:
       - lint
       - test
-      - build:
-          requires:
-            - lint
-            - test
+      - build
       - integration-test:
           requires:
             - build
+            - lint
+            - test
       - upload:
           requires:
             - integration-test


### PR DESCRIPTION
Move the dependency up to the next step - integration test - which
genuinely does depend on build since it pushes the container images.