### PR TITLE
Move fluentd buffers to /fluentd/log

### DIFF
--- a/logging/fluent-dev.conf
+++ b/logging/fluent-dev.conf
@@ -28,7 +28,7 @@
 
    # buffering
    buffer_type file
-   buffer_path /var/log/bigquery.*.buffer
+   buffer_path /fluentd/log/bigquery.*.buffer
    flush_interval 0.25
    try_flush_interval 0.05
    flush_at_shutdown true

--- a/logging/fluent.conf
+++ b/logging/fluent.conf
@@ -37,7 +37,7 @@
 
    # buffering
    buffer_type file
-   buffer_path /var/log/bigquery.*.buffer
+   buffer_path /fluentd/log/bigquery.*.buffer
    flush_interval 0.25
    try_flush_interval 0.05
    flush_at_shutdown true


### PR DESCRIPTION
Fixes #2242

`/fluentd` already exists in the image, and is `chown`-ed in `/etc/entrypoint.sh`