### PR TITLE
Fixes showing team name in invite email

### DIFF
--- a/users/emailer/smtp.go
+++ b/users/emailer/smtp.go
@@ -97,7 +97,7 @@ func (s SMTPEmailer) InviteToTeamEmail(inviter, invited *users.User, teamExterna
 		"InviterName": inviter.Email,
 		"LoginURL":    inviteToTeamURL(invited.Email, token, s.Domain, teamExternalID),
 		"RootURL":     s.Domain,
-		"TeamName":    teamExternalID,
+		"TeamName":    teamName,
 	}
 	e.Text = s.Templates.QuietBytes("invite_to_team_email.text", data)
 	e.HTML = s.Templates.EmbedHTML("invite_to_team_email.html", emailWrapperFilename, e.Subject, data)


### PR DESCRIPTION
- Rather than teamId which is a bit confusing

Fixes #2513