### PR TITLE
Return err if something goes wrong in update-notification

### DIFF
--- a/notification-eventmanager/db/postgres/receiver.go
+++ b/notification-eventmanager/db/postgres/receiver.go
@@ -265,7 +265,11 @@ func (d DB) UpdateReceiver(receiver types.Receiver, instanceID string, featureFl
 		return err
 	})
 
-	return userError
+	if userError != nil {
+		return userError
+	}
+
+	return err
 }
 
 // DeleteReceiver deletes receiver


### PR DESCRIPTION
Current update notification settings method swallows errors.[0]

Spit them out to aid in debugging.

[0] https://github.com/weaveworks/service/blob/7b2021a6732e8e76fcc7e314731825fd86eba788/notification-eventmanager/db/postgres/receiver.go#L189