### PR TITLE
Test permissions on authfe routes

### DIFF
--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -25,7 +25,6 @@ import (
 	"github.com/weaveworks/service/common"
 	"github.com/weaveworks/service/common/constants/webhooks"
 	"github.com/weaveworks/service/common/featureflag"
-	"github.com/weaveworks/service/common/permission"
 	"github.com/weaveworks/service/users"
 	users_client "github.com/weaveworks/service/users/client"
 )
@@ -139,28 +138,6 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 	userPermissionsMiddleware := users_client.UserPermissionsMiddleware{
 		UsersClient:  authenticator,
 		UserIDHeader: userIDHeader,
-		Permissions: []users_client.RequestPermission{
-			// Prometheus
-			{"/api/prom/configs/rules", []string{"POST"}, permission.UpdateAlertingSettings},
-			// Scope
-			{"/api/control/.*/.*/host_exec", []string{"POST"}, permission.OpenHostShell},
-			{"/api/control/.*/.*/docker_exec_container", []string{"POST"}, permission.OpenContainerShell},
-			{"/api/control/.*/.*/docker_attach_container", []string{"POST"}, permission.AttachToContainer},
-			{"/api/control/.*/.*/docker_(pause|unpause)_container", []string{"POST"}, permission.PauseContainer},
-			{"/api/control/.*/.*/docker_restart_container", []string{"POST"}, permission.RestartContainer},
-			{"/api/control/.*/.*/docker_stop_container", []string{"POST"}, permission.StopContainer},
-			{"/api/control/.*/.*/kubernetes_get_logs", []string{"POST"}, permission.ViewPodLogs},
-			{"/api/control/.*/.*/kubernetes_scale_(up|down)", []string{"POST"}, permission.UpdateReplicaCount},
-			{"/api/control/.*/.*/kubernetes_delete_pod", []string{"POST"}, permission.DeletePod},
-			// Flux
-			// TODO(fbarl): At the moment, `update-manifests` API is only used for pushing releases in the Flux UI,
-			// so setting the permission here works, but in the future, we should probably introduce case branching.
-			{"/api/flux/v9/update-manifests", []string{"POST"}, permission.DeployImage},
-			{"/api/flux/v6/update-images", []string{"POST"}, permission.DeployImage},
-			{"/api/flux/v6/policies", []string{"PATCH"}, permission.UpdateDeploymentPolicy},
-			// Notifications
-			{"/api/notification/config/.*", []string{"POST", "PUT"}, permission.UpdateNotificationSettings},
-		},
 	}
 
 	// middleware to set header to disable caching if path == "/" exactly

--- a/authfe/routes_test.go
+++ b/authfe/routes_test.go
@@ -90,7 +90,6 @@ func TestRoutes(t *testing.T) {
 		})
 	}
 }
