### PR TITLE
Use trailing slash for webhooks api in flux-api

### DIFF
--- a/flux-api/http/server.go
+++ b/flux-api/http/server.go
@@ -64,7 +64,7 @@ func NewServiceRouter() *mux.Router {
 	r.NewRoute().Name(GitPushNotify).Methods("POST").Path("/v6/integrations/git/push").Queries("instance", "{instance}")
 
 	// Webhooks
-	r.NewRoute().Name(Webhook).Methods("POST").Path("/webhooks/{secretID}")
+	r.NewRoute().Name(Webhook).Methods("POST").Path("/webhooks/{secretID}/")
 
 	// We assume every request that doesn't match a route is a client
 	// calling an old or hitherto unsupported API.

--- a/flux-api/http/webhooks_test.go
+++ b/flux-api/http/webhooks_test.go
@@ -18,7 +18,7 @@ func TestHandleWebhook(t *testing.T) {
 	s := Server{daemonProxy: mockDaemon}
 
 	{ // Invalid integration type
-		req, err := http.NewRequest("GET", "https://weave.test/webhooks/secret-abc", nil)
+		req, err := http.NewRequest("GET", "https://weave.test/webhooks/secret-abc/", nil)
 		assert.NoError(t, err)
 		req.Header.Set(webhooks.WebhooksIntegrationTypeHeader, "invalid")
 
@@ -165,7 +165,7 @@ func TestHandleWebhook(t *testing.T) {
 			  }
 		`)
 
-		req, err := http.NewRequest("GET", "https://weave.test/webhooks/secret-abc", bytes.NewReader(payload))
+		req, err := http.NewRequest("GET", "https://weave.test/webhooks/secret-abc/", bytes.NewReader(payload))
 		assert.NoError(t, err)
 		req.Header.Set(webhooks.WebhooksIntegrationTypeHeader, webhooks.GithubPushIntegrationType)
 		req.Header.Set("X-Github-Event", "push")


### PR DESCRIPTION
We are using trailing slashes in authfe. We hope this will fix a problem with the webhooks returning 502.