### PR TITLE
Stop sending notify emails to unconfirmed users

### DIFF
--- a/users-sync/attrsync/sync.go
+++ b/users-sync/attrsync/sync.go
@@ -107,7 +107,7 @@ func (c *AttributeSyncer) EnqueueOrgsSync(ctx context.Context, orgExternalIDs []
 	for _, externalID := range orgExternalIDs {
 		// We request memberships for deleted orgs too so that we update users who
 		// were connected to the deleted orgs
-		users, err := c.db.ListOrganizationUsers(ctx, externalID, true)
+		users, err := c.db.ListOrganizationUsers(ctx, externalID, true, false)
 		if err != nil {
 			return err
 		}

--- a/users/api/admin.go
+++ b/users/api/admin.go
@@ -104,7 +104,7 @@ func (a *API) adminListUsersForOrganization(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	us, err := a.db.ListOrganizationUsers(r.Context(), orgID, true)
+	us, err := a.db.ListOrganizationUsers(r.Context(), orgID, true, false)
 	if err != nil {
 		renderError(w, r, err)
 		return
@@ -129,7 +129,7 @@ func (a *API) adminRemoveUserFromOrganization(w http.ResponseWriter, r *http.Req
 	orgExternalID := vars["orgExternalID"]
 	userID := vars["userID"]
 
-	if members, err := a.db.ListOrganizationUsers(r.Context(), orgExternalID, false); err != nil {
+	if members, err := a.db.ListOrganizationUsers(r.Context(), orgExternalID, false, false); err != nil {
 		renderError(w, r, err)
 		return
 	} else if len(members) == 1 {
@@ -535,7 +535,7 @@ func (a *API) GetOrganizationsUsers(ctx context.Context, organizations []*users.
 	orgUsers := make(map[string][]*users.User)
 	moreUsersCount := make(map[string]int)
 	for _, org := range organizations {
-		us, err := a.db.ListOrganizationUsers(ctx, org.ExternalID, true)
+		us, err := a.db.ListOrganizationUsers(ctx, org.ExternalID, true, false)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/users/api/org.go
+++ b/users/api/org.go
@@ -462,7 +462,7 @@ func (a *API) listOrganizationUsers(currentUser *users.User, w http.ResponseWrit
 		return
 	}
 
-	users, err := a.db.ListOrganizationUsers(r.Context(), orgExternalID, false)
+	users, err := a.db.ListOrganizationUsers(r.Context(), orgExternalID, false, false)
 	if err != nil {
 		renderError(w, r, err)
 		return
@@ -534,7 +534,7 @@ func (a *API) removeUser(currentUser *users.User, w http.ResponseWriter, r *http
 		return
 	}
 
-	if members, err := a.db.ListOrganizationUsers(r.Context(), orgExternalID, false); err != nil {
+	if members, err := a.db.ListOrganizationUsers(r.Context(), orgExternalID, false, false); err != nil {
 		renderError(w, r, err)
 		return
 	} else if len(members) == 1 {
@@ -641,7 +641,7 @@ func (a *API) extendOrgTrialPeriod(ctx context.Context, org *users.Organization,
 		return nil
 	}
 
-	members, err := a.db.ListOrganizationUsers(ctx, org.ExternalID, false)
+	members, err := a.db.ListOrganizationUsers(ctx, org.ExternalID, false, false)
 	if err != nil {
 		return err
 	}

--- a/users/db/db.go
+++ b/users/db/db.go
@@ -57,7 +57,7 @@ type DB interface {
 	ListUsers(ctx context.Context, f filter.User, page uint64) ([]*users.User, error)
 	ListOrganizations(ctx context.Context, f filter.Organization, page uint64) ([]*users.Organization, error)
 	ListAllOrganizations(ctx context.Context, f filter.Organization, page uint64) ([]*users.Organization, error)
-	ListOrganizationUsers(ctx context.Context, orgExternalID string, includeDeletedOrgs bool) ([]*users.User, error)
+	ListOrganizationUsers(ctx context.Context, orgExternalID string, includeDeletedOrgs, excludeNewUsers bool) ([]*users.User, error)
 
 	// ListOrganizationsForUserIDs lists all organizations these users have
 	// access to.

--- a/users/db/db_test.go
+++ b/users/db/db_test.go
@@ -29,14 +29,14 @@ func TestDB_RemoveOtherUsersAccess(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, otherUserOrganizations, 1)
 
-	orgUsers, err := db.ListOrganizationUsers(context.Background(), org.ExternalID, false)
+	orgUsers, err := db.ListOrganizationUsers(context.Background(), org.ExternalID, false, false)
 	require.NoError(t, err)
 	require.Len(t, orgUsers, 2)
 
 	err = db.RemoveUserFromOrganization(context.Background(), org.ExternalID, otherUser.Email)
 	require.NoError(t, err)
 
-	orgUsers, err = db.ListOrganizationUsers(context.Background(), org.ExternalID, false)
+	orgUsers, err = db.ListOrganizationUsers(context.Background(), org.ExternalID, false, false)
 	require.NoError(t, err)
 	require.Len(t, orgUsers, 1)
 }
@@ -73,7 +73,7 @@ func TestDB_RemoveOtherUsersAccessWithTeams(t *testing.T) {
 	require.Len(t, otherUserTeams, 1)
 	require.Equal(t, team.ID, otherUserTeams[0].ID)
 
-	orgUsers, err := db.ListOrganizationUsers(ctx, org.ExternalID, false)
+	orgUsers, err := db.ListOrganizationUsers(ctx, org.ExternalID, false, false)
 	require.NoError(t, err)
 	require.Len(t, orgUsers, 2)
 
@@ -84,7 +84,7 @@ func TestDB_RemoveOtherUsersAccessWithTeams(t *testing.T) {
 	err = db.RemoveUserFromOrganization(ctx, org.ExternalID, otherUser.Email)
 	require.NoError(t, err)
 
-	orgUsers, err = db.ListOrganizationUsers(ctx, org.ExternalID, false)
+	orgUsers, err = db.ListOrganizationUsers(ctx, org.ExternalID, false, false)
 	require.NoError(t, err)
 	require.Len(t, orgUsers, 1)
 

--- a/users/db/timed.go
+++ b/users/db/timed.go
@@ -143,9 +143,9 @@ func (t timed) ListAllOrganizations(ctx context.Context, f filter.Organization, 
 	return
 }
 
-func (t timed) ListOrganizationUsers(ctx context.Context, orgExternalID string, includeDeletedOrgs bool) (us []*users.User, err error) {
+func (t timed) ListOrganizationUsers(ctx context.Context, orgExternalID string, includeDeletedOrgs, excludeNewUsers bool) (us []*users.User, err error) {
 	t.timeRequest(ctx, "ListOrganizationUsers", func(ctx context.Context) error {
-		us, err = t.d.ListOrganizationUsers(ctx, orgExternalID, includeDeletedOrgs)
+		us, err = t.d.ListOrganizationUsers(ctx, orgExternalID, includeDeletedOrgs, excludeNewUsers)
 		return err
 	})
 	return

--- a/users/db/traced.go
+++ b/users/db/traced.go
@@ -94,9 +94,9 @@ func (t traced) ListAllOrganizations(ctx context.Context, f filter.Organization,
 	return t.d.ListAllOrganizations(ctx, f, page)
 }
 
-func (t traced) ListOrganizationUsers(ctx context.Context, orgExternalID string, includeDeletedOrgs bool) (us []*users.User, err error) {
+func (t traced) ListOrganizationUsers(ctx context.Context, orgExternalID string, includeDeletedOrgs, excludeNewUsers bool) (us []*users.User, err error) {
 	defer t.trace("ListOrganizationUsers", orgExternalID, us, err)
-	return t.d.ListOrganizationUsers(ctx, orgExternalID, includeDeletedOrgs)
+	return t.d.ListOrganizationUsers(ctx, orgExternalID, includeDeletedOrgs, excludeNewUsers)
 }
 
 func (t traced) ListOrganizationsForUserIDs(ctx context.Context, userIDs ...string) (os []*users.Organization, err error) {

--- a/users/grpc/lookup.go
+++ b/users/grpc/lookup.go
@@ -303,7 +303,7 @@ func (a *usersServer) NotifyTrialPendingExpiry(ctx context.Context, req *users.N
 	}
 
 	// Notify all users
-	members, err := a.db.ListOrganizationUsers(ctx, req.ExternalID, false)
+	members, err := a.db.ListOrganizationUsers(ctx, req.ExternalID, false, true)
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +327,7 @@ func (a *usersServer) NotifyTrialExpired(ctx context.Context, req *users.NotifyT
 	}
 
 	// Notify all users
-	members, err := a.db.ListOrganizationUsers(ctx, req.ExternalID, false)
+	members, err := a.db.ListOrganizationUsers(ctx, req.ExternalID, false, true)
 	if err != nil {
 		return nil, err
 	}
@@ -382,7 +382,7 @@ func (a *usersServer) SendOutWeeklyReport(ctx context.Context, req *users.SendOu
 	}
 
 	// Get all users belonging to the organization
-	members, err := a.db.ListOrganizationUsers(ctx, org.ExternalID, false)
+	members, err := a.db.ListOrganizationUsers(ctx, org.ExternalID, false, true)
 	if err != nil {
 		return nil, err
 	}
@@ -409,7 +409,7 @@ func (a *usersServer) NotifyRefuseDataUpload(ctx context.Context, req *users.Not
 	}
 
 	// Notify all users
-	members, err := a.db.ListOrganizationUsers(ctx, req.ExternalID, false)
+	members, err := a.db.ListOrganizationUsers(ctx, req.ExternalID, false, true)
 	if err != nil {
 		return nil, err
 	}
@@ -452,7 +452,7 @@ func (a *usersServer) InformOrganizationBillingConfigured(ctx context.Context, r
 		return nil, err
 	}
 
-	members, err := a.db.ListOrganizationUsers(ctx, req.ExternalID, false)
+	members, err := a.db.ListOrganizationUsers(ctx, req.ExternalID, false, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Otherwise malicious actors can just invite other people's email and have
us send them weekly reports without their confirmation they actually
want that.

Closes #2440