### PR TITLE
Send single weekly summary email per instance

### DIFF
--- a/users/api/admin.go
+++ b/users/api/admin.go
@@ -194,7 +194,7 @@ func (a *API) adminWeeklyReportsPreview(w http.ResponseWriter, r *http.Request) 
 		renderError(w, r, err)
 		return
 	}
-	err = a.emailer.WeeklyReportEmail(user, weeklyReport)
+	err = a.emailer.WeeklyReportEmail([]*users.User{user}, weeklyReport)
 	if err != nil {
 		renderError(w, r, err)
 		return

--- a/users/cmd/debugemail/main.go
+++ b/users/cmd/debugemail/main.go
@@ -107,7 +107,7 @@ func main() {
 			return em.TrialExpiredEmail([]*users.User{dst}, orgExternalID, orgName)
 		},
 		"weekly": func() error {
-			return em.WeeklyReportEmail(dst, weeklyReport)
+			return em.WeeklyReportEmail([]*users.User{dst}, weeklyReport)
 		},
 	}
 

--- a/users/emailer/emailer.go
+++ b/users/emailer/emailer.go
@@ -27,7 +27,7 @@ type Emailer interface {
 	TrialPendingExpiryEmail(members []*users.User, orgExternalID, orgName string, expiresAt time.Time) error
 	TrialExpiredEmail(members []*users.User, orgExternalID, orgName string) error
 	RefuseDataUploadEmail(members []*users.User, orgExternalID, orgName string) error
-	WeeklyReportEmail(u *users.User, report *weeklyreports.Report) error
+	WeeklyReportEmail(members []*users.User, report *weeklyreports.Report) error
 }
 
 // MustNew creates a new Emailer, from the URI, or panics.

--- a/users/emailer/smtp.go
+++ b/users/emailer/smtp.go
@@ -56,13 +56,13 @@ func smtpEmailSender(u *url.URL) (func(e *email.Email) error, error) {
 }
 
 // WeeklyReportEmail sends the weekly report email
-func (s SMTPEmailer) WeeklyReportEmail(u *users.User, report *weeklyreports.Report) error {
+func (s SMTPEmailer) WeeklyReportEmail(members []*users.User, report *weeklyreports.Report) error {
 	organizationURL := organizationURL(s.Domain, report.Organization.ExternalID)
 	summary := weeklyreports.EmailSummaryFromReport(report, organizationURL)
 
 	e := email.NewEmail()
 	e.From = s.FromAddress
-	e.To = []string{u.Email}
+	e.To = collectEmails(members)
 	e.Subject = fmt.Sprintf("%s · %s Report", summary.DateInterval, summary.OrganizationName)
 	data := map[string]interface{}{
 		"Report": summary,

--- a/users/grpc/lookup.go
+++ b/users/grpc/lookup.go
@@ -387,9 +387,8 @@ func (a *usersServer) SendOutWeeklyReport(ctx context.Context, req *users.SendOu
 		return nil, err
 	}
 
-	// Iterate through the users and send emails to all of them
-	for _, user := range members {
-		a.emailer.WeeklyReportEmail(user, weeklyReport)
+	if err := a.emailer.WeeklyReportEmail(members, weeklyReport); err != nil {
+		return nil, err
 	}
 
 	// Persist weekly report timestamp in the db


### PR DESCRIPTION
This batches all the addresses for the weekly report and sends a single
email with all of them.

Closes #2439 