### PR TITLE
Make billing-exporter URI and password flags more like other services

### DIFF
--- a/billing-exporter/Dockerfile
+++ b/billing-exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.7-alpine
 LABEL maintainer="Weaveworks <help@weave.works>" \
       org.opencontainers.image.title="billing-exporter" \
       org.opencontainers.image.source="https://github.com/weaveworks/service/tree/master/billing-exporter" \

--- a/billing-exporter/Pipfile
+++ b/billing-exporter/Pipfile
@@ -7,8 +7,9 @@ name = "pypi"
 prometheus-client = "*"
 google-cloud-bigquery = "*"
 "psycopg2-binary" = "*"
+click = "*"
 
 [dev-packages]
 
 [requires]
-python_version = "3.6"
+python_version = "3.7"

--- a/billing-exporter/Pipfile.lock
+++ b/billing-exporter/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "30c2f37dd31c1863c8fe94971eab54a6b59699136ee0c2061ceec471694c1d7c"
+            "sha256": "7827cca4f82cb1187b3841018cbd955e098c58ce9af93c789a6efce00a3d1a78"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.6"
+            "python_version": "3.7"
         },
         "sources": [
             {
@@ -36,6 +36,14 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "click": {
+            "hashes": [
+                "sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d",
+                "sha256:f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b"
+            ],
+            "index": "pypi",
+            "version": "==6.7"
         },
         "google-api-core": {
             "hashes": [
@@ -77,6 +85,7 @@
             "hashes": [
                 "sha256:c075eddaa2628ab519e01b7d75b76e66c40eaa50fc52758d8225f84708950ef2"
             ],
+            "markers": "python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.2.*'",
             "version": "==1.5.3"
         },
         "idna": {
@@ -103,7 +112,6 @@
                 "sha256:7d786f3ef5b33a04e6538089674f244a3b0f588155016559d950989010af97d0",
                 "sha256:8bf82bb7a466a54be7272dcb492f71d55a2453a58d862fb74c3f2083f2768543",
                 "sha256:9bbc1ae1c33c1bd3a2fc05a3aec328544d2b039ff0ce6f000063628a32fad777",
-                "sha256:9e992c68103ab5635728d29fcf132c669cb4e2db24d012685210276185009d17",
                 "sha256:9f1087abb67b34e55108bc610936b34363a7aac692023bcbb17e065c253a1f80",
                 "sha256:9fefcb92a3784b446abf3641d9a14dad815bee88e0edd10b9a9e0e144d01a991",
                 "sha256:a37836aa47d1b81c2db1a6b7a5e79926062b5d76bd962115a0e615551be2b48d",
@@ -111,6 +119,7 @@
                 "sha256:d7ac50bc06d31deb07ace6de85556c1d7330e5c0958f3b2af85037d6d1182abf",
                 "sha256:dfe6899304b898538f4dc94fa0b281b56b70e40f58afa4c6f807805261cbe2e8"
             ],
+            "markers": "python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.2.*'",
             "version": "==3.6.0"
         },
         "psycopg2-binary": {
@@ -151,37 +160,15 @@
         },
         "pyasn1": {
             "hashes": [
-                "sha256:24f21b4fd2dc2b344dee2205fa3930464aa21292216d3d6e39007a2e059e21af",
-                "sha256:2f57960dc7a2820ea5a1782b872d974b639aa3b448ac6628d1ecc5d0fe3986f2",
-                "sha256:3651774ca1c9726307560792877db747ba5e8a844ea1a41feb7670b319800ab3",
-                "sha256:602fda674355b4701acd7741b2be5ac188056594bf1eecf690816d944e52905e",
-                "sha256:8fb265066eac1d3bb5015c6988981b009ccefd294008ff7973ed5f64335b0f2d",
-                "sha256:9334cb427609d2b1e195bb1e251f99636f817d7e3e1dffa150cb3365188fb992",
-                "sha256:9a15cc13ff6bf5ed29ac936ca941400be050dff19630d6cd1df3fb978ef4c5ad",
                 "sha256:a66dcda18dbf6e4663bde70eb30af3fc4fe1acb2d14c4867a861681887a5f9a2",
-                "sha256:ba77f1e8d7d58abc42bfeddd217b545fdab4c1eeb50fd37c2219810ad56303bf",
-                "sha256:cdc8eb2eaafb56de66786afa6809cd9db2df1b3b595dcb25aa5b9dc61189d40a",
-                "sha256:d01fbba900c80b42af5c3fe1a999acf61e27bf0e452e0f1ef4619065e57622da",
-                "sha256:f281bf11fe204f05859225ec2e9da7a7c140b65deccd8a4eb0bc75d0bd6949e0",
                 "sha256:fb81622d8f3509f0026b0683fe90fea27be7284d3826a5f2edf97f69151ab0fc"
             ],
             "version": "==0.4.3"
         },
         "pyasn1-modules": {
             "hashes": [
-                "sha256:077250b34432520430bc1c80dcbda4e354090785567c33ded35faa6df8d24753",
-                "sha256:0da2f947e8ad2697e86fe5fd0e55a4093a2fd79d839c9e19c34e28097db7002c",
-                "sha256:35ff894a0b5df8e28b700126b2869c7dcfb2b2db5bc82e5d5e82547069241553",
-                "sha256:44688b94841349648b1e1a5a7a3d96e6596d5d4f21d0b59a82307e153c4dc74b",
-                "sha256:833716dde880a7f2f2ccdeea9a096842626981ff2a477d8b318c0906367ac11b",
                 "sha256:a0cf3e1842e7c60fde97cb22d275eb6f9524f5c5250489e292529de841417547",
-                "sha256:a38a8811ea784c0136abfdba73963876328f66172db21a05a82f9515909bfb4e",
-                "sha256:a728bb9502d1fdc104c66f24a176b6a70a32e89d1d8a5b55c959233ed51c67be",
-                "sha256:c30a098435ea0989c37005a971843e9d3966c7f6d056ddbf052e5061c06e3291",
-                "sha256:c355a45b32c5bc1d9893eceb704b0cfcd1126f91b5a7b9ee64c1c05383283381",
-                "sha256:e64679de1940f41ead5170fce364d54e7b9e2e862f064727b6bcb5cee753b7a2",
-                "sha256:ed71d20225c356881c29f0b1d7a0d6521563a389d9478e8f95d798cc5ba07b88",
-                "sha256:f183f0940b9f5ed2ad9d04c80cab2451440fa9af4fc959d85113fadd2e777962"
+                "sha256:a38a8811ea784c0136abfdba73963876328f66172db21a05a82f9515909bfb4e"
             ],
             "version": "==0.2.2"
         },
@@ -218,6 +205,7 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
+            "markers": "python_version >= '2.6' and python_version != '3.0.*' and python_version < '4' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.2.*'",
             "version": "==1.23"
         }
     },

