### PR TITLE
Include cacerts in service-net-discovery image

### DIFF
--- a/service-net-discovery/Dockerfile
+++ b/service-net-discovery/Dockerfile
@@ -1,4 +1,5 @@
 FROM       alpine:3.6
+RUN        apk add --no-cache ca-certificates
 COPY       cmd/discovery/discovery /bin/discovery
 EXPOSE     80
 ENTRYPOINT [ "/bin/discovery" ]


### PR DESCRIPTION
When I merged it into service (#2581) I changed the image FROM to match all the other images, without realising that the original had cacerts preinstalled.