### PR TITLE
Fix undetected template lookup error

### DIFF
--- a/users/templates/engine.go
+++ b/users/templates/engine.go
@@ -57,9 +57,13 @@ type extensionsTemplateEngine struct {
 func (l *extensionsTemplateEngine) Lookup(name string) (t Executor, err error) {
 	switch filepath.Ext(name) {
 	case ".html":
-		t = l.htmlTemplates.Lookup(name)
+		if ht := l.htmlTemplates.Lookup(name); ht != nil {
+			t = ht
+		}
 	case ".text":
-		t = l.textTemplates.Lookup(name)
+		if tt := l.textTemplates.Lookup(name); tt != nil {
+			t = tt
+		}
 	}
 	if t == nil {
 		err = ErrTemplateNotFound{name}

--- a/users/templates/engine_test.go
+++ b/users/templates/engine_test.go
@@ -33,3 +33,22 @@ func TestEmbedHTML__Invite(t *testing.T) {
 	assert.Contains(t, rendered, "has invited you to access the \"local-test-org\"")
 	assert.Contains(t, rendered, data["LoginURL"])
 }
+
+func TestExtensionsTemplateEngine_Lookup(t *testing.T) {
+	eng := templates.MustNewEngine(".")
+	{
+		tmpl, err := eng.Lookup("notfound.html")
+		assert.Nil(t, tmpl)
+		assert.Error(t, err)
+	}
+	{
+		tmpl, err := eng.Lookup("notfound.text")
+		assert.Nil(t, tmpl)
+		assert.Error(t, err)
+	}
+	{
+		tmpl, err := eng.Lookup("file.unknown")
+		assert.Nil(t, tmpl)
+		assert.Error(t, err)
+	}
+}


### PR DESCRIPTION
Template lookup did not return an error when a template was not found.