--- a/billing-exporter/exporter/__main__.py
+++ b/billing-exporter/exporter/__main__.py
@@ -1,37 +1,47 @@
 import sys
-import argparse
 import json
 import signal
 import logging
 from threading import Event, Thread
+from urllib.parse import urlparse
 
 from prometheus_client import start_http_server
 from google.oauth2 import service_account
+import click
 
 from .checks.access import AccessCheck
 from .checks.usage import UsageCheck
 
 
-def parse_args(args):
-    parser = argparse.ArgumentParser('billing-exporter')
-    parser.add_argument(
-        '--bigquery-creds-file', required=True, type=str)
-    parser.add_argument(
-        '--users-db-creds-file', required=True, type=argparse.FileType('r'))
-    parser.add_argument(
-        '--billing-db-creds-file', required=True, type=argparse.FileType('r'))
-    parser.add_argument(
-        '--zuora-creds-file', required=True, type=argparse.FileType('r'))
-    parser.add_argument(
-        '--production', type=bool, default=False)
-    parser.add_argument(
-        '--check-instance-id', type=str, nargs='+')
-    return parser.parse_args(args)
+_LOG = logging.getLogger(__name__)
 
 
-def load_json_file(fh):
-    with fh:
-        return json.load(fh)
+class UriParamType(click.ParamType):
+    name = 'uri'
+
+    def convert(self, value, param, ctx):
+        try:
+            return urlparse(value)
+        except ValueError as e:
+            self.fail(f'{value!r} is not a valid URL: {e}', param, ctx)
+
+
+def inject_password_from_file(name, uri, password_file):
+    if not password_file:
+        return uri
+
+    if uri.password:
+        _LOG.warn('Password for %s specified in both URI and password file', name)
+    with password_file as fh:
+        password = fh.read()
+
+    netloc = ''
+    if uri.username:
+        netloc += uri.username
+    netloc += f':{password}@{uri.hostname}'
+    if uri.port:
+        netloc += f':{uri.port}'
+    return uri._replace(netloc=netloc)
 
 
 def run_checker(checker, *args, **kwargs):
