### PR TITLE
Ignore samples from rules when checking prom agent status

### DIFF
--- a/users/api/services.go
+++ b/users/api/services.go
@@ -69,7 +69,9 @@ type scopeStatus struct {
 
 type promStatus struct {
 	FirstSeenConnectedAt *time.Time `json:"firstSeenConnectedAt"`
-	IngestionRate        float64    `json:"ingestionRate"`
+	IngestionRate        float64    `json:"ingestionRate,omitempty"`
+	APIIngestionRate     float64    `json:"APIIngestionRate"`
+	RuleIngestionRate    float64    `json:"RuleIngestionRate"`
 	NumSeries            uint64     `json:"numSeries"`
 	NumberOfMetrics      int        `json:"numberOfMetrics"`
 	Error                string     `json:"error,omitempty"`
@@ -113,7 +115,13 @@ func (a *API) getOrgServiceStatus(currentUser *users.User, w http.ResponseWriter
 	status := a.getServiceStatus(r.Context(), sparse)
 	fluxConnected := status.flux.Fluxd.Connected
 	scopeConnected := status.scope.NumberOfProbes > 0
-	promConnected := status.prom.NumSeries > 0
+	var promConnected bool
+	if status.prom.APIIngestionRate == 0 && status.prom.RuleIngestionRate == 0 {
+		// Legacy: if the specific rates are missing, use the series count.
+		promConnected = status.prom.NumSeries > 0
+	} else {
+		promConnected = status.prom.APIIngestionRate > 0
+	}
 	netConnected := status.net.NumberOfPeers > 0
 	anyConnected := (fluxConnected || scopeConnected || promConnected || netConnected)
 	now := mtime.Now()


### PR DESCRIPTION
Should fix https://github.com/weaveworks/service-ui/issues/604
Depends on https://github.com/weaveworks/cortex/pull/924 so tested only in unit tests.