### PR TITLE
Revert "Revert "Move all orphan instances into teams""

### DIFF
--- a/users/db/migrations/047_create_teams_for_orphan_organizations.up.sql
+++ b/users/db/migrations/047_create_teams_for_orphan_organizations.up.sql
@@ -1,8 +1,11 @@
 -- Ground work for https://github.com/weaveworks/service/issues/2117.
 --
+--
 -- Creates one team for each of the orphan organizations (i.e. organizations that are so far not part of a team):
 --   * Teams will be given the same name based on organization name, as is currently the case in the app
 --   * External IDs will be a direct extension of organization ones to be able to map them 1-1 when continuing the migration
+--   * Since organizations.external_id might contain duplicates (constraint only on `deleted_at is null`) we additionally
+--     include the `organizations.id`.
 --   * We also handle deleted organizations by creating deleted teams for them
 --   * The trial expiry date will be carried over as well
 --
@@ -10,5 +13,5 @@
 --       We absolutely don't want to move orphan organizations into existing teams belonging to different users!
 
 INSERT INTO teams(name, external_id, trial_expires_at, deleted_at)
-SELECT CONCAT(LEFT(name, 95), ' Team') AS name, CONCAT(external_id, '-team') AS external_id, trial_expires_at, deleted_at
+SELECT CONCAT(LEFT(name, 95), ' Team') AS name, CONCAT(external_id, '-', id) AS external_id, trial_expires_at, deleted_at
 FROM organizations WHERE team_id IS NULL;

--- a/users/db/migrations/048_move_orphan_organizations_into_teams.up.sql
+++ b/users/db/migrations/048_move_orphan_organizations_into_teams.up.sql
@@ -3,7 +3,7 @@
 
 -- Move all orphan organizations into their dedicated teams
 UPDATE organizations SET team_id = teams.id FROM teams
-WHERE organizations.team_id IS NULL AND CONCAT(organizations.external_id, '-team') = teams.external_id;
+WHERE organizations.team_id IS NULL AND CONCAT(organizations.external_id, '-', organizations.id) = teams.external_id;
 
 -- Move all user memberships into the new teams
 -- (implicitly linking the users to same organizations)
@@ -18,7 +18,7 @@ FROM memberships
   INNER JOIN organizations ON organizations.id = memberships.organization_id
   INNER JOIN teams ON organizations.team_id = teams.id
 WHERE
-  teams.external_id LIKE '%-team'
+  teams.external_id LIKE '%-%-%-%' -- 'proud-wind-05-8168'
 ;
 
 -- Finally delete all the legacy direct user-organization memberships


### PR DESCRIPTION
The constraint is on `deleted_at is not null` and as such can have
duplicates. Since we determined assignment by just `{orgextid}-team` we
ran into duplicate team external_ids.

This PR additionally includes the `organizations.id` to make it
unambiguous.

Reverts weaveworks/service#2447
