### PR TITLE
Only hide Event.Metadata in simple history requests

### DIFF
--- a/flux-api/http/server.go
+++ b/flux-api/http/server.go
@@ -323,9 +323,9 @@ func (s Server) history(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.FormValue("simple") == "true" {
-		// Remove all the individual event data, just return the timestamps and messages
+		// Remove event metadata as it's the only bit that adds a significant overhead.
 		for i := range h {
-			h[i].Event = nil
+			h[i].Event.Metadata = nil
 		}
 	}
 


### PR DESCRIPTION
Resolves #2228 by exposing event IDs even in simple requests.
Resolves #2130 by exposing event service IDs even in simple requests.
 
Most of the JSON overhead for simple requests comes from `Event.Metadata` chunks, so they are still kept hidden. Everything else in the `Event` hash however seems quite lightweight and there are a few fields that might be quite useful on the UI even for simple requests.

For example, the `Data` field is barely used in its raw format in the UI, but instead we do parsing in a couple of places to get the event type and a list of service IDs so that the UI can interpret them and format them into appropriate messages.

With `ServiceIDs` and `Type` type fields being always exposed, we can have Time Travel timeline etc. components interpreting this info in a cleaner way and perhaps eventually drop the `Data` field altogether...

**Note:** I didn't manage to test this locally, but since the change is literally one line, I don't expect it would break things?