### PR TITLE
Adds EKS as a valid env to be recorded during onboarding

### DIFF
--- a/users/organization.go
+++ b/users/organization.go
@@ -30,6 +30,7 @@ var (
 	platforms = map[string]map[string]struct{}{
 		"kubernetes": {
 			"minikube": struct{}{},
+			"eks":      struct{}{},
 			"gke":      struct{}{},
 			"generic":  struct{}{},
 		},
@@ -37,6 +38,7 @@ var (
 			"mac":     struct{}{},
 			"linux":   struct{}{},
 			"windows": struct{}{},
+			"cloud":   struct{}{},
 			"ee":      struct{}{},
 			"swarm":   struct{}{},
 		},


### PR DESCRIPTION
- Fixes a bug where leaving this blank would cause it to be accidentally
  set to something wrong later on.

Fixes #2623