@@ -39,20 +49,29 @@ def run_checker(checker, *args, **kwargs):
         try:
             checker.run(*args, **kwargs)
         except Exception as e:
-            print(e)
+            _LOG.exception("Unhandled exception in checker %s", checker)
             raise
 
     t = Thread(target=_target)
     t.start()
 
 
-def main(args):
+@click.command()
+@click.option('--billing-database-uri', type=UriParamType())
+@click.option('--billing-database-password-file', type=click.File(), default=None)
+@click.option('--users-database-uri', type=UriParamType())
+@click.option('--users-database-password-file', type=click.File(), default=None)
+@click.option('--zuora-uri', type=UriParamType())
+@click.option('--zuora-password-file', type=click.File(), default=None)
+@click.option('--bigquery-creds-file', type=click.Path())
+@click.option('--production', is_flag=True, flag_value=True, default=False)
+@click.option('--check-instance-id', 'check_instance_ids', multiple=True)
+def main(
+        billing_database_uri, billing_database_password_file, 
+        users_database_uri, users_database_password_file,
+        zuora_uri, zuora_password_file, bigquery_creds_file,
+        production, check_instance_ids):
     logging.basicConfig()
-
-    opts = parse_args(args)
-
-    bq_creds = service_account.Credentials.from_service_account_file(
-        opts.bigquery_creds_file)
 
     should_stop = Event()
     def signal_handler():
@@ -60,18 +79,28 @@ def main(args):
 
     signal.signal(signal.SIGINT, signal_handler)
 
+    billing_db_uri = inject_password_from_file(
+        'billing', billing_database_uri, billing_database_password_file).geturl()
+    users_db_uri = inject_password_from_file(
+        'users', users_database_uri, users_database_password_file).geturl()
+    zuora_uri = inject_password_from_file(
+        'zuora', zuora_uri, zuora_password_file).geturl()
+
+    bq_creds = service_account.Credentials.from_service_account_file(
+        bigquery_creds_file)
+
     run_checker(
-        AccessCheck(opts.production),
+        AccessCheck(production),
         should_stop,
         bq_creds)
     run_checker(
-        UsageCheck(opts.production),
+        UsageCheck(production),
         should_stop,
-        opts.check_instance_id,
+        check_instance_ids,
         bq_creds,
-        load_json_file(opts.users_db_creds_file),
-        load_json_file(opts.billing_db_creds_file),
-        load_json_file(opts.zuora_creds_file))
+        users_db_uri,
+        billing_db_uri,
+        zuora_uri)
 
     # Start up the server to expose the metrics.
     start_http_server(8000)

--- a/billing-exporter/exporter/billing/zuora.py
+++ b/billing-exporter/exporter/billing/zuora.py
@@ -3,6 +3,7 @@ import csv
 import tempfile
 from datetime import datetime, timedelta, timezone
 from functools import lru_cache
+from urllib.parse import urlparse
 
 
 def _fmt_date(date):
@@ -13,9 +14,21 @@ def parse_datetime(s):
     return datetime.strptime(s, '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone.utc)
 
 
+def extract_creds(uri):
+    pr = urlparse(uri)
+
+    netloc = pr.hostname
+    if pr.port:
+        netloc += f':{pr.port}'
+    base_url = pr._replace(netloc=netloc).geturl()
+
+    return pr.username, pr.password, base_url
+
+
 class Zuora(object):
-    def __init__(self, url, username, password):
-        self.base_url = url
+    def __init__(self, uri):
+        username, password, base_url = extract_creds(uri)
+        self.base_url = base_url
         self.s = s = requests.Session()
         s.auth = (username, password)
 


### PR DESCRIPTION
I realised the current approach would have required the secret to hold all connection info, which isn't great, so I tried to match the argument parsing tricks of the golang services


Towards the [post mortem](https://docs.google.com/document/d/1ZMbPsy0n7nuWXSr6eZuFAaJQUdxVczZKxT5SZC6rjmg/edit#heading=h.t2dwa58e340t) for  https://github.com/weaveworks/service-conf/issues/2349