### PR TITLE
authfe routing for atlantis

### DIFF
--- a/authfe/config.go
+++ b/authfe/config.go
@@ -68,6 +68,7 @@ type Config struct {
 	billingUploaderHost   proxyConfig
 	compareImagesHost     proxyConfig
 	compareRevisionsHost  proxyConfig
+	corpAtlantisHost      proxyConfig
 	corpTerradiffHost     proxyConfig
 	devGrafanaHost        proxyConfig
 	elasticsearchHost     proxyConfig
@@ -125,6 +126,7 @@ func (c *Config) proxies() map[string]*proxyConfig {
 		"billing-uploader":   &c.billingUploaderHost,
 		"compare-images":     &c.compareImagesHost,
 		"compare-revisions":  &c.compareRevisionsHost,
+		"corp-atlantis":      &c.corpAtlantisHost,
 		"corp-terradiff":     &c.corpTerradiffHost,
 		"dev-grafana":        &c.devGrafanaHost,
 		"elasticsearch":      &c.elasticsearchHost,

--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -313,6 +313,15 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 		dataUploadRoutes,
 		dataAccessRoutes,
 
+		// Unauthenticated webhook for Atlantis. We trust Atlantis to do its own authenication.
+		MiddlewarePrefix{
+			"/",
+			Matchables([]Prefix{
+				{"/admin/corp-atlantis/events", trimPrefix("/admin/corp-atlantis", c.corpAtlantisHost)},
+			}),
+			uiHTTPlogger,
+		},
+
 		// For all admin functionality, authenticated using header credentials
 		MiddlewarePrefix{
 			"/admin",
@@ -344,6 +353,7 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 				{"/kibana", trimPrefix("/admin/kibana", c.kibanaHost)},
 				{"/elasticsearch", trimPrefix("/admin/elasticsearch", c.elasticsearchHost)},
 				{"/esh", trimPrefix("/admin/esh", c.eshHost)},
+				{"/corp-atlantis", trimPrefix("/admin/corp-atlantis", c.corpAtlantisHost)},
 				{"/corp-terradiff", trimPrefix("/admin/corp-terradiff", c.corpTerradiffHost)},
 				{"/", http.HandlerFunc(adminRoot)},
 			}),


### PR DESCRIPTION
Directly forward the webhook events to atlantis, because we trust it to test GitHub signing.

@squaremo, this is much simpler than we discussed, because I think this is worth a try. I have a local patch that does the GitHub signing check in authfe as well. I just question its worth.