### PR TITLE
Add some tests to MVP permission checks

### DIFF
--- a/users/api/org.go
+++ b/users/api/org.go
@@ -395,7 +395,7 @@ func (a *API) deleteOrg(currentUser *users.User, w http.ResponseWriter, r *http.
 
 	org, err := a.db.FindOrganizationByID(ctx, orgExternalID)
 	if err == users.ErrNotFound {
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusNotFound)
 		return
 	}
 	if err != nil {

--- a/users/api/org_test.go
+++ b/users/api/org_test.go
@@ -639,7 +639,7 @@ func Test_Organization_Delete(t *testing.T) {
 	{
 		w := httptest.NewRecorder()
 		app.ServeHTTP(w, r)
-		assert.Equal(t, http.StatusNoContent, w.Code)
+		assert.Equal(t, http.StatusNotFound, w.Code)
 	}
 
 	// Create the org so it exists

--- a/users/api/permission_test.go
+++ b/users/api/permission_test.go
@@ -1,13 +1,20 @@
 package api_test
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	billing_grpc "github.com/weaveworks/service/common/billing/grpc"
+	"github.com/weaveworks/service/common/billing/provider"
 	"github.com/weaveworks/service/users"
 	"github.com/weaveworks/service/users/api"
 	"github.com/weaveworks/service/users/db/dbtest"
@@ -67,4 +74,166 @@ func Test_PermissionsInRoleResponse(t *testing.T) {
 
 	// should be some permissions!
 	assert.NotZero(t, len(admin.Permissions))
+}
+
+func Test_PermissionInviteTeamMember(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	_, org, team := dbtest.GetOrgAndTeam(t, database)
+	database.SetFeatureFlags(context.TODO(), org.ExternalID, []string{"permissions"})
+
+	path := fmt.Sprintf("/api/users/teams/%s/users", team.ExternalID)
+	requestBody, _ := json.Marshal(map[string]string{
+		"email":  "blu@blu.blu",
+		"roleId": "viewer",
+	})
+
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
+	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	doRequest(t, viewer, "POST", path, bytes.NewReader(requestBody), http.StatusForbidden)
+	doRequest(t, editor, "POST", path, bytes.NewReader(requestBody), http.StatusForbidden)
+	doRequest(t, admin, "POST", path, bytes.NewReader(requestBody), http.StatusOK)
+}
+func Test_PermissionUpdateTeamMemberRole(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	_, org, team := dbtest.GetOrgAndTeam(t, database)
+	database.SetFeatureFlags(context.TODO(), org.ExternalID, []string{"permissions"})
+
+	other, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	path := fmt.Sprintf("/api/users/teams/%s/users/%s", team.ExternalID, other.Email)
+	requestBody, _ := json.Marshal(map[string]string{
+		"roleId": "viewer",
+	})
+
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
+	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	doRequest(t, viewer, "PUT", path, bytes.NewReader(requestBody), http.StatusForbidden)
+	doRequest(t, editor, "PUT", path, bytes.NewReader(requestBody), http.StatusForbidden)
+	doRequest(t, admin, "PUT", path, bytes.NewReader(requestBody), http.StatusNoContent)
+}
+func Test_PermissionRemoveTeamMember(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	_, org, team := dbtest.GetOrgAndTeam(t, database)
+	database.SetFeatureFlags(context.TODO(), org.ExternalID, []string{"permissions"})
+
+	other, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	path := fmt.Sprintf("/api/users/teams/%s/users/%s", team.ExternalID, other.Email)
+
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
+	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	doRequest(t, viewer, "DELETE", path, nil, http.StatusForbidden)
+	doRequest(t, editor, "DELETE", path, nil, http.StatusForbidden)
+	doRequest(t, admin, "DELETE", path, nil, http.StatusOK)
+}
+func Test_PermissionViewTeamMembers(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	_, org, team := dbtest.GetOrgAndTeam(t, database)
+	database.SetFeatureFlags(context.TODO(), org.ExternalID, []string{"permissions"})
+
+	path := fmt.Sprintf("/api/users/org/%s/users", org.ExternalID)
+
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
+	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	doRequest(t, viewer, "GET", path, nil, http.StatusOK)
+	doRequest(t, editor, "GET", path, nil, http.StatusOK)
+	doRequest(t, admin, "GET", path, nil, http.StatusOK)
+}
+func Test_PermissionDeleteInstance(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	_, org, team := dbtest.GetOrgAndTeam(t, database)
+	database.SetFeatureFlags(context.TODO(), org.ExternalID, []string{"permissions"})
+
+	path := fmt.Sprintf("/api/users/org/%s", org.ExternalID)
+
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
+	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	doRequest(t, viewer, "DELETE", path, nil, http.StatusForbidden)
+	doRequest(t, editor, "DELETE", path, nil, http.StatusForbidden)
+	doRequest(t, admin, "DELETE", path, nil, http.StatusNoContent)
+}
+
+func Test_PermissionViewToken(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	_, org, team := dbtest.GetOrgAndTeam(t, database)
+	database.SetFeatureFlags(context.TODO(), org.ExternalID, []string{"permissions"})
+
+	body := map[string]interface{}{}
+	path := fmt.Sprintf("/api/users/org/%s", org.ExternalID)
+
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
+	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	bodyBytes := doRequest(t, viewer, "GET", path, nil, http.StatusOK)
+	assert.NoError(t, json.Unmarshal(bodyBytes, &body))
+	assert.Equal(t, nil, body["probeToken"])
+	bodyBytes = doRequest(t, editor, "GET", path, nil, http.StatusOK)
+	assert.NoError(t, json.Unmarshal(bodyBytes, &body))
+	assert.Equal(t, nil, body["probeToken"])
+	bodyBytes = doRequest(t, admin, "GET", path, nil, http.StatusOK)
+	assert.NoError(t, json.Unmarshal(bodyBytes, &body))
+	assert.NotEqual(t, nil, body["probeToken"])
+}
+
+func Test_PermissionTransferInstance(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	_, org, team := dbtest.GetOrgAndTeam(t, database)
+	database.SetFeatureFlags(context.TODO(), org.ExternalID, []string{"permissions"})
+	_, otherOrg, otherTeam := dbtest.GetOrgAndTeam(t, database)
+	database.SetFeatureFlags(context.TODO(), otherOrg.ExternalID, []string{"permissions"})
+
+	path := fmt.Sprintf("/api/users/org/%s", org.ExternalID)
+	requestBody, _ := json.Marshal(map[string]string{
+		"teamId": otherTeam.ExternalID,
+	})
+
+	billingClient.EXPECT().
+		FindBillingAccountByTeamID(gomock.Any(), gomock.Any()).AnyTimes().
+		Return(&billing_grpc.BillingAccount{
+			ID:        1,
+			CreatedAt: time.Now(),
+			Provider:  provider.External,
+		}, nil)
+
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
+	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	// Viewers in the other team
+	database.AddUserToTeam(context.TODO(), viewer.ID, otherTeam.ID, "viewer")
+	database.AddUserToTeam(context.TODO(), editor.ID, otherTeam.ID, "viewer")
+	database.AddUserToTeam(context.TODO(), admin.ID, otherTeam.ID, "viewer")
+	doRequest(t, viewer, "PUT", path, bytes.NewReader(requestBody), http.StatusForbidden)
+	doRequest(t, editor, "PUT", path, bytes.NewReader(requestBody), http.StatusForbidden)
+	doRequest(t, admin, "PUT", path, bytes.NewReader(requestBody), http.StatusForbidden)
+	// Editors in the other team
+	database.UpdateUserRoleInTeam(context.TODO(), viewer.ID, otherTeam.ID, "editor")
+	database.UpdateUserRoleInTeam(context.TODO(), editor.ID, otherTeam.ID, "editor")
+	database.UpdateUserRoleInTeam(context.TODO(), admin.ID, otherTeam.ID, "editor")
+	doRequest(t, viewer, "PUT", path, bytes.NewReader(requestBody), http.StatusForbidden)
+	doRequest(t, editor, "PUT", path, bytes.NewReader(requestBody), http.StatusForbidden)
+	doRequest(t, admin, "PUT", path, bytes.NewReader(requestBody), http.StatusForbidden)
+	// Admins in the other team
+	database.UpdateUserRoleInTeam(context.TODO(), viewer.ID, otherTeam.ID, "admin")
+	database.UpdateUserRoleInTeam(context.TODO(), editor.ID, otherTeam.ID, "admin")
+	database.UpdateUserRoleInTeam(context.TODO(), admin.ID, otherTeam.ID, "admin")
+	doRequest(t, viewer, "PUT", path, bytes.NewReader(requestBody), http.StatusForbidden)
+	doRequest(t, editor, "PUT", path, bytes.NewReader(requestBody), http.StatusForbidden)
+	doRequest(t, admin, "PUT", path, bytes.NewReader(requestBody), http.StatusNoContent)
 }

--- a/users/db/dbtest/helpers.go
+++ b/users/db/dbtest/helpers.go
@@ -26,6 +26,12 @@ func GetUser(t *testing.T, db db.DB) *users.User {
 	return GetUserWithDomain(t, db, "domain.com")
 }
 
+// GetUserInTeam makes a randomly named user and adds it as a team member
+func GetUserInTeam(t *testing.T, db db.DB, team *users.Team, roleID string) (*users.User, error) {
+	user := GetUser(t, db)
+	return user, db.AddUserToTeam(context.TODO(), user.ID, team.ID, roleID)
+}
+
 // GetUserWithDomain makes a randomly named user with an address email finishing with the provided domain
 func GetUserWithDomain(t *testing.T, db db.DB, domain string) *users.User {
 	email := fmt.Sprintf("%d@%v", rand.Int63(), domain)

--- a/users/db/memory/memory.go
+++ b/users/db/memory/memory.go
@@ -41,6 +41,7 @@ var permissions = map[string]*users.Permission{
 	"scope.container.exec":         {ID: "scope.container.exec", Name: "Scope.container.exec", Description: "derp"},
 	"scope.container.attach.out":   {ID: "scope.container.attach.out", Name: "Scope.container.attach.out", Description: "derp"},
 	"scope.replicas.update":        {ID: "scope.replicas.update", Name: "Scope.replicas.update", Description: "derp"},
+	"scope.pod.logs.view":          {ID: "scope.pod.logs.view", Name: "Scope.pod.logs.view", Description: "derp"},
 	"scope.pod.delete":             {ID: "scope.pod.delete", Name: "Scope.pod.delete", Description: "derp"},
 	"flux.image.deploy":            {ID: "flux.image.deploy", Name: "Flux.image.deploy", Description: "derp"},
 	"flux.policy.update":           {ID: "flux.policy.update", Name: "Flux.policy.update", Description: "derp"},
@@ -48,18 +49,66 @@ var permissions = map[string]*users.Permission{
 	"instance.token.view":          {ID: "instance.token.view", Name: "Instance.token.view", Description: "derp"},
 	"instance.webhook.create":      {ID: "instance.webhook.create", Name: "Instance.webhook.create", Description: "derp"},
 	"instance.webhook.delete":      {ID: "instance.webhook.delete", Name: "Instance.webhook.delete", Description: "derp"},
+	"scope.container.attach.in":    {ID: "scope.container.attach.in", Name: "Scope.container.attach.in", Description: "derp"},
+	"scope.container.pause":        {ID: "scope.container.pause", Name: "Scope.container.pause", Description: "derp"},
+	"scope.container.restart":      {ID: "scope.container.restart", Name: "Scope.container.restart", Description: "derp"},
+	"scope.container.stop":         {ID: "scope.container.stop", Name: "Scope.container.stop", Description: "derp"},
 }
 
 // New creates a new in-memory database
 func New(_, _ string, passwordHashingCost int) (*DB, error) {
 	rolesPermissions := map[string][]string{
-		"admin":  {},
-		"editor": {},
-		"viewer": {},
-	}
-
-	for roleID := range permissions {
-		rolesPermissions["admin"] = append(rolesPermissions["admin"], roleID)
+		"admin": {
+			"team.member.invite",
+			"instance.delete",
+			"instance.billing.update",
+			"alert.settings.update",
+			"team.member.update",
+			"team.member.remove",
+			"team.members.view",
+			"instance.transfer",
+			"notebook.create",
+			"notebook.update",
+			"notebook.delete",
+			"scope.host.exec",
+			"scope.container.exec",
+			"scope.container.attach.out",
+			"scope.replicas.update",
+			"scope.pod.delete",
+			"scope.pod.logs.view",
+			"flux.image.deploy",
+			"flux.policy.update",
+			"notification.settings.update",
+			"instance.token.view",
+			"instance.webhook.create",
+			"instance.webhook.delete",
+			"scope.container.attach.in",
+			"scope.container.pause",
+			"scope.container.restart",
+			"scope.container.stop",
+		},
+		"editor": {
+			"alert.settings.update",
+			"team.members.view",
+			"notebook.create",
+			"notebook.update",
+			"notebook.delete",
+			"scope.container.attach.out",
+			"scope.replicas.update",
+			"scope.pod.delete",
+			"flux.image.deploy",
+			"flux.policy.update",
+			"scope.pod.logs.view",
+			"scope.container.pause",
+			"scope.container.restart",
+			"scope.container.stop",
+			"instance.webhook.create",
+			"instance.webhook.delete",
+		},
+		"viewer": {
+			"team.members.view",
+			"scope.pod.logs.view",
+		},
 	}
 
 	return &DB{
@@ -72,7 +121,7 @@ func New(_, _ string, passwordHashingCost int) (*DB, error) {
 		teamMemberships:      make(map[string]map[string]string),
 		roles: map[string]*users.Role{
 			"admin":  {ID: "admin", Name: "Admin", Description: "Can add/remove team members, update billing info, delete and move instances"},
-			"editor": {ID: "editor", Name: "Editor", Description: "Can deploy new image versions, change alert configurations, edit notebooks and delete pods etc"},
+			"editor": {ID: "editor", Name: "Editor", Description: "Can update deployments, change configuration, delete pods, edit notebooks and perform other editing actions"},
 			"viewer": {ID: "viewer", Name: "Viewer", Description: "Has a read-only view of the cluster"},
 		},
 		permissions:         permissions,


### PR DESCRIPTION
Resolves part of #2527 which covers the permission checks in the `users` service:

* [x] `team.member.invite`
* [x] `team.member.update`
* [x] `team.member.remove`
* [x] `team.members.view`
* [x] `instance.delete`
* [x] `instance.transfer`
* [x] `instance.token.view`

The other big chunk of permissions should be tested directly on the `authfe` routes and I had trouble making that work as CSRF check + authorization should somehow be bypassed in the tests, so will try to tackle that separately.
