### PR TITLE
Add corpdiff admin route to authfe

### DIFF
--- a/authfe/config.go
+++ b/authfe/config.go
@@ -69,6 +69,7 @@ type Config struct {
 	compareImagesHost     proxyConfig
 	compareRevisionsHost  proxyConfig
 	corpAtlantisHost      proxyConfig
+	corpDiffHost          proxyConfig
 	corpTerradiffHost     proxyConfig
 	devGrafanaHost        proxyConfig
 	elasticsearchHost     proxyConfig
@@ -128,6 +129,7 @@ func (c *Config) proxies() map[string]*proxyConfig {
 		"compare-images":     &c.compareImagesHost,
 		"compare-revisions":  &c.compareRevisionsHost,
 		"corp-atlantis":      &c.corpAtlantisHost,
+		"corpdiff":           &c.corpDiffHost,
 		"corp-terradiff":     &c.corpTerradiffHost,
 		"dev-grafana":        &c.devGrafanaHost,
 		"wkp-ui-grafana":     &c.wkpUIGrafana,

--- a/authfe/routes.go
+++ b/authfe/routes.go
@@ -369,6 +369,7 @@ func routes(c Config, authenticator users.UsersClient, ghIntegration *users_clie
 				{"/esh", trimPrefix("/admin/esh", c.eshHost)},
 				{"/corp-atlantis", trimPrefix("/admin/corp-atlantis", c.corpAtlantisHost)},
 				{"/corp-terradiff", trimPrefix("/admin/corp-terradiff", c.corpTerradiffHost)},
+				{"/corpdiff", trimPrefix("/admin/corpdiff", c.corpDiffHost)},
 				{"/", http.HandlerFunc(adminRoot)},
 			}),
 			middleware.Merge(


### PR DESCRIPTION
So that we can access the https://github.com/weaveworks/corpdiff UI.