### PR TITLE
Fix misuse of a zuora upload import ID as a URL

### DIFF
--- a/billing-api/routes/accounts.go
+++ b/billing-api/routes/accounts.go
@@ -66,7 +66,7 @@ func (a *API) createAccount(w http.ResponseWriter, r *http.Request) error {
 			return err
 		}
 		if usageImportID != "" {
-			err = a.DB.InsertPostTrialInvoice(r.Context(), externalID, account.Number, usageImportID)
+			err = a.DB.InsertPostTrialInvoice(r.Context(), externalID, account.Number, string(usageImportID))
 			if err != nil {
 				return err
 			}
@@ -143,7 +143,7 @@ func (a *API) markOrganizationDutiful(ctx context.Context, logger *log.Entry, ex
 }
 
 // FetchAndUploadUsage gets usage from the database and uploads it to Zuora.
-func (a *API) FetchAndUploadUsage(ctx context.Context, account *zuora.Account, orgID, externalID string, trialExpiry, today time.Time, cycleDay int) (string, error) {
+func (a *API) FetchAndUploadUsage(ctx context.Context, account *zuora.Account, orgID, externalID string, trialExpiry, today time.Time, cycleDay int) (zuora.UsageUploadID, error) {
 	aggs, err := a.getPostTrialChargeableUsage(ctx, orgID, trialExpiry, today)
 	if err != nil {
 		return "", err
@@ -170,7 +170,7 @@ func (a *API) getPostTrialChargeableUsage(ctx context.Context, orgID string, tri
 	return aggs, nil
 }
 
-func (a *API) uploadUsage(ctx context.Context, externalID string, account *zuora.Account, aggs []db.Aggregate, trialExpiry, today time.Time, cycleDay int) (string, error) {
+func (a *API) uploadUsage(ctx context.Context, externalID string, account *zuora.Account, aggs []db.Aggregate, trialExpiry, today time.Time, cycleDay int) (zuora.UsageUploadID, error) {
 	logger := logging.With(ctx)
 	// If the trial expired before today, then we need to upload the gap that would be missed
 	aggs, err := zuora.FilterAggregatesForSubscription(ctx, a.Zuora, aggs, account)

--- a/billing-api/routes/e2etest/billing_test.go
+++ b/billing-api/routes/e2etest/billing_test.go
@@ -297,7 +297,7 @@ func createZuoraAccount(ctx context.Context, z *zuora.Zuora, externalID string, 
 	)
 }
 
-func waitUntilUsageCompleted(ctx context.Context, z *zuora.Zuora, timeout time.Duration, importID string) error {
+func waitUntilUsageCompleted(ctx context.Context, z *zuora.Zuora, timeout time.Duration, importID zuora.UsageUploadID) error {
 	startTime := time.Now().UTC()
 	pollInterval := time.Duration(100 * time.Millisecond)
 	for {

--- a/billing-uploader/job/invoice.go
+++ b/billing-uploader/job/invoice.go
@@ -71,8 +71,9 @@ func (j *InvoiceUpload) Do() error {
 		invoicesToProcess.Set(float64(len(postTrialInvoices)))
 
 		for _, postTrialInvoice := range postTrialInvoices {
-			usageImportID := postTrialInvoice.UsageImportID
-			usageImportStatusResp, err := j.zuora.GetUsageImportStatus(ctx, usageImportID)
+			usageImportID := zuora.UsageUploadID(postTrialInvoice.UsageImportID)
+			usageImportStatusResp, err := j.zuora.GetUsageImportStatus(
+				ctx, j.zuora.GetUsageImportStatusURL(usageImportID))
 
 			if err != nil {
 				logger.Errorf("Failed to get usage import status, id %v: %v", usageImportID, err)
@@ -114,7 +115,7 @@ func (j *InvoiceUpload) Do() error {
 				}
 			}
 
-			err = j.db.DeletePostTrialInvoice(ctx, usageImportID)
+			err = j.db.DeletePostTrialInvoice(ctx, string(usageImportID))
 			if err != nil {
 				logger.Errorf("Failed to delete post trial invoice %v, %v", usageImportID, err)
 				continue

--- a/billing-uploader/job/usage_test.go
+++ b/billing-uploader/job/usage_test.go
@@ -50,7 +50,7 @@ func (z *stubZuoraClient) GetProductsUnitSet(ctx context.Context, productIDs []s
 	}, nil
 }
 
-func (z *stubZuoraClient) UploadUsage(ctx context.Context, r io.Reader, id string) (string, error) {
+func (z *stubZuoraClient) UploadUsage(ctx context.Context, r io.Reader, id string) (zuora.UsageUploadID, error) {
 	z.uploadUsage = r
 	return "", z.err
 }

--- a/common/zuora/mockzuora/stubclient.go
+++ b/common/zuora/mockzuora/stubclient.go
@@ -35,7 +35,7 @@ func (z StubClient) DeleteAccount(ctx context.Context, zuoraID string) error {
 }
 
 // UploadUsage mocks.
-func (z StubClient) UploadUsage(ctx context.Context, r io.Reader, id string) (string, error) {
+func (z StubClient) UploadUsage(ctx context.Context, r io.Reader, id string) (zuora.UsageUploadID, error) {
 	return "", nil
 }
 
@@ -116,6 +116,11 @@ func (z StubClient) URL(format string, components ...interface{}) string {
 // GetUsage mocks.
 func (z StubClient) GetUsage(ctx context.Context, zuoraAccountNumber, page, pageSize string) ([]zuora.Usage, error) {
 	return nil, nil
+}
+
+// GetUsageImportStatusURL mocks.
+func (z StubClient) GetUsageImportStatusURL(usageUploadID zuora.UsageUploadID) string {
+	return string(usageUploadID)
 }
 
 // GetUsageImportStatus mocks.

--- a/common/zuora/zuora.go
+++ b/common/zuora/zuora.go
@@ -28,6 +28,9 @@ func init() {
 	prometheus.MustRegister(usageImportHistogram)
 }
 
+// UsageUploadID represents the ID of a usage record
+type UsageUploadID string
+
 // Client defines an interface to access the Zuora API.
 type Client interface {
 	GetAuthenticationTokens(ctx context.Context, zuoraAccountNumber string) (*AuthenticationTokens, error)
@@ -48,8 +51,9 @@ type Client interface {
 	GetPayments(ctx context.Context, zuoraAccountNumber string) ([]*PaymentDetails, error)
 	GetPaymentTransactionLog(ctx context.Context, paymentID string) (*PaymentTransaction, error)
 	UpdatePaymentMethod(ctx context.Context, paymentMethodID string) error
-	UploadUsage(ctx context.Context, r io.Reader, id string) (string, error)
+	UploadUsage(ctx context.Context, r io.Reader, id string) (UsageUploadID, error)
 	GetUsage(ctx context.Context, zuoraAccountNumber, page, pageSize string) ([]Usage, error)
+	GetUsageImportStatusURL(usageUploadID UsageUploadID) string
 	GetUsageImportStatus(ctx context.Context, url string) (*ImportStatusResponse, error)
 
 	GetCurrentRates(ctx context.Context) (RateMap, error)


### PR DESCRIPTION
In an earlier PR I tried to move away from parsing the URL in order to be less brittle, but clearly only did half the changes, this left something broken.

I didn't go so far as to plumb this into the DB layer because it introduced an import cycle, and I wasn't sure what to do.