### PR TITLE
More permissions post GA cleanup

### DIFF
--- a/billing-api/routes/api.go
+++ b/billing-api/routes/api.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"encoding/base64"
+
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
 	"github.com/weaveworks/service/billing-api/db"

--- a/users/api/admin_test.go
+++ b/users/api/admin_test.go
@@ -151,7 +151,7 @@ func TestAPI_adminDeleteUser(t *testing.T) {
 	usr, single := getOrg(t)
 	other, multi := getOrg(t)
 	// single: usr / multi: usr, other
-	_, _, err := database.InviteUserToTeam(context.TODO(), usr.Email, multi.TeamExternalID, "admin")
+	_, _, err := database.InviteUserToTeam(context.TODO(), usr.Email, multi.TeamExternalID, users.AdminRoleID)
 	assert.NoError(t, err)
 
 	{ // delete first user

--- a/users/api/org_test.go
+++ b/users/api/org_test.go
@@ -73,7 +73,7 @@ func Test_OrgFiltersTokenIfMissingPermission(t *testing.T) {
 
 	admin, org, team := dbtest.GetOrgAndTeam(t, database)
 	user := getUser(t)
-	err := database.AddUserToTeam(context.TODO(), user.ID, team.ID, "viewer")
+	err := database.AddUserToTeam(context.TODO(), user.ID, team.ID, users.ViewerRoleID)
 	assert.NoError(t, err)
 
 	w := httptest.NewRecorder()
@@ -136,7 +136,7 @@ func Test_ListOrganizationUsers(t *testing.T) {
 	user, org := getOrg(t)
 
 	team := getTeam(t)
-	err := database.AddUserToTeam(context.TODO(), user.ID, team.ID, "admin")
+	err := database.AddUserToTeam(context.TODO(), user.ID, team.ID, users.AdminRoleID)
 	assert.NoError(t, err)
 
 	err = database.MoveOrganizationToTeam(context.TODO(), org.ExternalID, team.ExternalID, "", "")
@@ -145,10 +145,10 @@ func Test_ListOrganizationUsers(t *testing.T) {
 	us, err := database.ListTeamUsersWithRoles(context.TODO(), team.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(us))
-	assert.Equal(t, "admin", us[0].Role.ID)
+	assert.Equal(t, users.AdminRoleID, us[0].Role.ID)
 
 	fran := getUser(t)
-	fran, _, err = database.InviteUserToTeam(context.Background(), fran.Email, team.ExternalID, "admin")
+	fran, _, err = database.InviteUserToTeam(context.Background(), fran.Email, team.ExternalID, users.AdminRoleID)
 	require.NoError(t, err)
 
 	us, err = database.ListTeamUsersWithRoles(context.TODO(), team.ID)
@@ -166,12 +166,12 @@ func Test_ListOrganizationUsers(t *testing.T) {
 		"users": []interface{}{
 			map[string]interface{}{
 				"email":  fran.Email,
-				"roleId": "admin",
+				"roleId": users.AdminRoleID,
 			},
 			map[string]interface{}{
 				"email":  user.Email,
 				"self":   true,
-				"roleId": "admin",
+				"roleId": users.AdminRoleID,
 			},
 		},
 	}, responseBody)
@@ -257,7 +257,7 @@ func TestAPI_updateOrg_moveTeam(t *testing.T) {
 
 	{ // move from no-team to team
 		team := getTeam(t)
-		err := database.AddUserToTeam(context.TODO(), user.ID, team.ID, "admin")
+		err := database.AddUserToTeam(context.TODO(), user.ID, team.ID, users.AdminRoleID)
 		assert.NoError(t, err)
 
 		body := map[string]interface{}{"teamId": team.ExternalID}
@@ -274,7 +274,7 @@ func TestAPI_updateOrg_moveTeam(t *testing.T) {
 	}
 	{ // move from team to team
 		team := getTeam(t)
-		err := database.AddUserToTeam(context.TODO(), user.ID, team.ID, "admin")
+		err := database.AddUserToTeam(context.TODO(), user.ID, team.ID, users.AdminRoleID)
 		assert.NoError(t, err)
 
 		body := map[string]interface{}{"teamId": team.ExternalID}
@@ -308,7 +308,7 @@ func TestAPI_updateOrg_moveTeamBilledExternally(t *testing.T) {
 	user, org, team := dbtest.GetOrgAndTeam(t, database)
 
 	exteam := getTeam(t)
-	err := database.AddUserToTeam(context.TODO(), user.ID, exteam.ID, "admin")
+	err := database.AddUserToTeam(context.TODO(), user.ID, exteam.ID, users.AdminRoleID)
 	assert.NoError(t, err)
 
 	billingClient.EXPECT().FindBillingAccountByTeamID(gomock.Any(), &grpc.BillingAccountByTeamIDRequest{TeamID: team.ID}).
@@ -798,7 +798,7 @@ func Test_Organization_UserWithExpiredTrialButInTeamBilledExternallyShouldBeAble
 
 	// Create a team, and simulate the fact that team is marked as "billed externally":
 	team := getTeam(t)
-	err := database.AddUserToTeam(context.Background(), user.ID, team.ID, "admin")
+	err := database.AddUserToTeam(context.Background(), user.ID, team.ID, users.AdminRoleID)
 	assert.NoError(t, err)
 	billingClient.EXPECT().FindBillingAccountByTeamID(gomock.Any(), &grpc.BillingAccountByTeamIDRequest{TeamID: team.ID}).
 		Return(&grpc.BillingAccount{Provider: provider.External}, nil)
@@ -837,7 +837,7 @@ func Test_Organization_UserWithExpiredTrialAndNotInTeamBilledExternallyShouldNot
 
 	// Create a team, and simulate the fact that team is NOT marked as "billed externally":
 	team := getTeam(t)
-	err := database.AddUserToTeam(context.Background(), user.ID, team.ID, "admin")
+	err := database.AddUserToTeam(context.Background(), user.ID, team.ID, users.AdminRoleID)
 	assert.NoError(t, err)
 	billingClient.EXPECT().FindBillingAccountByTeamID(gomock.Any(), &grpc.BillingAccountByTeamIDRequest{TeamID: team.ID}).
 		Return(&grpc.BillingAccount{}, nil)

--- a/users/api/permission_test.go
+++ b/users/api/permission_test.go
@@ -62,7 +62,7 @@ func Test_RolesIsInTeamResponse(t *testing.T) {
 			map[string]interface{}{
 				"id":     team.ExternalID,
 				"name":   team.Name,
-				"roleId": "admin",
+				"roleId": users.AdminRoleID,
 			},
 		},
 	}, body)
@@ -82,7 +82,7 @@ func Test_PermissionsInRoleResponse(t *testing.T) {
 
 	var admin api.RoleView
 	for _, role := range body.Roles {
-		if role.ID == "admin" {
+		if role.ID == users.AdminRoleID {
 			admin = role
 		}
 	}
@@ -102,12 +102,12 @@ func Test_PermissionInviteTeamMember(t *testing.T) {
 	path := fmt.Sprintf("/api/users/teams/%s/users", team.ExternalID)
 	requestBody, _ := json.Marshal(map[string]string{
 		"email":  "blu@blu.blu",
-		"roleId": "viewer",
+		"roleId": users.ViewerRoleID,
 	})
 
-	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
-	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
-	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, users.ViewerRoleID)
+	editor, _ := dbtest.GetUserInTeam(t, database, team, users.EditorRoleID)
+	admin, _ := dbtest.GetUserInTeam(t, database, team, users.AdminRoleID)
 	doRequest(t, viewer, "POST", path, bytes.NewReader(requestBody), http.StatusForbidden)
 	doRequest(t, editor, "POST", path, bytes.NewReader(requestBody), http.StatusForbidden)
 	doRequest(t, admin, "POST", path, bytes.NewReader(requestBody), http.StatusOK)
@@ -118,15 +118,15 @@ func Test_PermissionUpdateTeamMemberRole(t *testing.T) {
 
 	_, _, team := dbtest.GetOrgAndTeam(t, database)
 
-	other, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	other, _ := dbtest.GetUserInTeam(t, database, team, users.ViewerRoleID)
 	path := fmt.Sprintf("/api/users/teams/%s/users/%s", team.ExternalID, other.Email)
 	requestBody, _ := json.Marshal(map[string]string{
-		"roleId": "viewer",
+		"roleId": users.ViewerRoleID,
 	})
 
-	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
-	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
-	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, users.ViewerRoleID)
+	editor, _ := dbtest.GetUserInTeam(t, database, team, users.EditorRoleID)
+	admin, _ := dbtest.GetUserInTeam(t, database, team, users.AdminRoleID)
 	doRequest(t, viewer, "PUT", path, bytes.NewReader(requestBody), http.StatusForbidden)
 	doRequest(t, editor, "PUT", path, bytes.NewReader(requestBody), http.StatusForbidden)
 	doRequest(t, admin, "PUT", path, bytes.NewReader(requestBody), http.StatusNoContent)
@@ -137,12 +137,12 @@ func Test_PermissionRemoveTeamMember(t *testing.T) {
 
 	_, _, team := dbtest.GetOrgAndTeam(t, database)
 
-	other, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
+	other, _ := dbtest.GetUserInTeam(t, database, team, users.ViewerRoleID)
 	path := fmt.Sprintf("/api/users/teams/%s/users/%s", team.ExternalID, other.Email)
 
-	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
-	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
-	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, users.ViewerRoleID)
+	editor, _ := dbtest.GetUserInTeam(t, database, team, users.EditorRoleID)
+	admin, _ := dbtest.GetUserInTeam(t, database, team, users.AdminRoleID)
 	doRequest(t, viewer, "DELETE", path, nil, http.StatusForbidden)
 	doRequest(t, editor, "DELETE", path, nil, http.StatusForbidden)
 	doRequest(t, admin, "DELETE", path, nil, http.StatusOK)
@@ -155,9 +155,9 @@ func Test_PermissionViewTeamMembers(t *testing.T) {
 
 	path := fmt.Sprintf("/api/users/org/%s/users", org.ExternalID)
 
-	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
-	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
-	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, users.ViewerRoleID)
+	editor, _ := dbtest.GetUserInTeam(t, database, team, users.EditorRoleID)
+	admin, _ := dbtest.GetUserInTeam(t, database, team, users.AdminRoleID)
 	doRequest(t, viewer, "GET", path, nil, http.StatusOK)
 	doRequest(t, editor, "GET", path, nil, http.StatusOK)
 	doRequest(t, admin, "GET", path, nil, http.StatusOK)
@@ -170,9 +170,9 @@ func Test_PermissionDeleteInstance(t *testing.T) {
 
 	path := fmt.Sprintf("/api/users/org/%s", org.ExternalID)
 
-	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
-	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
-	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, users.ViewerRoleID)
+	editor, _ := dbtest.GetUserInTeam(t, database, team, users.EditorRoleID)
+	admin, _ := dbtest.GetUserInTeam(t, database, team, users.AdminRoleID)
 	doRequest(t, viewer, "DELETE", path, nil, http.StatusForbidden)
 	doRequest(t, editor, "DELETE", path, nil, http.StatusForbidden)
 	doRequest(t, admin, "DELETE", path, nil, http.StatusNoContent)
@@ -187,9 +187,9 @@ func Test_PermissionViewToken(t *testing.T) {
 	body := map[string]interface{}{}
 	path := fmt.Sprintf("/api/users/org/%s", org.ExternalID)
 
-	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
-	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
-	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, users.ViewerRoleID)
+	editor, _ := dbtest.GetUserInTeam(t, database, team, users.EditorRoleID)
+	admin, _ := dbtest.GetUserInTeam(t, database, team, users.AdminRoleID)
 	bodyBytes := doRequest(t, viewer, "GET", path, nil, http.StatusOK)
 	assert.NoError(t, json.Unmarshal(bodyBytes, &body))
 	assert.Equal(t, nil, body["probeToken"])
@@ -221,27 +221,27 @@ func Test_PermissionTransferInstance(t *testing.T) {
 			Provider:  provider.External,
 		}, nil)
 
-	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
-	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
-	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, users.ViewerRoleID)
+	editor, _ := dbtest.GetUserInTeam(t, database, team, users.EditorRoleID)
+	admin, _ := dbtest.GetUserInTeam(t, database, team, users.AdminRoleID)
 	// Viewers in the other team
-	database.AddUserToTeam(context.TODO(), viewer.ID, otherTeam.ID, "viewer")
-	database.AddUserToTeam(context.TODO(), editor.ID, otherTeam.ID, "viewer")
-	database.AddUserToTeam(context.TODO(), admin.ID, otherTeam.ID, "viewer")
+	database.AddUserToTeam(context.TODO(), viewer.ID, otherTeam.ID, users.ViewerRoleID)
+	database.AddUserToTeam(context.TODO(), editor.ID, otherTeam.ID, users.ViewerRoleID)
+	database.AddUserToTeam(context.TODO(), admin.ID, otherTeam.ID, users.ViewerRoleID)
 	doRequest(t, viewer, "PUT", path, bytes.NewReader(requestBody), http.StatusForbidden)
 	doRequest(t, editor, "PUT", path, bytes.NewReader(requestBody), http.StatusForbidden)
 	doRequest(t, admin, "PUT", path, bytes.NewReader(requestBody), http.StatusForbidden)
 	// Editors in the other team
-	database.UpdateUserRoleInTeam(context.TODO(), viewer.ID, otherTeam.ID, "editor")
-	database.UpdateUserRoleInTeam(context.TODO(), editor.ID, otherTeam.ID, "editor")
-	database.UpdateUserRoleInTeam(context.TODO(), admin.ID, otherTeam.ID, "editor")
+	database.UpdateUserRoleInTeam(context.TODO(), viewer.ID, otherTeam.ID, users.EditorRoleID)
+	database.UpdateUserRoleInTeam(context.TODO(), editor.ID, otherTeam.ID, users.EditorRoleID)
+	database.UpdateUserRoleInTeam(context.TODO(), admin.ID, otherTeam.ID, users.EditorRoleID)
 	doRequest(t, viewer, "PUT", path, bytes.NewReader(requestBody), http.StatusForbidden)
 	doRequest(t, editor, "PUT", path, bytes.NewReader(requestBody), http.StatusForbidden)
 	doRequest(t, admin, "PUT", path, bytes.NewReader(requestBody), http.StatusForbidden)
 	// Admins in the other team
-	database.UpdateUserRoleInTeam(context.TODO(), viewer.ID, otherTeam.ID, "admin")
-	database.UpdateUserRoleInTeam(context.TODO(), editor.ID, otherTeam.ID, "admin")
-	database.UpdateUserRoleInTeam(context.TODO(), admin.ID, otherTeam.ID, "admin")
+	database.UpdateUserRoleInTeam(context.TODO(), viewer.ID, otherTeam.ID, users.AdminRoleID)
+	database.UpdateUserRoleInTeam(context.TODO(), editor.ID, otherTeam.ID, users.AdminRoleID)
+	database.UpdateUserRoleInTeam(context.TODO(), admin.ID, otherTeam.ID, users.AdminRoleID)
 	doRequest(t, viewer, "PUT", path, bytes.NewReader(requestBody), http.StatusForbidden)
 	doRequest(t, editor, "PUT", path, bytes.NewReader(requestBody), http.StatusForbidden)
 	doRequest(t, admin, "PUT", path, bytes.NewReader(requestBody), http.StatusNoContent)
@@ -272,9 +272,9 @@ func Test_PermissionUpdateAlertingSettings(t *testing.T) {
 	defer ctrl.Finish()
 
 	_, org, team := dbtest.GetOrgAndTeam(t, database)
-	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
-	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
-	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, users.ViewerRoleID)
+	editor, _ := dbtest.GetUserInTeam(t, database, team, users.EditorRoleID)
+	admin, _ := dbtest.GetUserInTeam(t, database, team, users.AdminRoleID)
 
 	middleware := client.UserPermissionsMiddleware{
 		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.UpdateAlertingSettings),
@@ -295,9 +295,9 @@ func Test_PermissionOpenHostShell(t *testing.T) {
 	defer ctrl.Finish()
 
 	_, org, team := dbtest.GetOrgAndTeam(t, database)
-	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
-	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
-	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, users.ViewerRoleID)
+	editor, _ := dbtest.GetUserInTeam(t, database, team, users.EditorRoleID)
+	admin, _ := dbtest.GetUserInTeam(t, database, team, users.AdminRoleID)
 
 	middleware := client.UserPermissionsMiddleware{
 		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.OpenHostShell),
@@ -317,9 +317,9 @@ func Test_PermissionOpenContainerShell(t *testing.T) {
 	defer ctrl.Finish()
 
 	_, org, team := dbtest.GetOrgAndTeam(t, database)
-	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
-	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
-	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, users.ViewerRoleID)
+	editor, _ := dbtest.GetUserInTeam(t, database, team, users.EditorRoleID)
+	admin, _ := dbtest.GetUserInTeam(t, database, team, users.AdminRoleID)
 
 	middleware := client.UserPermissionsMiddleware{
 		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.OpenContainerShell),
@@ -339,9 +339,9 @@ func Test_PermissionAttachToContainer(t *testing.T) {
 	defer ctrl.Finish()
 
 	_, org, team := dbtest.GetOrgAndTeam(t, database)
-	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
-	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
-	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, users.ViewerRoleID)
+	editor, _ := dbtest.GetUserInTeam(t, database, team, users.EditorRoleID)
+	admin, _ := dbtest.GetUserInTeam(t, database, team, users.AdminRoleID)
 
 	middleware := client.UserPermissionsMiddleware{
 		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.AttachToContainer),
@@ -361,9 +361,9 @@ func Test_PermissionPauseContainer(t *testing.T) {
 	defer ctrl.Finish()
 
 	_, org, team := dbtest.GetOrgAndTeam(t, database)
-	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
-	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
-	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, users.ViewerRoleID)
+	editor, _ := dbtest.GetUserInTeam(t, database, team, users.EditorRoleID)
+	admin, _ := dbtest.GetUserInTeam(t, database, team, users.AdminRoleID)
 
 	middleware := client.UserPermissionsMiddleware{
 		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.PauseContainer),
@@ -391,9 +391,9 @@ func Test_PermissionRestartContainer(t *testing.T) {
 	defer ctrl.Finish()
 
 	_, org, team := dbtest.GetOrgAndTeam(t, database)
-	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
-	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
-	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, users.ViewerRoleID)
+	editor, _ := dbtest.GetUserInTeam(t, database, team, users.EditorRoleID)
+	admin, _ := dbtest.GetUserInTeam(t, database, team, users.AdminRoleID)
 
 	middleware := client.UserPermissionsMiddleware{
 		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.RestartContainer),
@@ -414,9 +414,9 @@ func Test_PermissionStopContainer(t *testing.T) {
 	defer ctrl.Finish()
 
 	_, org, team := dbtest.GetOrgAndTeam(t, database)
-	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
-	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
-	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, users.ViewerRoleID)
+	editor, _ := dbtest.GetUserInTeam(t, database, team, users.EditorRoleID)
+	admin, _ := dbtest.GetUserInTeam(t, database, team, users.AdminRoleID)
 
 	middleware := client.UserPermissionsMiddleware{
 		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.StopContainer),
@@ -437,9 +437,9 @@ func Test_PermissionViewPodLogs(t *testing.T) {
 	defer ctrl.Finish()
 
 	_, org, team := dbtest.GetOrgAndTeam(t, database)
-	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
-	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
-	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, users.ViewerRoleID)
+	editor, _ := dbtest.GetUserInTeam(t, database, team, users.EditorRoleID)
+	admin, _ := dbtest.GetUserInTeam(t, database, team, users.AdminRoleID)
 
 	middleware := client.UserPermissionsMiddleware{
 		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.ViewPodLogs),
@@ -460,9 +460,9 @@ func Test_PermissionUpdateReplicaCount(t *testing.T) {
 	defer ctrl.Finish()
 
 	_, org, team := dbtest.GetOrgAndTeam(t, database)
-	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
-	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
-	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, users.ViewerRoleID)
+	editor, _ := dbtest.GetUserInTeam(t, database, team, users.EditorRoleID)
+	admin, _ := dbtest.GetUserInTeam(t, database, team, users.AdminRoleID)
 
 	middleware := client.UserPermissionsMiddleware{
 		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.UpdateReplicaCount),
@@ -490,9 +490,9 @@ func Test_PermissionDeletePod(t *testing.T) {
 	defer ctrl.Finish()
 
 	_, org, team := dbtest.GetOrgAndTeam(t, database)
-	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
-	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
-	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, users.ViewerRoleID)
+	editor, _ := dbtest.GetUserInTeam(t, database, team, users.EditorRoleID)
+	admin, _ := dbtest.GetUserInTeam(t, database, team, users.AdminRoleID)
 
 	middleware := client.UserPermissionsMiddleware{
 		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.DeletePod),
@@ -513,9 +513,9 @@ func Test_PermissionDeployImage(t *testing.T) {
 	defer ctrl.Finish()
 
 	_, org, team := dbtest.GetOrgAndTeam(t, database)
-	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
-	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
-	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, users.ViewerRoleID)
+	editor, _ := dbtest.GetUserInTeam(t, database, team, users.EditorRoleID)
+	admin, _ := dbtest.GetUserInTeam(t, database, team, users.AdminRoleID)
 
 	middleware := client.UserPermissionsMiddleware{
 		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.DeployImage),
@@ -543,9 +543,9 @@ func Test_PermissionUpdateDeploymentPolicy(t *testing.T) {
 	defer ctrl.Finish()
 
 	_, org, team := dbtest.GetOrgAndTeam(t, database)
-	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
-	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
-	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, users.ViewerRoleID)
+	editor, _ := dbtest.GetUserInTeam(t, database, team, users.EditorRoleID)
+	admin, _ := dbtest.GetUserInTeam(t, database, team, users.AdminRoleID)
 
 	middleware := client.UserPermissionsMiddleware{
 		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.UpdateDeploymentPolicy),
@@ -566,9 +566,9 @@ func Test_PermissionUpdateNotificationSettings(t *testing.T) {
 	defer ctrl.Finish()
 
 	_, org, team := dbtest.GetOrgAndTeam(t, database)
-	viewer, _ := dbtest.GetUserInTeam(t, database, team, "viewer")
-	editor, _ := dbtest.GetUserInTeam(t, database, team, "editor")
-	admin, _ := dbtest.GetUserInTeam(t, database, team, "admin")
+	viewer, _ := dbtest.GetUserInTeam(t, database, team, users.ViewerRoleID)
+	editor, _ := dbtest.GetUserInTeam(t, database, team, users.EditorRoleID)
+	admin, _ := dbtest.GetUserInTeam(t, database, team, users.AdminRoleID)
 
 	middleware := client.UserPermissionsMiddleware{
 		UsersClient:  usersClientMock(org, []*users.User{viewer, editor, admin}, permission.UpdateNotificationSettings),

--- a/users/api/team.go
+++ b/users/api/team.go
@@ -254,11 +254,10 @@ func (a *API) removeUserFromTeam(currentUser *users.User, w http.ResponseWriter,
 
 	// A team always has to have at least one admin present,
 	// so if the user to be removed is the only admin, deny it.
-	// TODO(fbarl): Consider extracting "admin", "editor", "viewer" into constants.
-	if role.ID == "admin" {
+	if role.ID == users.AdminRoleID {
 		adminCount := 0
 		for _, m := range members {
-			if m.Role.ID == "admin" {
+			if m.Role.ID == users.AdminRoleID {
 				adminCount++
 			}
 		}

--- a/users/api/webhooks_test.go
+++ b/users/api/webhooks_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/weaveworks/service/common/constants/webhooks"
+	"github.com/weaveworks/service/users"
 	"github.com/weaveworks/service/users/db/dbtest"
 )
 
@@ -90,7 +91,7 @@ func TestAPI_createOrganizationWebhookNonAdmin(t *testing.T) {
 	_, org, team := dbtest.GetOrgAndTeam(t, database)
 	viewerUser := getUser(t)
 
-	err := database.AddUserToTeam(context.TODO(), viewerUser.ID, team.ID, "viewer")
+	err := database.AddUserToTeam(context.TODO(), viewerUser.ID, team.ID, users.ViewerRoleID)
 	assert.NoError(t, err)
 
 	payload, err := json.Marshal(map[string]string{"integrationType": webhooks.GithubPushIntegrationType})
@@ -131,7 +132,7 @@ func TestAPI_deleteOrganizationWebhookNonAdmin(t *testing.T) {
 	viewerUser := getUser(t)
 	w1 := dbtest.CreateWebhookForOrg(t, database, org, webhooks.GithubPushIntegrationType)
 
-	err := database.AddUserToTeam(context.TODO(), viewerUser.ID, team.ID, "viewer")
+	err := database.AddUserToTeam(context.TODO(), viewerUser.ID, team.ID, users.ViewerRoleID)
 	assert.NoError(t, err)
 
 	w := httptest.NewRecorder()

--- a/users/db/db_test.go
+++ b/users/db/db_test.go
@@ -23,7 +23,7 @@ func TestDB_RemoveOtherUsersAccess(t *testing.T) {
 
 	_, org := dbtest.GetOrg(t, db)
 	otherUser := dbtest.GetUser(t, db)
-	otherUser, _, err := db.InviteUserToTeam(context.Background(), otherUser.Email, org.TeamExternalID, "admin")
+	otherUser, _, err := db.InviteUserToTeam(context.Background(), otherUser.Email, org.TeamExternalID, users.AdminRoleID)
 	require.NoError(t, err)
 	otherUserOrganizations, err := db.ListOrganizationsForUserIDs(context.Background(), otherUser.ID)
 	require.NoError(t, err)
@@ -62,7 +62,7 @@ func TestDB_RemoveOtherUsersAccessWithTeams(t *testing.T) {
 	require.Len(t, userTeams, 1)
 	require.Equal(t, team.ID, userTeams[0].ID)
 
-	otherUser, _, err = db.InviteUserToTeam(ctx, otherUser.Email, org.TeamExternalID, "admin")
+	otherUser, _, err = db.InviteUserToTeam(ctx, otherUser.Email, org.TeamExternalID, users.AdminRoleID)
 	require.NoError(t, err)
 	otherUserOrganizations, err := db.ListOrganizationsForUserIDs(context.Background(), otherUser.ID)
 	require.NoError(t, err)
@@ -264,7 +264,7 @@ func TestDB_DoubleTeamMembershipEntry(t *testing.T) {
 	require.Equal(t, team.ID, userTeams[0].ID)
 
 	// re-add user to the same team
-	err = db.AddUserToTeam(ctx, user.ID, team.ID, "admin")
+	err = db.AddUserToTeam(ctx, user.ID, team.ID, users.AdminRoleID)
 	require.NoError(t, err)
 }
 

--- a/users/db/dbtest/helpers.go
+++ b/users/db/dbtest/helpers.go
@@ -77,7 +77,7 @@ func CreateOrgForTeam(t *testing.T, db db.DB, u *users.User, team *users.Team) *
 	assert.NotEqual(t, nil, team)
 	assert.NotEqual(t, "", team.ID)
 
-	err := db.AddUserToTeam(context.Background(), u.ID, team.ID, "admin")
+	err := db.AddUserToTeam(context.Background(), u.ID, team.ID, users.AdminRoleID)
 	require.NoError(t, err)
 
 	externalID, err := db.GenerateOrganizationExternalID(context.Background())

--- a/users/db/memory/team.go
+++ b/users/db/memory/team.go
@@ -189,7 +189,7 @@ func (d *DB) CreateTeamAsUser(ctx context.Context, name, userID string) (*users.
 		return nil, err
 	}
 
-	err = d.AddUserToTeam(ctx, userID, team.ID, "admin")
+	err = d.AddUserToTeam(ctx, userID, team.ID, users.AdminRoleID)
 	if err != nil {
 		return nil, err
 	}

--- a/users/db/postgres/team.go
+++ b/users/db/postgres/team.go
@@ -243,7 +243,7 @@ func (d *DB) CreateTeamAsUser(ctx context.Context, name, userID string) (*users.
 		return nil, err
 	}
 
-	err = d.AddUserToTeam(ctx, userID, team.ID, "admin")
+	err = d.AddUserToTeam(ctx, userID, team.ID, users.AdminRoleID)
 	if err != nil {
 		return nil, err
 	}

--- a/users/user.go
+++ b/users/user.go
@@ -7,13 +7,22 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+const (
+	// AdminRoleID stands for the ID of team admin role
+	AdminRoleID = "admin"
+	// EditorRoleID stands for the ID of team editor role
+	EditorRoleID = "editor"
+	// ViewerRoleID stands for the ID of team viewer role
+	ViewerRoleID = "viewer"
+)
+
 // TrialDuration is how long a user has a free trial
 // period before we start charging for it.
 const TrialDuration = 14 * 24 * time.Hour
 
 // DefaultRoleID is the role given to a new team member if no role is specified
 // used in entry points to the system like API endpoints.
-const DefaultRoleID = "viewer"
+const DefaultRoleID = ViewerRoleID
 
 // FindUserByIDer is an interface of just FindUserByID, for loosely coupling
 // things to the db.DB


### PR DESCRIPTION
* Make viewer a default team role (BE part of #2545)
* Use constants for team role IDs
