### PR TITLE
prevent authfe webhook log "slice bounds" panic / DOS

### DIFF
--- a/authfe/logger.go
+++ b/authfe/logger.go
@@ -129,7 +129,11 @@ func newWebhooksLogger(webhooksIntegrationTypeHeader string) HTTPEventExtractor 
 
 		// Only pass first 8 chars of secret in URL `/webhooks/abcd1234abcd1234abcd1234abcd1234/`
 		urlParts := strings.Split(r.URL.Path, "/")
-		urlParts[2] = urlParts[2][:8] + strings.Repeat("*", 24)
+		l := len(urlParts[2])
+		if l > 8 {
+			l = 8
+		}
+		urlParts[2] = urlParts[2][:l] + strings.Repeat("*", 32-l)
 		url := strings.Join(urlParts, "/")
 
 		event := Event{


### PR DESCRIPTION
curl https://frontend.dev.weave.works/webhooks/blah/ would result in

2018/11/12 09:38:54 http: panic serving 81.159.29.212:45582: runtime error: slice bounds out of range

which is pretty bad since there is no (other) auth on that endpoint, so literally anyone can hit it.