### PR TITLE
Ignore empty GCP pubsub messages

### DIFF
--- a/gcp-launcher-webhook/entitlement/messagehandler.go
+++ b/gcp-launcher-webhook/entitlement/messagehandler.go
@@ -26,7 +26,12 @@ type MessageHandler struct {
 
 // Handle proceeds entitlement messages from PubSub.
 func (m MessageHandler) Handle(msg dto.Message) error {
-	log.Infof("Incoming webhook message: %+v", string(msg.Data))
+	log.Infof("Incoming webhook message %q (attributes %+v): %+v", msg.MessageID, msg.Attributes, string(msg.Data))
+	if len(msg.Data) == 0 {
+		log.Warnf("Ignoring empty message %q with attributes: %+v", msg.MessageID, msg.Attributes)
+		return nil // ACK
+
+	}
 	ctx := context.Background()
 
 	var payload event.Payload


### PR DESCRIPTION
We are currently receiving empty messages which we NACK and as such will
be resent over and over. I presume this might be because Google runs
code that supports Subscriptions API (legacy) and Procurement API (new)
at the same time.

Functionality for subscribing and changing entitlement plans is there so
we can just ignore them for now and wait for Google to respond to the
inquiry.