### PR TITLE
Small tweaks to weekly emails

### DIFF
--- a/common/templates/wrapper.html
+++ b/common/templates/wrapper.html
@@ -23,19 +23,19 @@
       </div>
       <div style="display: inline-block">
         <a style="text-decoration: none; margin-right: 16px;" href="https://www.facebook.com/WeaveworksInc/" target="_blank">
-          <img style="width: 24px; height: 24px" src="https://s3-us-west-2.amazonaws.com/weaveworks-ui-components/images/facebook-square.png" alt="Facebook_icon_128x128-circle.png" height="32" width="32" constrain="true" imagepreview="false">
+          <img style="width: 22px; height: 22px" src="https://s3-us-west-2.amazonaws.com/weaveworks-ui-components/images/facebook-square.png" alt="Facebook_icon_128x128-circle.png" height="32" width="32" constrain="true" imagepreview="false">
         </a>
         <a style="text-decoration: none; margin-right: 16px;" href="https://twitter.com/weaveworks?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor" target="_blank">
-          <img style="width: 24px; height: 24px" src="https://s3-us-west-2.amazonaws.com/weaveworks-ui-components/images/twitter-square.png" alt="Twitter_icon_128x128-circle.png" height="32" width="32" constrain="true" imagepreview="false">
+          <img style="width: 22px; height: 22px" src="https://s3-us-west-2.amazonaws.com/weaveworks-ui-components/images/twitter-square.png" alt="Twitter_icon_128x128-circle.png" height="32" width="32" constrain="true" imagepreview="false">
         </a>
-        <a style="text-decoration: none; margin-right: 16px;" href="https://weave-community.slack.com/messages">
-          <img style="width: 24px; height: 24px" src="https://s3-us-west-2.amazonaws.com/weaveworks-ui-components/images/slack.png" alt="googleplus_icon_128x128-circle.png" height="32" width="32" constrain="true" imagepreview="false">
+        <a style="text-decoration: none; margin-right: 16px;" href="https://weave-community.slack.com/messages" target="_blank">
+          <img style="width: 22px; height: 22px" src="https://s3-us-west-2.amazonaws.com/weaveworks-ui-components/images/slack.png" alt="googleplus_icon_128x128-circle.png" height="32" width="32" constrain="true" imagepreview="false">
         </a>
         <a style="text-decoration: none; margin-right: 16px;" href="https://www.youtube.com/channel/UCmIz9ew1lA3-XDy5FqY-mrA" target="_blank">
-          <img style="width: 24px; height: 24px" src="https://s3-us-west-2.amazonaws.com/weaveworks-ui-components/images/youtube-square.png" alt="Youtube_icon_128x128-circle.png" height="32" width="32" constrain="true" imagepreview="false">
+          <img style="width: 22px; height: 22px" src="https://s3-us-west-2.amazonaws.com/weaveworks-ui-components/images/youtube-square.png" alt="Youtube_icon_128x128-circle.png" height="32" width="32" constrain="true" imagepreview="false">
         </a>
-        <a style="text-decoration: none; margin-right: 16px;" href="https://www.linkedin.com/company-beta/9420084" target="_blank">
-          <img style="width: 24px; height: 24px" src="https://s3-us-west-2.amazonaws.com/weaveworks-ui-components/images/linkedin-square.png" alt="LinkedIn_icon_128x128-circle.png" height="32" width="32" constrain="true" imagepreview="false">
+        <a style="text-decoration: none; margin-right: 16px;" href="https://www.linkedin.com/company/weaveworks" target="_blank">
+          <img style="width: 22px; height: 22px" src="https://s3-us-west-2.amazonaws.com/weaveworks-ui-components/images/linkedin-square.png" alt="LinkedIn_icon_128x128-circle.png" height="32" width="32" constrain="true" imagepreview="false">
         </a>
       </div>
     </div>

--- a/users/weekly-summary/README
+++ b/users/weekly-summary/README
@@ -9,3 +9,5 @@ const = (
     fluxURI = "https://user:[TOKEN]@frontend.dev.weave.works/api/flux"
 )
 ```
+
+On top of that, `report.Organization.CreatedAt` in `generateDeploymentsHistogram` probably needs to be pushed a few days back to make sure the creation date of the local instance is not blocking the deployments histogram from being shown.


### PR DESCRIPTION
##### Changes

* Reduced the social networks' icons `24px` -> `22px` to match the real image size and avoid blurriness - in a long run, we should probably use bigger images, but this fixes #2332 quickly
* Fixed the LinkedIn link - fixes #2334
* Opens Slack link in a new tab (for consistency with other 4 icons)
* Some extra explanation for developing weekly emails locally
