### PR TITLE
Use bigger buckets for request_duration_seconds metric

### DIFF
--- a/common/monitoring.go
+++ b/common/monitoring.go
@@ -2,6 +2,8 @@ package common
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/weaveworks/common/instrument"
 )
 
 const (
@@ -15,7 +17,7 @@ var (
 		Namespace: PrometheusNamespace,
 		Name:      "request_duration_seconds",
 		Help:      "Time (in seconds) spent serving HTTP requests.",
-		Buckets:   prometheus.DefBuckets,
+		Buckets:   instrument.DefBuckets,
 	}, []string{"method", "route", "status_code", "ws"})
 
 	// DatabaseRequestDuration is our standard database histogram vector.
@@ -23,6 +25,6 @@ var (
 		Namespace: PrometheusNamespace,
 		Name:      "database_request_duration_seconds",
 		Help:      "Time spent (in seconds) doing database requests.",
-		Buckets:   prometheus.DefBuckets,
+		Buckets:   instrument.DefBuckets,
 	}, []string{"method", "status_code"})
 )


### PR DESCRIPTION
The previous set topped out at 10 seconds, which lacks clarity when things are bogged down.