### PR TITLE
Calculate active hosts by the usage bucket from 2 hours ago

### DIFF
--- a/billing-api/routes/accounts.go
+++ b/billing-api/routes/accounts.go
@@ -480,10 +480,10 @@ func (a *API) GetAccountStatus(w http.ResponseWriter, r *http.Request) {
 
 	sum, hourly, daily := sumAndFilterAggregates(aggs)
 
-	// Look at the usage for the previous hourly bucket because we get bad
-	// (too low) values from the most recent bucket, because it's not
-	// complete yet and we are dividing by a full hour's worth of seconds
-	bucket := time.Now().UTC().Truncate(time.Hour).Add(-1 * time.Hour)
+	// Look at the usage from a previous hourly bucket, picking a bucket to avoid finding a value that is too low.
+	// We can't use the current hour because we don't aggregate until the end of an hour
+	// We don't use the previous hour because sometimes usage arrives late, and won't be counted until the current hour is up
+	bucket := time.Now().UTC().Truncate(time.Hour).Add(-2 * time.Hour)
 	var activeHosts float64
 	if bucketSeconds, ok := hourly[bucket]; ok {
 		activeHosts = float64(bucketSeconds) / time.Hour.Seconds()


### PR DESCRIPTION
I did some analysis in dev:

```
Usage per hour:
U: 2018-07-26T00:00:00+00:00 6.0008333333333335
U: 2018-07-26T01:00:00+00:00 5.9991666666666665
U: 2018-07-26T02:00:00+00:00 6
U: 2018-07-26T03:00:00+00:00 6
U: 2018-07-26T04:00:00+00:00 6
U: 2018-07-26T05:00:00+00:00 6
U: 2018-07-26T06:00:00+00:00 6
U: 2018-07-26T07:00:00+00:00 6
U: 2018-07-26T08:00:00+00:00 6
U: 2018-07-26T09:00:00+00:00 6.0008333333333335
U: 2018-07-26T10:00:00+00:00 5.9775
U: 2018-07-26T11:00:00+00:00 6.0008333333333335
U: 2018-07-26T12:00:00+00:00 6
U: 2018-07-26T13:00:00+00:00 5.9991666666666665
U: 2018-07-26T14:00:00+00:00 3.3991666666666664

We used:
B: 2018-07-26T14:00:00+00:00
```

We were picking a partially complete bucket, which was exactly the thing we were trying to avoid.

Actually fixes #2204