### PR TITLE
Fix logging

### DIFF
--- a/billing-aggregator/main.go
+++ b/billing-aggregator/main.go
@@ -48,7 +48,6 @@ func main() {
 			"cron-spec",
 			"0 10 * * * *", // Hourly at 10 minutes past - Seconds, Minutes, Hours, Day of month, Month, Day of week
 			"Cron spec for periodic query execution.")
-		logLevel       = flag.String("log.level", "info", "The log level")
 		serverConfig   server.Config
 		bigQueryConfig bigquery.Config
 		dbConfig       dbconfig.Config
@@ -58,9 +57,10 @@ func main() {
 	dbConfig.RegisterFlags(flag.CommandLine, "postgres://postgres@billing-db/billing?sslmode=disable", "Database to use.", "/migrations", "Migrations directory.")
 	flag.Parse()
 
-	if err := logging.Setup(*logLevel); err != nil {
+	if err := logging.Setup(serverConfig.LogLevel.String()); err != nil {
 		log.Fatalf("Error initialising logging: %v", err)
 	}
+	serverConfig.Log = logging.Logrus(log.StandardLogger())
 
 	bigqueryClient, err := bigquery.New(context.Background(), bigQueryConfig)
 	if err != nil {

--- a/billing-api/main.go
+++ b/billing-api/main.go
@@ -19,8 +19,6 @@ import (
 
 // Config holds the API settings.
 type Config struct {
-	logLevel string
-
 	dbConfig     dbconfig.Config
 	routesConfig routes.Config
 	serverConfig server.Config
@@ -30,8 +28,6 @@ type Config struct {
 
 // RegisterFlags registers configuration variables.
 func (c *Config) RegisterFlags(f *flag.FlagSet) {
-	flag.StringVar(&c.logLevel, "log.level", "info", "The log level")
-
 	c.dbConfig.RegisterFlags(f, "postgres://postgres@billing-db/billing?sslmode=disable", "Database to use.", "/migrations", "Migrations directory.")
 	c.routesConfig.RegisterFlags(f)
 	c.serverConfig.RegisterFlags(f)
@@ -53,9 +49,10 @@ func main() {
 	if err := cfg.Validate(); err != nil {
 		log.Fatalf("invalid config: %v", err)
 	}
-	if err := logging.Setup(cfg.logLevel); err != nil {
+	if err := logging.Setup(cfg.serverConfig.LogLevel.String()); err != nil {
 		log.Fatalf("error initialising logging: %v", err)
 	}
+	cfg.serverConfig.Log = logging.Logrus(log.StandardLogger())
 
 	users, err := users.NewClient(cfg.usersConfig)
 	if err != nil {

--- a/billing-enforcer/main.go
+++ b/billing-enforcer/main.go
@@ -44,7 +44,6 @@ func main() {
 			// Hourly at xx:40 - Seconds, Minutes, Hours, Day of month, Month, Day of week
 			"0 40  * * *",
 			"Cron spec for periodic enforcement tasks.")
-		logLevel = flag.String("log.level", "info", "The log level")
 
 		serverConfig server.Config
 		usersConfig  users.Config
@@ -55,9 +54,10 @@ func main() {
 	usersConfig.RegisterFlags(flag.CommandLine)
 	flag.Parse()
 
-	if err := logging.Setup(*logLevel); err != nil {
+	if err := logging.Setup(serverConfig.LogLevel.String()); err != nil {
 		log.Fatalf("Error initialising logging: %v", err)
 	}
+	serverConfig.Log = logging.Logrus(log.StandardLogger())
 
 	users, err := users.NewClient(usersConfig)
 	if err != nil {

--- a/billing-uploader/main.go
+++ b/billing-uploader/main.go
@@ -65,7 +65,6 @@ func main() {
 			"invoice-cron-spec",
 			"0 * * * * *", // Every minute
 			"Cron spec for periodic execution of the invoice job")
-		logLevel     = flag.String("log.level", "info", "The log level")
 		serverConfig server.Config
 		dbConfig     dbconfig.Config
 		usersConfig  users.Config
@@ -79,9 +78,10 @@ func main() {
 	gcpConfig.RegisterFlags(flag.CommandLine)
 	flag.Parse()
 
-	if err := logging.Setup(*logLevel); err != nil {
+	if err := logging.Setup(serverConfig.LogLevel.String()); err != nil {
 		log.Fatalf("Error initialising logging: %v", err)
 	}
+	serverConfig.Log = logging.Logrus(log.StandardLogger())
 
 	db, err := db.New(dbConfig)
 	if err != nil {

--- a/dashboard-api/main.go
+++ b/dashboard-api/main.go
@@ -12,7 +12,6 @@ import (
 )
 
 type config struct {
-	logLevel   string
 	prometheus struct {
 		uri     string
 		timeout time.Duration
@@ -21,7 +20,6 @@ type config struct {
 }
 
 func (c *config) registerFlags(f *flag.FlagSet) {
-	flag.StringVar(&c.logLevel, "log.level", "info", "The log level")
 	flag.StringVar(&c.prometheus.uri, "prometheus.uri", "http://querier.cortex.svc.cluster.local", "Prometheus server URI")
 	flag.DurationVar(&c.prometheus.timeout, "prometheus.timeout", 10*time.Second, "Timout when talking to the prometheus API")
 
@@ -34,9 +32,10 @@ func main() {
 	flag.Parse()
 	cfg.server.MetricsNamespace = "service"
 
-	if err := logging.Setup(cfg.logLevel); err != nil {
+	if err := logging.Setup(cfg.server.LogLevel.String()); err != nil {
 		log.Fatalf("error initializing logging: %v", err)
 	}
+	cfg.server.Log = logging.Logrus(log.StandardLogger())
 
 	server, err := server.New(cfg.server)
 	if err != nil {

--- a/gcp-launcher-webhook/main.go
+++ b/gcp-launcher-webhook/main.go
@@ -8,6 +8,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/weaveworks/common/logging"
 	"github.com/weaveworks/common/server"
 	"github.com/weaveworks/service/common"
 	"github.com/weaveworks/service/common/gcp/partner"
@@ -20,6 +21,7 @@ import (
 type config struct {
 	port               int
 	endpoint           string
+	logLevel           string
 	secret             string // Secret used to authenticate incoming GCP webhook requests.
 	createSubscription bool
 	subscriptionID     string
@@ -31,6 +33,7 @@ type config struct {
 }
 
 func (c *config) RegisterFlags(f *flag.FlagSet) {
+	flag.StringVar(&c.logLevel, "log.level", "info", "Logging level to use: debug | info | warn | error")
 	flag.IntVar(&c.port, "port", 80, "HTTP port for the Cloud Launcher's GCP Pub/Sub push webhook")
 	flag.StringVar(&c.endpoint, "webhook-endpoint", "https://frontend.dev.weave.works/api/gcp-launcher/webhook?secret=FILLMEIN", "Endpoint this webhook is accessible from the outside")
 	flag.BoolVar(&c.createSubscription, "pubsub-api.create-subscription", false, "Enable/Disable programmatic creation of the Pub/Sub subscription.")
@@ -58,6 +61,11 @@ func main() {
 	cfg.RegisterFlags(flag.CommandLine)
 	flag.Parse()
 
+	if err := logging.Setup(cfg.logLevel); err != nil {
+		log.Fatalf("Error configuring logging: %v", err)
+		return
+	}
+
 	if cfg.createSubscription {
 		createSubscription(&cfg)
 	}
@@ -76,6 +84,7 @@ func main() {
 		HTTPListenPort:          cfg.port,
 		MetricsNamespace:        common.PrometheusNamespace,
 		RegisterInstrumentation: true,
+		Log: logging.Logrus(log.StandardLogger()),
 	}
 	server, err := server.New(serverCfg)
 	if err != nil {

--- a/notebooks/cmd/notebooks/main.go
+++ b/notebooks/cmd/notebooks/main.go
@@ -5,6 +5,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/weaveworks/common/logging"
 	"github.com/weaveworks/common/server"
 	"github.com/weaveworks/service/common/dbconfig"
 	"github.com/weaveworks/service/notebooks/api"
@@ -30,6 +31,11 @@ func main() {
 		"Path where the database migration files can be found")
 
 	flag.Parse()
+
+	if err := logging.Setup(serverConfig.LogLevel.String()); err != nil {
+		log.Fatalf("error initialising logging: %v", err)
+	}
+	serverConfig.Log = logging.Logrus(log.StandardLogger())
 
 	db, err := db.New(dbConfig)
 	if err != nil {

--- a/notification-eventmanager/cmd/eventmanager/main.go
+++ b/notification-eventmanager/cmd/eventmanager/main.go
@@ -23,7 +23,6 @@ func main() {
 			ServerGracefulShutdownTimeout: 16 * time.Second,
 		}
 		dbConfig dbconfig.Config
-		logLevel string
 		sqsURL   string
 		// Connect to users service to get information about an event's instance
 		usersServiceURL string
@@ -34,7 +33,6 @@ func main() {
 	serverConfig.RegisterFlags(flag.CommandLine)
 	dbConfig.RegisterFlags(flag.CommandLine, "", "URI where the database can be found", "", "Path where the database migration files can be found")
 
-	flag.StringVar(&logLevel, "log.level", "info", "Logging level to use: debug | info | warn | error")
 	flag.StringVar(&sqsURL, "sqsURL", "sqs://123user:123password@localhost:9324/events", "URL to connect to SQS")
 	flag.StringVar(&usersServiceURL, "usersServiceURL", "users.default:4772", "URL to connect to users service")
 	flag.StringVar(&eventTypesPath, "eventtypes", "", "Path to a JSON file defining available event types")
@@ -42,9 +40,10 @@ func main() {
 
 	flag.Parse()
 
-	if err := logging.Setup(logLevel); err != nil {
+	if err := logging.Setup(serverConfig.LogLevel.String()); err != nil {
 		log.Fatalf("Error configuring logging: %v", err)
 	}
+	serverConfig.Log = logging.Logrus(log.StandardLogger())
 
 	sqsCli, sqsQueue, err := sqsconnect.NewSQS(sqsURL)
 	if err != nil {

--- a/users/cmd/users/main.go
+++ b/users/cmd/users/main.go
@@ -209,6 +209,7 @@ func main() {
 		GRPCListenPort:          *grpcPort,
 		GRPCMiddleware:          []grpc.UnaryServerInterceptor{render.GRPCErrorInterceptor},
 		RegisterInstrumentation: true,
+		Log: logging.Logrus(log.StandardLogger()),
 	})
 	if err != nil {
 		log.Fatalf("Failed to create server: %v", err)


### PR DESCRIPTION
After merging #2201 all logging disappeared.

Revert the commit that caused the issue and have another go.

If the main program and the library both register a flag `-log.level` then the program will abort.  In general we standardise on the one from package `weaveworks/common/server`, except where the program did not register that package's flags and used its own.

Add logging initialization to a couple of programs that had none, and thus non-standard formatting.