### PR TITLE
Remove dead notification code

### DIFF
--- a/flux-api/notifications/notifications.go
+++ b/flux-api/notifications/notifications.go
@@ -24,41 +24,6 @@ func Event(url string, e event.Event, instID service.InstanceID) error {
 		return nil
 	}
 
-	// temporary check if we should use new url to send events to,
-	// can remove it after we switch to new url in service-conf
-	if strings.Contains(url, "slack") {
-		switch e.Type {
-		case event.EventRelease:
-			r := e.Metadata.(*event.ReleaseEventMetadata)
-			return slackNotifyRelease(url, r, r.Error)
-		case event.EventAutoRelease:
-			r := e.Metadata.(*event.AutoReleaseEventMetadata)
-			return slackNotifyAutoRelease(url, r, r.Error)
-		case event.EventSync:
-			details := e.Metadata.(*event.SyncEventMetadata)
-			if details.Includes != nil {
-				if _, ok := details.Includes[event.NoneOfTheAbove]; !ok {
-					return nil
-				}
-			}
-			return slackNotifySync(url, &e)
-		case event.EventCommit:
-			commitMetadata := e.Metadata.(*event.CommitEventMetadata)
-			switch commitMetadata.Spec.Type {
-			case update.Policy:
-				return slackNotifyCommitPolicyChange(url, commitMetadata)
-			case update.Images:
-				return slackNotifyCommitRelease(url, commitMetadata)
-			case update.Auto:
-				return slackNotifyCommitAutoRelease(url, commitMetadata)
-			default:
-				return errors.Errorf("cannot notify for event, unknown commit metadata event type %s", commitMetadata.Spec.Type)
-			}
-		default:
-			return errors.Errorf("cannot notify for event, unknown event type %s", e.Type)
-		}
-	}
-
 	var notifyEvent notificationTypes.Event
 	notifyData := e.Metadata
 	notifyEvent.InstanceID = string(instID)

--- a/flux-api/notifications/notifications_test.go
+++ b/flux-api/notifications/notifications_test.go
@@ -1,7 +1,6 @@
 package notifications
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,7 +9,6 @@ import (
 	"github.com/weaveworks/flux/event"
 	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/update"
-	"github.com/weaveworks/service/flux-api/service"
 )
 
 // Generate an example release
@@ -70,10 +68,8 @@ func TestNotificationEventsURL(t *testing.T) {
 	}))
 	defer server.Close()
 
-	var instanceID service.InstanceID = "2"
-	eventsURL := server.URL + fmt.Sprintf("/api/notification/slack/%v/{eventType}", instanceID)
-	eventType := "deploy"
-	expectedPath := fmt.Sprintf("/api/notification/slack/%v/%v", instanceID, eventType)
+	path := "/api/notification/events"
+	eventsURL := server.URL + path
 
 	ev := event.Event{Metadata: exampleRelease(t), Type: event.EventRelease}
 
@@ -83,7 +79,7 @@ func TestNotificationEventsURL(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if gotReq.URL.EscapedPath() != expectedPath {
-		t.Fatalf("Expected: %v, Got: %v", expectedPath, gotReq.URL.String())
+	if gotReq.URL.EscapedPath() != path {
+		t.Fatalf("Expected: %v, Got: %v", path, gotReq.URL.String())
 	}
 }


### PR DESCRIPTION
We moved to

    --events-url=http://eventmanager.notification.svc.cluster.local/api/notification/events

so this code path should no longer trigger.