-
 func TestStripSetCookieHeader(t *testing.T) {
 	tests := []struct {
 		url      string

--- a/users/api/permission_test.go
+++ b/users/api/permission_test.go
@@ -15,9 +15,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	billing_grpc "github.com/weaveworks/service/common/billing/grpc"
 	"github.com/weaveworks/service/common/billing/provider"
+	"github.com/weaveworks/service/common/permission"
 	"github.com/weaveworks/service/users"
 	"github.com/weaveworks/service/users/api"
+	"github.com/weaveworks/service/users/client"
 	"github.com/weaveworks/service/users/db/dbtest"
+	"github.com/weaveworks/service/users/mock_users"
 )
 
 func doRequest(t *testing.T, user *users.User, method string, path string, body io.Reader, expectedStatus int) []byte {
@@ -30,6 +33,20 @@ func doRequest(t *testing.T, user *users.User, method string, path string, body 
 		return nil
 	}
 	return w.Body.Bytes()
+}
+
+func usersClientMock(org *users.Organization, u []*users.User, permissionID string) *mock_users.MockUsersClient {
+	c := mock_users.NewMockUsersClient(ctrl)
+	for _, user := range u {
+		c.EXPECT().
+			RequireOrgMemberPermissionTo(gomock.Any(), &users.RequireOrgMemberPermissionToRequest{
+				OrgID:        &users.RequireOrgMemberPermissionToRequest_OrgExternalID{},
+				UserID:       user.ID,
+				PermissionID: permissionID,
+			}).
+			Return(nil, api.RequireOrgMemberPermissionTo(context.Background(), database, user.ID, org.ExternalID, permissionID))
+	}
+	return c
 }
 
 func Test_RolesIsInTeamResponse(t *testing.T) {
@@ -236,4 +253,358 @@ func Test_PermissionTransferInstance(t *testing.T) {
 	doRequest(t, viewer, "PUT", path, bytes.NewReader(requestBody), http.StatusForbidden)
 	doRequest(t, editor, "PUT", path, bytes.NewReader(requestBody), http.StatusForbidden)
 	doRequest(t, admin, "PUT", path, bytes.NewReader(requestBody), http.StatusNoContent)
+}
+
+type mockHTTPHandler struct {
+	r *http.Request
+}
+
+func (h *mockHTTPHandler) ServeHTTP(_ http.ResponseWriter, req *http.Request) {
+	h.r = req
+}
+
+func testMiddleware(t *testing.T, middleware *client.UserPermissionsMiddleware, user *users.User, method string, path string, expectedStatus int) {
+	w := httptest.NewRecorder()
+	r := requestAs(t, user, method, path, nil)
+	r.Header.Set(middleware.UserIDHeader, user.ID)
+
+	middleware.Wrap(&mockHTTPHandler{}).ServeHTTP(w, r)
+	assert.Equal(t, expectedStatus, w.Code)
+}
+
+func Test_PermissionUpdateAlertingSettings(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, org, team := dbtest.GetOrgAndTeam(t, database)
+	database.SetFeatureFlags(context.TODO(), org.ExternalID, []string{"permissions"})
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
+	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+
+	middleware := client.UserPermissionsMiddleware{
+		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.UpdateAlertingSettings),
+		UserIDHeader: "UserID",
+	}
+	path := fmt.Sprintf("/api/app/%s/api/prom/configs/rules", org.ExternalID)
+
+	testMiddleware(t, &middleware, viewer, "POST", path, http.StatusBadGateway)
+	testMiddleware(t, &middleware, editor, "POST", path, http.StatusOK)
+	testMiddleware(t, &middleware, admin, "POST", path, http.StatusOK)
+}
+
+func Test_PermissionOpenHostShell(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, org, team := dbtest.GetOrgAndTeam(t, database)
+	database.SetFeatureFlags(context.TODO(), org.ExternalID, []string{"permissions"})
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
+	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+
+	middleware := client.UserPermissionsMiddleware{
+		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.OpenHostShell),
+		UserIDHeader: "UserID",
+	}
+	path := fmt.Sprintf("/api/app/%s/api/control/2ds3dcccesdkf7b/ip-43-43-120-4-host/host_exec", org.ExternalID)
+
+	testMiddleware(t, &middleware, viewer, "POST", path, http.StatusBadGateway)
+	testMiddleware(t, &middleware, editor, "POST", path, http.StatusBadGateway)
+	testMiddleware(t, &middleware, admin, "POST", path, http.StatusOK)
+}
+func Test_PermissionOpenContainerShell(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, org, team := dbtest.GetOrgAndTeam(t, database)
+	database.SetFeatureFlags(context.TODO(), org.ExternalID, []string{"permissions"})
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
+	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+
+	middleware := client.UserPermissionsMiddleware{
+		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.OpenContainerShell),
+		UserIDHeader: "UserID",
+	}
+	path := fmt.Sprintf("/api/app/%s/api/control/45ea4112d38b6bf5/d63bbd1efac7cc746867c8affkc05e701fa11d40fe28e2a4cf28bd7bd4cdb3a1/docker_exec_container", org.ExternalID)
+
+	testMiddleware(t, &middleware, viewer, "POST", path, http.StatusBadGateway)
+	testMiddleware(t, &middleware, editor, "POST", path, http.StatusBadGateway)
+	testMiddleware(t, &middleware, admin, "POST", path, http.StatusOK)
+}
+func Test_PermissionAttachToContainer(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, org, team := dbtest.GetOrgAndTeam(t, database)
+	database.SetFeatureFlags(context.TODO(), org.ExternalID, []string{"permissions"})
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
+	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+
+	middleware := client.UserPermissionsMiddleware{
+		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.AttachToContainer),
+		UserIDHeader: "UserID",
+	}
+	path := fmt.Sprintf("/api/app/%s/api/control/45ea4112d38b6bf5/d63bbd1efac7cc746867c8affkc05e701fa11d40fe28e2a4cf28bd7bd4cdb3a1/docker_attach_container", org.ExternalID)
+
+	testMiddleware(t, &middleware, viewer, "POST", path, http.StatusBadGateway)
+	testMiddleware(t, &middleware, editor, "POST", path, http.StatusOK)
+	testMiddleware(t, &middleware, admin, "POST", path, http.StatusOK)
+}
+func Test_PermissionPauseContainer(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, org, team := dbtest.GetOrgAndTeam(t, database)
+	database.SetFeatureFlags(context.TODO(), org.ExternalID, []string{"permissions"})
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
+	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+
+	middleware := client.UserPermissionsMiddleware{
+		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.PauseContainer),
+		UserIDHeader: "UserID",
+	}
+	path := fmt.Sprintf("/api/app/%s/api/control/45ea4112d38b6bf5/d63bbd1efac7cc746867c8affkc05e701fa11d40fe28e2a4cf28bd7bd4cdb3a1/docker_pause_container", org.ExternalID)
+
+	testMiddleware(t, &middleware, viewer, "POST", path, http.StatusBadGateway)
+	testMiddleware(t, &middleware, editor, "POST", path, http.StatusOK)
+	testMiddleware(t, &middleware, admin, "POST", path, http.StatusOK)
+
+	middleware.UsersClient = usersClientMock(org, []*users.User{viewer, editor, admin}, permission.PauseContainer)
+	path = fmt.Sprintf("/api/app/%s/api/control/45ea4112d38b6bf5/d63bbd1efac7cc746867c8affkc05e701fa11d40fe28e2a4cf28bd7bd4cdb3a1/docker_unpause_container", org.ExternalID)
+
+	testMiddleware(t, &middleware, viewer, "POST", path, http.StatusBadGateway)
+	testMiddleware(t, &middleware, editor, "POST", path, http.StatusOK)
+	testMiddleware(t, &middleware, admin, "POST", path, http.StatusOK)
+}
+
+func Test_PermissionRestartContainer(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, org, team := dbtest.GetOrgAndTeam(t, database)
+	database.SetFeatureFlags(context.TODO(), org.ExternalID, []string{"permissions"})
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
+	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+
+	middleware := client.UserPermissionsMiddleware{
+		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.RestartContainer),
+		UserIDHeader: "UserID",
+	}
+	path := fmt.Sprintf("/api/app/%s/api/control/45ea4112d38b6bf5/d63bbd1efac7cc746867c8affkc05e701fa11d40fe28e2a4cf28bd7bd4cdb3a1/docker_restart_container", org.ExternalID)
+
+	testMiddleware(t, &middleware, viewer, "POST", path, http.StatusBadGateway)
+	testMiddleware(t, &middleware, editor, "POST", path, http.StatusOK)
+	testMiddleware(t, &middleware, admin, "POST", path, http.StatusOK)
+}
+
+func Test_PermissionStopContainer(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, org, team := dbtest.GetOrgAndTeam(t, database)
+	database.SetFeatureFlags(context.TODO(), org.ExternalID, []string{"permissions"})
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
+	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+
+	middleware := client.UserPermissionsMiddleware{
+		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.StopContainer),
+		UserIDHeader: "UserID",
+	}
+	path := fmt.Sprintf("/api/app/%s/api/control/45ea4112d38b6bf5/d63bbd1efac7cc746867c8affkc05e701fa11d40fe28e2a4cf28bd7bd4cdb3a1/docker_stop_container", org.ExternalID)
+
+	testMiddleware(t, &middleware, viewer, "POST", path, http.StatusBadGateway)
+	testMiddleware(t, &middleware, editor, "POST", path, http.StatusOK)
+	testMiddleware(t, &middleware, admin, "POST", path, http.StatusOK)
+}
+
+func Test_PermissionViewPodLogs(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, org, team := dbtest.GetOrgAndTeam(t, database)
+	database.SetFeatureFlags(context.TODO(), org.ExternalID, []string{"permissions"})
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
+	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+
+	middleware := client.UserPermissionsMiddleware{
+		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.ViewPodLogs),
+		UserIDHeader: "UserID",
+	}
+	path := fmt.Sprintf("/api/app/%s/api/control/45ea4112d38b6bf5/ebc1e081-43ec-11e9-ad34-34324/kubernetes_get_logs", org.ExternalID)
+
+	testMiddleware(t, &middleware, viewer, "POST", path, http.StatusOK)
+	testMiddleware(t, &middleware, editor, "POST", path, http.StatusOK)
+	testMiddleware(t, &middleware, admin, "POST", path, http.StatusOK)
+}
+
+func Test_PermissionUpdateReplicaCount(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, org, team := dbtest.GetOrgAndTeam(t, database)
+	database.SetFeatureFlags(context.TODO(), org.ExternalID, []string{"permissions"})
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
+	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+
+	middleware := client.UserPermissionsMiddleware{
+		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.UpdateReplicaCount),
+		UserIDHeader: "UserID",
+	}
+	path := fmt.Sprintf("/api/app/%s/api/control/45ea4112d38b6bf5/ebc1e081-43ec-11e9-ad34-34324/kubernetes_scale_up", org.ExternalID)
+
+	testMiddleware(t, &middleware, viewer, "POST", path, http.StatusBadGateway)
+	testMiddleware(t, &middleware, editor, "POST", path, http.StatusOK)
+	testMiddleware(t, &middleware, admin, "POST", path, http.StatusOK)
+
+	middleware.UsersClient = usersClientMock(org, []*users.User{viewer, editor, admin}, permission.UpdateReplicaCount)
+	path = fmt.Sprintf("/api/app/%s/api/control/45ea4112d38b6bf5/ebc1e081-43ec-11e9-ad34-34324/kubernetes_scale_down", org.ExternalID)
+
+	testMiddleware(t, &middleware, viewer, "POST", path, http.StatusBadGateway)
+	testMiddleware(t, &middleware, editor, "POST", path, http.StatusOK)
+	testMiddleware(t, &middleware, admin, "POST", path, http.StatusOK)
+}
+
+func Test_PermissionDeletePod(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, org, team := dbtest.GetOrgAndTeam(t, database)
+	database.SetFeatureFlags(context.TODO(), org.ExternalID, []string{"permissions"})
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
+	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+
+	middleware := client.UserPermissionsMiddleware{
+		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.DeletePod),
+		UserIDHeader: "UserID",
+	}
+	path := fmt.Sprintf("/api/app/%s/api/control/45ea4112d38b6bf5/ebc1e081-43ec-11e9-ad34-34324/kubernetes_delete_pod", org.ExternalID)
+
+	testMiddleware(t, &middleware, viewer, "POST", path, http.StatusBadGateway)
+	testMiddleware(t, &middleware, editor, "POST", path, http.StatusOK)
+	testMiddleware(t, &middleware, admin, "POST", path, http.StatusOK)
+}
+
+func Test_PermissionDeployImage(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, org, team := dbtest.GetOrgAndTeam(t, database)
+	database.SetFeatureFlags(context.TODO(), org.ExternalID, []string{"permissions"})
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
+	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+
+	middleware := client.UserPermissionsMiddleware{
+		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.DeployImage),
+		UserIDHeader: "UserID",
+	}
+	path := fmt.Sprintf("/api/app/%s/api/flux/v9/update-manifests", org.ExternalID)
+
+	testMiddleware(t, &middleware, viewer, "POST", path, http.StatusBadGateway)
+	testMiddleware(t, &middleware, editor, "POST", path, http.StatusOK)
+	testMiddleware(t, &middleware, admin, "POST", path, http.StatusOK)
+
+	middleware.UsersClient = usersClientMock(org, []*users.User{viewer, editor, admin}, permission.DeployImage)
+	path = fmt.Sprintf("/api/app/%s/api/flux/v6/update-images", org.ExternalID)
+
+	testMiddleware(t, &middleware, viewer, "POST", path, http.StatusBadGateway)
+	testMiddleware(t, &middleware, editor, "POST", path, http.StatusOK)
+	testMiddleware(t, &middleware, admin, "POST", path, http.StatusOK)
+}
+
+func Test_PermissionUpdateDeploymentPolicy(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, org, team := dbtest.GetOrgAndTeam(t, database)
+	database.SetFeatureFlags(context.TODO(), org.ExternalID, []string{"permissions"})
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
+	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+
+	middleware := client.UserPermissionsMiddleware{
+		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.UpdateDeploymentPolicy),
+		UserIDHeader: "UserID",
+	}
+	path := fmt.Sprintf("/api/app/%s/api/flux/v6/policies", org.ExternalID)
+
+	testMiddleware(t, &middleware, viewer, "PATCH", path, http.StatusBadGateway)
+	testMiddleware(t, &middleware, editor, "PATCH", path, http.StatusOK)
+	testMiddleware(t, &middleware, admin, "PATCH", path, http.StatusOK)
+}
+
+func Test_PermissionUpdateNotificationSettings(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, org, team := dbtest.GetOrgAndTeam(t, database)
+	database.SetFeatureFlags(context.TODO(), org.ExternalID, []string{"permissions"})
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
+	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+
+	middleware := client.UserPermissionsMiddleware{
+		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.UpdateNotificationSettings),
+		UserIDHeader: "UserID",
+	}
+	path := fmt.Sprintf("/api/app/%s/api/notification/config/receivers/97b52281-5c6d-4250-b9a7-ad8a65427fac", org.ExternalID)
+
+	testMiddleware(t, &middleware, viewer, "POST", path, http.StatusBadGateway)
+	testMiddleware(t, &middleware, editor, "POST", path, http.StatusBadGateway)
+	testMiddleware(t, &middleware, admin, "POST", path, http.StatusOK)
+
+	middleware.UsersClient = usersClientMock(org, []*users.User{viewer, editor, admin}, permission.UpdateNotificationSettings)
+	path = fmt.Sprintf("/api/app/%s/api/notification/config/receivers/97b52281-5c6d-4250-b9a7-ad8a65427fac", org.ExternalID)
+
+	testMiddleware(t, &middleware, viewer, "PUT", path, http.StatusBadGateway)
+	testMiddleware(t, &middleware, editor, "PUT", path, http.StatusBadGateway)
+	testMiddleware(t, &middleware, admin, "PUT", path, http.StatusOK)
 }


### PR DESCRIPTION
Part of #2527.

#### Checklist

* [x] `notification.settings.update`
* [x] `alert.settings.update`
* [x] `scope.host.exec`
* [x] `scope.container.exec`
* [x] `scope.container.attach`
* [x] `scope.container.stop`
* [x] `scope.container.pause`
* [x] `scope.container.restart`
* [x] `scope.replicas.update`
* [x] `scope.pod.delete`
* [x] `scope.pod.logs.view`
* [x] `flux.image.deploy`
* [x] `flux.policy.update`

Unfortunately, I didn't know how to mock `handleError` so the tests get status code `http.StatusBadGateway` where there should have been `http.StatusForbidden`, but the more important thing is that we test `http.StatusOK` vs. any other.