### PR TITLE
Replace Click Here link with descriptive text

### DIFF
--- a/common/templates/wrapper.html
+++ b/common/templates/wrapper.html
@@ -41,7 +41,8 @@
     </div>
     {{if .Unsubscribable}}
       <p style="text-align: center; font-style: italic; font-size: 12px; margin: 20px 0 30px;">
-        If you would like to unsubscribe and stop receiving these emails <a href="<%asm_group_unsubscribe_raw_url%>" style="color: #666; outline: none;">click here</a>.
+        <a href="<%asm_group_unsubscribe_raw_url%>" style="color: #666; outline: none;">Unsubscribe</a> from receiving these emails. You may subscribe at any time in your
+          <a href="<%asm_preferences_raw_url%>" style="color: #666; outline: none;">subscription preferences</a>.
       </p>
     {{end}}
     <div style="text-align: center; font-size: 9px; margin: 24px 0;">


### PR DESCRIPTION
Puts the link to click to the text 'subscribe' instead of having a
'click here' link.
Also adds a note on how to re-subscribe with a link to the preferences.