### PR TITLE
Revendor weaveworks/flux to get dotty resource IDs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -788,7 +788,7 @@
     "ssh",
     "update"
   ]
-  revision = "33408f23f2afe280d39cea85f203bbe4ed70680d"
+  revision = "783f23e66ed8d561cc30606d35bc71eb24b9fa1f"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/weaveworks/flux/flux.go
+++ b/vendor/github.com/weaveworks/flux/flux.go
@@ -14,8 +14,8 @@ var (
 	ErrInvalidServiceID = errors.New("invalid service ID")
 
 	LegacyServiceIDRegexp       = regexp.MustCompile("^([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)$")
-	ResourceIDRegexp            = regexp.MustCompile("^([a-zA-Z0-9_-]+):([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)$")
-	UnqualifiedResourceIDRegexp = regexp.MustCompile("^([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)$")
+	ResourceIDRegexp            = regexp.MustCompile("^([a-zA-Z0-9_-]+):([a-zA-Z0-9_-]+)/([a-zA-Z0-9_.-]+)$")
+	UnqualifiedResourceIDRegexp = regexp.MustCompile("^([a-zA-Z0-9_-]+)/([a-zA-Z0-9_.-]+)$")
 )
 
 // ResourceID is an opaque type which uniquely identifies a resource in an

--- a/vendor/github.com/weaveworks/flux/git/repo.go
+++ b/vendor/github.com/weaveworks/flux/git/repo.go
@@ -19,10 +19,19 @@ const (
 )
 
 var (
-	ErrNoChanges = errors.New("no changes made in repo")
-	ErrNotReady  = errors.New("git repo not ready")
-	ErrNoConfig  = errors.New("git repo does not have valid config")
+	ErrNoChanges  = errors.New("no changes made in repo")
+	ErrNoConfig   = errors.New("git repo does not have valid config")
+	ErrNotCloned  = errors.New("git repo has not been cloned yet")
+	ErrClonedOnly = errors.New("git repo has been cloned but not yet checked for write access")
 )
+
+type NotReadyError struct {
+	underlying error
+}
+
+func (err NotReadyError) Error() string {
+	return "git repo not ready: " + err.underlying.Error()
+}
 
 // GitRepoStatus represents the progress made synchronising with a git
 // repo. These are given below in expected order, but the status may
@@ -76,7 +85,7 @@ func NewRepo(origin Remote, opts ...Option) *Repo {
 		origin:   origin,
 		status:   status,
 		interval: defaultInterval,
-		err:      nil,
+		err:      ErrNotCloned,
 		notify:   make(chan struct{}, 1), // `1` so that Notify doesn't block
 		C:        make(chan struct{}, 1), // `1` so we don't block on completing a refresh
 	}
@@ -114,18 +123,25 @@ func (r *Repo) Clean() {
 }
 
 // Status reports that readiness status of this Git repo: whether it
-// has been cloned, whether it is writable, and if not, the error
-// stopping it getting to the next state.
+// has been cloned and is writable, and if not, the error stopping it
+// getting to the next state.
 func (r *Repo) Status() (GitRepoStatus, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.status, r.err
 }
 
-func (r *Repo) setStatus(s GitRepoStatus, err error) {
+func (r *Repo) setUnready(s GitRepoStatus, err error) {
 	r.mu.Lock()
 	r.status = s
 	r.err = err
+	r.mu.Unlock()
+}
+
+func (r *Repo) setReady() {
+	r.mu.Lock()
+	r.status = RepoReady
+	r.err = nil
 	r.mu.Unlock()
 }
 
@@ -157,7 +173,7 @@ func (r *Repo) errorIfNotReady() error {
 	case RepoNoConfig:
 		return ErrNoConfig
 	default:
-		return ErrNotReady
+		return NotReadyError{r.err}
 	}
 }
 
@@ -229,29 +245,29 @@ func (r *Repo) Start(shutdown <-chan struct{}, done *sync.WaitGroup) error {
 				r.mu.Unlock()
 			}
 			if err == nil {
-				r.setStatus(RepoCloned, nil)
+				r.setUnready(RepoCloned, ErrClonedOnly)
 				continue // with new status, skipping timer
 			}
 			dir = ""
 			os.RemoveAll(rootdir)
-			r.setStatus(RepoNew, err)
+			r.setUnready(RepoNew, err)
 
 		case RepoCloned:
 			ctx, cancel := context.WithTimeout(bg, opTimeout)
 			err := checkPush(ctx, dir, url)
 			cancel()
 			if err == nil {
-				r.setStatus(RepoReady, nil)
+				r.setReady()
 				// Treat every transition to ready as a refresh, so
 				// that any listeners can respond in the same way.
 				r.refreshed()
 				continue // with new status, skipping timer
 			}
-			r.setStatus(RepoCloned, err)
+			r.setUnready(RepoCloned, err)
 
 		case RepoReady:
 			if err := r.refreshLoop(shutdown); err != nil {
-				r.setStatus(RepoNew, err)
+				r.setUnready(RepoNew, err)
 				continue // with new status, skipping timer
 			}
 		}


### PR DESCRIPTION
The flux definition of a resource ID was expanded to include dots in
the resource name, since that corresponds more closely with
Kubernetes. Since resource IDs are sent in events to Weave Cloud, we
also have to understand the dotty IDs here.