### PR TITLE
Fix build dep check for images w/o root files

### DIFF
--- a/push-images
+++ b/push-images
@@ -90,7 +90,7 @@ def get_go_dependencies(component):
     # Fetch go dependencies using 'go list'
     cmd = """
         cd {} &&
-        for dep in `go list -f '{{{{ .Deps }}}}'`; do
+        for dep in `go list -f '{{{{ .Deps }}}}' ./...`; do
             echo $dep | grep '{}';
         done | xargs
     """.format(component, SERVICE_REPO)


### PR DESCRIPTION
If there are no `.go` files in the image's root directory (where the
Dockerfile resides) the dependency check does not include any
dependencies except its own directory.
For services that include code from other services this will fail to
push an updated image to quay.io