### PR TITLE
include deleted orgs in user's org list in admin interface

### DIFF
--- a/users/api/admin.go
+++ b/users/api/admin.go
@@ -244,7 +244,7 @@ func (a *API) adminListOrganizationsForUser(w http.ResponseWriter, r *http.Reque
 		renderError(w, r, err)
 		return
 	}
-	organizations, err := a.db.ListOrganizationsForUserIDs(r.Context(), userID)
+	organizations, err := a.db.ListAllOrganizationsForUserIDs(r.Context(), userID)
 	if err != nil {
 		renderError(w, r, err)
 		return

--- a/users/db/db.go
+++ b/users/db/db.go
@@ -62,6 +62,7 @@ type DB interface {
 	// ListOrganizationsForUserIDs lists all organizations these users have
 	// access to.
 	ListOrganizationsForUserIDs(ctx context.Context, userIDs ...string) ([]*users.Organization, error)
+	ListAllOrganizationsForUserIDs(ctx context.Context, userIDs ...string) ([]*users.Organization, error)
 
 	// ListLoginsForUserIDs lists all the logins associated with these users
 	ListLoginsForUserIDs(ctx context.Context, userIDs ...string) ([]*login.Login, error)

--- a/users/db/postgres/team.go
+++ b/users/db/postgres/team.go
@@ -28,8 +28,8 @@ func (d DB) ListTeamsForUserID(ctx context.Context, userID string) ([]*users.Tea
 	return d.scanTeams(rows)
 }
 
-func (d DB) listTeamOrganizationsForUserIDs(ctx context.Context, userIDs ...string) ([]*users.Organization, error) {
-	rows, err := d.organizationsQuery().
+func (d DB) listTeamOrganizationsForUserIDs(ctx context.Context, userIDs []string, includeDeletedOrgs bool) ([]*users.Organization, error) {
+	rows, err := d.organizationsQueryHelper(includeDeletedOrgs).
 		Join("team_memberships on (organizations.team_id = team_memberships.team_id)").
 		Where("team_memberships.deleted_at IS NULL").
 		Where(squirrel.Eq{"team_memberships.user_id": userIDs}).

--- a/users/db/timed.go
+++ b/users/db/timed.go
@@ -159,6 +159,14 @@ func (t timed) ListOrganizationsForUserIDs(ctx context.Context, userIDs ...strin
 	return
 }
 
+func (t timed) ListAllOrganizationsForUserIDs(ctx context.Context, userIDs ...string) (os []*users.Organization, err error) {
+	t.timeRequest(ctx, "ListAllOrganizationsForUserIDs", func(ctx context.Context) error {
+		os, err = t.d.ListAllOrganizationsForUserIDs(ctx, userIDs...)
+		return err
+	})
+	return
+}
+
 func (t timed) ListLoginsForUserIDs(ctx context.Context, userIDs ...string) (ls []*login.Login, err error) {
 	t.timeRequest(ctx, "ListLoginsForUserIDs", func(ctx context.Context) error {
 		ls, err = t.d.ListLoginsForUserIDs(ctx, userIDs...)

--- a/users/db/traced.go
+++ b/users/db/traced.go
@@ -104,6 +104,11 @@ func (t traced) ListOrganizationsForUserIDs(ctx context.Context, userIDs ...stri
 	return t.d.ListOrganizationsForUserIDs(ctx, userIDs...)
 }
 
+func (t traced) ListAllOrganizationsForUserIDs(ctx context.Context, userIDs ...string) (os []*users.Organization, err error) {
+	defer t.trace("ListAllOrganizationsForUserIDs", userIDs, os, err)
+	return t.d.ListAllOrganizationsForUserIDs(ctx, userIDs...)
+}
+
 func (t traced) ListLoginsForUserIDs(ctx context.Context, userIDs ...string) (ls []*login.Login, err error) {
 	defer t.trace("ListLoginsForUserIDs", userIDs, ls, err)
 	return t.d.ListLoginsForUserIDs(ctx, userIDs...)


### PR DESCRIPTION
Fixes #2283.

This is entirely untested. My plan is to check it in dev and tweak if necessary.

The admin UI _should_ render fine since the user org list uses the same template as the main org list, which handles deleted orgs already.