### PR TITLE
Clean up notification text for config_changed

### DIFF
--- a/notification-eventmanager/eventmanager/configchanged.go
+++ b/notification-eventmanager/eventmanager/configchanged.go
@@ -128,19 +128,21 @@ func (em *EventManager) createConfigChangedEvent(ctx context.Context, instanceID
 			return nil
 		}
 
-		text := formatEventTypeText("<b>", "</b>", receiver.RType, "<i>", "</i>", added, removed, userEmail)
+		html := formatEventTypeText("<b>", "</b>", receiver.RType, "<i>", "</i>", added, removed, userEmail)
+		markdown := formatEventTypeText("**", "**", receiver.RType, "_", "_", added, removed, userEmail)
+		plain := formatEventTypeText("", "", receiver.RType, "", "", added, removed, userEmail)
 
-		emailMsg, err := em.Render.EmailFromSlack(configChangeTitle, text, eventType, instanceName, "", "", "", link, eventTime)
+		emailMsg, err := em.Render.EmailFromSlack(configChangeTitle, html, eventType, instanceName, "", "", "", link, eventTime)
 		if err != nil {
 			return errors.Wrap(err, "cannot get email message")
 		}
 
-		browserMsg, err := render.BrowserFromSlack(types.SlackMessage{Text: text}, eventType, link, "Weave Cloud notification")
+		browserMsg, err := render.BrowserFromSlack(types.SlackMessage{Text: markdown}, eventType, link, "Weave Cloud notification")
 		if err != nil {
 			return errors.Wrap(err, "cannot get email message")
 		}
 
-		textJSON, err := json.Marshal(text)
+		textJSON, err := json.Marshal(plain)
 		if err != nil {
 			return errors.Wrap(err, "cannot marshal message")
 		}

--- a/notification-eventmanager/types/types.go
+++ b/notification-eventmanager/types/types.go
@@ -121,7 +121,7 @@ type EmailMessage struct {
 // BrowserMessage contains the required fields for formatting browser notifications
 type BrowserMessage struct {
 	Type        string            `json:"type"`
-	Text        string            `json:"text"`
+	Text        string            `json:"text"` // is in Markdown
 	Attachments []SlackAttachment `json:"attachments"`
 	Timestamp   time.Time         `json:"timestamp"`
 }


### PR DESCRIPTION
Changes text for the `config_changed` notification to be formatted for

- Email: HTML
- Browser: Markdown
- Stackdriver: no formatting
- Slack: Slack

Fixes #2417