### PR TITLE
check 'data upload' instance access flag for webhooks

### DIFF
--- a/users/grpc/webhooks.go
+++ b/users/grpc/webhooks.go
@@ -8,13 +8,25 @@ import (
 	"golang.org/x/net/context"
 )
 
-// LookupOrganizationWebhookUsingSecretID gets the webhook given the external org ID and the secret ID of the webhook.
+// LookupOrganizationWebhookUsingSecretID gets the webhook given the
+// secret ID of the webhook. It also checks that the organization to
+// which that web hook belongs has 'data upload' enabled, i.e. hasn't
+// been cut off because of lack of payment.
 func (a *usersServer) LookupOrganizationWebhookUsingSecretID(ctx context.Context, req *users.LookupOrganizationWebhookUsingSecretIDRequest) (*users.LookupOrganizationWebhookUsingSecretIDResponse, error) {
 	webhook, err := a.db.FindOrganizationWebhookBySecretID(ctx, req.SecretID)
 	if err == users.ErrNotFound {
 		err = httpgrpc.Errorf(http.StatusNotFound, "Webhook does not exist.")
 	}
 	if err != nil {
+		return nil, err
+	}
+	org, err := a.db.FindOrganizationByInternalID(ctx, webhook.OrganizationID)
+	if err != nil {
+		return nil, err
+	}
+	// For now treat all webhook invocations as 'data uploads'; we
+	// may want to be more discriminating at some point.
+	if err := authorizeAction(users.INSTANCE_DATA_UPLOAD, org); err != nil {
 		return nil, err
 	}
 	return &users.LookupOrganizationWebhookUsingSecretIDResponse{


### PR DESCRIPTION
...so webhooks stop working when RefuseDataUpload is set (usually due to lack of payment).

Fixes #2229.

This is untested; I will check it works as intended once it hits dev.