### PR TITLE
Make weekly emails more responsive

### DIFF
--- a/users/templates/weekly_report_email.html
+++ b/users/templates/weekly_report_email.html
@@ -16,13 +16,13 @@
   
     <div style="margin-top: 10px; height: 200px; width: 100%;">
       {{range .Deployments}}
-        <div style="display: inline-block; height: 100%; margin-right: 4%; position: relative; width: 9.5%;">
+        <div style="display: inline-block; height: 100%; position: relative; width: 12.5%;">
           {{if .LinkTo}}
             <a href="{{.LinkTo}}" style="outline: none; text-decoration: none">
           {{end}}
             <div style="bottom: 0; color: #1a1a1a; position: absolute; text-align: center; width: 100%;">
               <span style="color: hsl(191,100%,30%); display: block; margin-bottom: 2px;">{{.TotalCount}}</span>
-              <div style="background: hsl(191,100%,45%); border-radius: 2px; height: {{.BarHeightPx}}px; width: 100%;"></div>
+              <div style="background: hsl(191,100%,45%); border-radius: 2px; height: {{.BarHeightPx}}px; margin: auto; width: 70%;"></div>
               <span style="color: #888; display: block; margin-top: 5px;">{{.DayOfWeek}}</span>
             </div>
           {{if .LinkTo}}
@@ -38,7 +38,7 @@
     <p style="color: #888; font-size: 12px; margin: 0 0 15px;">Showing workloads consuming most resources (% of total cluster capacity)</p>
 
     {{range .Resources}}
-      <div style="display: inline-block; margin-bottom: 30px; margin-right: 4.5%; width: 45%;">
+      <div class="resource-section" style="display: inline-block; margin: 0 4% 30px 0;">
         <h3 style="color: #888; font-size: 14px; font-weight: bold; margin-bottom: 20px;">{{.Label}}</h3>
         {{range .TopConsumers}}
           <a href="{{.LinkTo}}" style="outline: none; text-decoration: none">
@@ -59,3 +59,15 @@
 <p>Thanks,<br />
 <br />
 The Weaveworks team</p>
+
+<style>
+  .resource-section {
+    width: 45%;
+  }
+
+  @media (max-width: 640px) {
+    .resource-section {
+      width: 95%;
+    }
+  }
+</style>


### PR DESCRIPTION
Resolves #2336.

* [x] Make the deployments histogram stay in one row even when on lower screen widths
* [x] Better use of space for resource consumption bars on lower screen widths

Should work well down to `320px` screen width now!

![image](https://user-images.githubusercontent.com/1216874/49078190-a336bb00-f23d-11e8-8243-77393fd2b4ff.png)
