### PR TITLE
Send user name & company info to marketo

### DIFF
--- a/users-sync/attrsync/marketo.go
+++ b/users-sync/attrsync/marketo.go
@@ -1,0 +1,23 @@
+package attrsync
+
+import (
+	"github.com/FrenchBen/goketo"
+
+	"github.com/weaveworks/service/users/marketing"
+)
+
+// NewMarketoClient returns a new marketo client from the connection, auth & program details
+// NB: if cfg.ClientID == "" it will return a Noop client
+func NewMarketoClient(cfg marketing.MarketoConfig) (marketing.MarketoClient, error) {
+	if cfg.ClientID == "" {
+		return &marketing.NoopMarketoClient{}, nil
+	}
+
+	goketoClient, err := goketo.NewAuthClient(
+		cfg.ClientID, cfg.Secret, cfg.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	return marketing.NewMarketoClient(goketoClient, cfg.Program), nil
+}

--- a/users-sync/attrsync/sync_test.go
+++ b/users-sync/attrsync/sync_test.go
@@ -2,6 +2,7 @@ package attrsync
 
 import (
 	"context"
+	"github.com/weaveworks/service/users/marketing"
 	"testing"
 	"time"
 
@@ -46,8 +47,9 @@ func setup(t *testing.T) (testFixtures, *AttributeSyncer) {
 	ctrl := gomock.NewController(t)
 	billingClient := billing_grpc.NewMockBillingClient(ctrl)
 	mockSegment := MockSegment{}
+	noopMarketo := marketing.NoopMarketoClient{}
 
-	attrSync := New(logger, db, billingClient, &mockSegment)
+	attrSync := New(logger, db, billingClient, &mockSegment, &noopMarketo)
 
 	return testFixtures{billingClient, ctrl, ctx, db, &mockSegment}, attrSync
 }


### PR DESCRIPTION
This doesn't use the existing 'marketingQueues' mechanism because it's a little square-peg-round-hole already, and we're already rate limiting this so we don't need that part of it.

Towards https://github.com/weaveworks/service-ui/issues/2812
Related to https://github.com/weaveworks/service/issues/1308