### PR TITLE
Add routes for a terradiff for weaveworks/corp

### DIFF
--- a/authfe/config.go
+++ b/authfe/config.go
@@ -68,6 +68,7 @@ type Config struct {
 	billingUploaderHost   proxyConfig
 	compareImagesHost     proxyConfig
 	compareRevisionsHost  proxyConfig
+	corpTerradiffHost     proxyConfig
 	devGrafanaHost        proxyConfig
 	elasticsearchHost     proxyConfig
 	eshHost               proxyConfig
@@ -124,6 +125,7 @@ func (c *Config) proxies() map[string]*proxyConfig {
 		"billing-uploader":   &c.billingUploaderHost,
 		"compare-images":     &c.compareImagesHost,
 		"compare-revisions":  &c.compareRevisionsHost,
+		"corp-terradiff":     &c.corpTerradiffHost,
 		"dev-grafana":        &c.devGrafanaHost,
 		"elasticsearch":      &c.elasticsearchHost,
 		"esh":                &c.eshHost,

--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -344,6 +344,7 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 				{"/kibana", trimPrefix("/admin/kibana", c.kibanaHost)},
 				{"/elasticsearch", trimPrefix("/admin/elasticsearch", c.elasticsearchHost)},
 				{"/esh", trimPrefix("/admin/esh", c.eshHost)},
+				{"/corp-terradiff", trimPrefix("/admin/corp-terradiff", c.corpTerradiffHost)},
 				{"/", http.HandlerFunc(adminRoot)},
 			}),
 			middleware.Merge(


### PR DESCRIPTION
Not sure if this needs to land before or after weaveworks/service-conf#2448, or after we actually have something running and working.

Nevertheless, submitting here because it's a key part of weaveworks/corp#61.