### PR TITLE
Use consistent struct pointer receiver

### DIFF
--- a/users/db/memory/organization.go
+++ b/users/db/memory/organization.go
@@ -453,7 +453,7 @@ func (d *DB) MoveOrganizationToTeam(ctx context.Context, externalID, teamExterna
 	})
 }
 
-func (d DB) findTeamByExternalID(ctx context.Context, externalID string) (*users.Team, error) {
+func (d *DB) findTeamByExternalID(ctx context.Context, externalID string) (*users.Team, error) {
 	for _, t := range d.teams {
 		if t.ExternalID == externalID {
 			return t, nil

--- a/users/db/memory/team.go
+++ b/users/db/memory/team.go
@@ -113,7 +113,7 @@ func (d *DB) AddUserToTeam(_ context.Context, userID, teamID string) error {
 }
 
 // DeleteTeam marks the given team as deleted.
-func (d DB) DeleteTeam(ctx context.Context, teamID string) error {
+func (d *DB) DeleteTeam(ctx context.Context, teamID string) error {
 	// Verify team has no orgs
 	for _, org := range d.organizations {
 		if org.TeamID == teamID {
@@ -137,7 +137,7 @@ func (d DB) DeleteTeam(ctx context.Context, teamID string) error {
 }
 
 // getTeamUserIsPartOf returns the team the user is part of.
-func (d DB) getTeamUserIsPartOf(ctx context.Context, userID, teamExternalID string) (*users.Team, error) {
+func (d *DB) getTeamUserIsPartOf(ctx context.Context, userID, teamExternalID string) (*users.Team, error) {
 	if teamExternalID == "" {
 		return nil, errors.New("teamExternalID must be provided")
 	}
@@ -165,7 +165,7 @@ func (d DB) getTeamUserIsPartOf(ctx context.Context, userID, teamExternalID stri
 }
 
 // ensureUserIsPartOfTeamByName ensures the users is part of team by name, the team is created if it does not exist
-func (d DB) ensureUserIsPartOfTeamByName(ctx context.Context, userID, teamName string) (*users.Team, error) {
+func (d *DB) ensureUserIsPartOfTeamByName(ctx context.Context, userID, teamName string) (*users.Team, error) {
 	// no lock needed: caller must acquire lock.
 	if teamName == "" {
 		return nil, errors.New("teamName must be provided")

--- a/users/db/memory/user.go
+++ b/users/db/memory/user.go
@@ -23,7 +23,7 @@ func (d *DB) CreateUser(_ context.Context, email string, details *users.UserUpda
 }
 
 // UpdateUser applies a UserUpdate to an existing user
-func (d DB) UpdateUser(ctx context.Context, userID string, update *users.UserUpdate) (*users.User, error) {
+func (d *DB) UpdateUser(ctx context.Context, userID string, update *users.UserUpdate) (*users.User, error) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 	if update.Name != "" {
@@ -44,7 +44,7 @@ func (d DB) UpdateUser(ctx context.Context, userID string, update *users.UserUpd
 
 // DeleteUser marks a user as deleted. It also removes the user from memberships and triggers a deletion of organizations
 // where the user was the lone member.
-func (d DB) DeleteUser(ctx context.Context, userID string) error {
+func (d *DB) DeleteUser(ctx context.Context, userID string) error {
 	// All organizations with this user as sole member
 	for orgID, us := range d.memberships {
 		if len(us) == 1 && us[0] == userID {


### PR DESCRIPTION
Hinted by `go tool vet .`. While functionality wasn't broken (the data
it accesses are maps which contain pointers themselves), it is error
prone in case someone in the future attempts to modify a struct field
that is not a pointer.