### PR TITLE
Only update scope version after deploy job succeeds

### DIFF
--- a/service-ui-kicker/scope/handler.go
+++ b/service-ui-kicker/scope/handler.go
@@ -109,7 +109,9 @@ func (u *Updater) HandlePush(pl github.PushPayload) {
 // HandleStatus handles GitHub Commit status updated from the API
 func (u *Updater) HandleStatus(pl github.StatusPayload) {
 	u.mu.Lock()
-	if !(pl.Sha == u.latest && pl.State == "success") {
+	// 'deploy' is the name of the Circle CI job which publishes the scope assets
+	// 'ci/circleci: ' is the prefix CircleCI uses when it reports build status to Github
+	if !(pl.Sha == u.latest && pl.State == "success" && pl.Context == "ci/circleci: deploy") {
 		u.mu.Unlock()
 		return
 	}


### PR DESCRIPTION
Has been broken since https://github.com/weaveworks/scope/pull/3333 split the CI pipeline into multiple jobs. The hook fires when the first job completes, which is before the artifacts are available.