### PR TITLE
Add security headers to stop PII leak in referrer URLs

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -32,9 +32,13 @@ const maxAnalyticsPayloadSize = 16 * 1024 // bytes
 
 func (c Config) commonMiddleWare(routeMatcher middleware.RouteMatcher) middleware.Interface {
 	extraHeaders := http.Header{}
+
+	// Common security headers
 	extraHeaders.Add("X-Frame-Options", "SAMEORIGIN")
 	extraHeaders.Add("X-XSS-Protection", "1; mode=block")
 	extraHeaders.Add("X-Content-Type-Options", "nosniff")
+	extraHeaders.Add("Referrer-Policy", "origin-when-cross-origin")
+
 	if c.sendCSPHeader {
 		extraHeaders.Add("Content-Security-Policy", "default-src https: 'unsafe-inline'")
 	}


### PR DESCRIPTION
Fixes #2240 

See https://github.com/weaveworks/service-conf/issues/2517