### PR TITLE
Enforce wait period between Marketo pushes

### DIFF
--- a/users/marketing/queue.go
+++ b/users/marketing/queue.go
@@ -91,8 +91,11 @@ func (c *Queue) loop() {
 func (c *Queue) waitForStuffToDo() {
 	c.Lock()
 	defer c.Unlock()
-	for len(c.hits)+len(c.prospects) == 0 {
+	for {
 		c.cond.Wait()
+		if len(c.hits)+len(c.prospects) > 0 {
+			break
+		}
 	}
 }
 


### PR DESCRIPTION
We have a 1min wait period between pushes which was only enforced if
there is no work in the queue.

It seems we have enough movements on Weave Cloud to always have
something in the queue when returning from our previous request. This
means that we send request after request leading to more than the 50k
quota we have per day.

This PR changes to enforce the 1min wait time unless an explicit trigger
(sync.Broadcast) requests an upload.

This helps with https://github.com/weaveworks/service-conf/issues/2698