### PR TITLE
bump fluentd elasticsearch plugin version

### DIFF
--- a/fluentd-loggly/Dockerfile
+++ b/fluentd-loggly/Dockerfile
@@ -12,7 +12,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev autoconf automake libtool lib
          fluent-plugin-concat:2.2.0 \
          fluent-plugin-fields-parser:0.1.2 \
          fluent-plugin-rewrite-tag-filter:2.0.2 \
-         fluent-plugin-elasticsearch:2.8.2 \
+         fluent-plugin-elasticsearch:2.11.11 \
  && sudo gem sources --clear-all \
  && SUDO_FORCE_REMOVE=yes \
     apt-get purge -y --auto-remove \


### PR DESCRIPTION
...in the hope that this will stop errors like `Yajl::EncodeError error="'Infinity' is an invalid number` or at least prevent them from being considered as recoverable errors, which causes us to actually lose logs - see weaveworks/service-conf#2689.

NB: The latest version is 2.12.0, but that feels a bit too risky, it being very recent and .0.