### PR TITLE
Notification: add Weave Cloud link to all events

### DIFF
--- a/notification-eventmanager/eventmanager/configchanged.go
+++ b/notification-eventmanager/eventmanager/configchanged.go
@@ -77,7 +77,7 @@ func (em *EventManager) createConfigChangedEvent(ctx context.Context, instanceID
 			return errors.Wrap(err, "cannot get email message")
 		}
 
-		browserMsg, err := render.BrowserFromSlack(types.SlackMessage{Text: msg}, eventType, "", "")
+		browserMsg, err := render.BrowserFromSlack(types.SlackMessage{Text: msg}, eventType, link, "Weave Cloud notification")
 		if err != nil {
 			return errors.Wrap(err, "cannot get email message")
 		}
@@ -135,7 +135,7 @@ func (em *EventManager) createConfigChangedEvent(ctx context.Context, instanceID
 			return errors.Wrap(err, "cannot get email message")
 		}
 
-		browserMsg, err := render.BrowserFromSlack(types.SlackMessage{Text: text}, eventType, "", "")
+		browserMsg, err := render.BrowserFromSlack(types.SlackMessage{Text: text}, eventType, link, "Weave Cloud notification")
 		if err != nil {
 			return errors.Wrap(err, "cannot get email message")
 		}


### PR DESCRIPTION
Add Weave Cloud link to `user_test` and `config_changed` events.

Fixes https://github.com/weaveworks/service/issues/1932