### PR TITLE
Add an option to enable http connection pooling on some services

### DIFF
--- a/authfe/config.go
+++ b/authfe/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	listen, privateListen string
 	logLevel              string
 	stopTimeout           time.Duration
+	httpKeepAlives        string // comma-separated list of services
 
 	// Security-related flags
 	hstsMaxAge            int
@@ -165,6 +166,7 @@ func (c *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&c.privateListen, "private-listen", ":8080", "HTTP server listen address (private endpoints)")
 	f.StringVar(&c.logLevel, "log.level", "info", "Logging level to use: debug | info | warn | error")
 	f.DurationVar(&c.stopTimeout, "stop.timeout", 5*time.Second, "How long to wait for remaining requests to finish during shutdown")
+	f.StringVar(&c.httpKeepAlives, "http-keep-alives", "", "Services where http keep-alive is not disabled (comma-separated)")
 
 	// Security-related flags
 	f.IntVar(&c.hstsMaxAge, "hsts-max-age", 0, "Max Age in seconds for HSTS header - zero means no header.  Header will only be send if redirect-https is true.")
@@ -194,6 +196,9 @@ func (c *Config) ReadEnvVars() {
 type proxyConfig struct {
 	// Determines the names of the flags
 	name string
+
+	// Enable http keep-alives if true
+	allowKeepAlive bool
 
 	// Values set by flags.
 	hostAndPort string

--- a/authfe/main.go
+++ b/authfe/main.go
@@ -86,6 +86,11 @@ func main() {
 		if proxyCfg.hostAndPort == "" && proxyCfg.grpcHost == "" {
 			log.Warningf("Host for %s not given; will not be proxied", name)
 		}
+		for _, n := range strings.Split(cfg.httpKeepAlives, ",") {
+			if n == name {
+				proxyCfg.allowKeepAlive = true
+			}
+		}
 		handler, err := newProxy(*proxyCfg)
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
The current status is off everywhere, which increases latency in the name of improving fairness. 
This PR allows fine-tuning in cases where we prefer lower latency.

The comma-separated list was chosen to be low-impact on config, especially if we decide to flip the default and have it on everywhere.
