### PR TITLE
Adjust notification alerts page

### DIFF
--- a/notification-eventmanager/eventmanager/event.go
+++ b/notification-eventmanager/eventmanager/event.go
@@ -29,7 +29,7 @@ const (
 	MaxEventsList          = 10000
 	notificationConfigPath = "/org/notifications"
 	alertsConfigPath       = "/org/alerts"
-	alertsPage             = "/prom/alerts"
+	alertsPage             = "/monitor/alerts"
 	alertLinkText          = "View firing alerts"
 	deployPage             = "/deploy/services"
 	deployLinkText         = "Weave Cloud Deploy"


### PR DESCRIPTION
This has changed and a redirect is in place but we can directly go to
the right destination.

Sample Slack notification with outdated url:
https://weaveworks.slack.com/archives/C0CG6Q4BG/p1551387857121700

Redirect is in place:
https://cloud.weave.works/loud-breeze-77/prom/alerts