### PR TITLE
Fix extracting account email from Google+ person

### DIFF
--- a/users/login/google.go
+++ b/users/login/google.go
@@ -3,9 +3,11 @@ package login
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
@@ -97,11 +99,11 @@ func (g *google) person(token *oauth2.Token) (*plus.Person, error) {
 
 func (g *google) personEmail(p *plus.Person) (string, error) {
 	for _, e := range p.Emails {
-		if e.Type == "account" {
+		if strings.ToLower(e.Type) == "account" {
 			return e.Value, nil
 		}
 	}
-	return "", fmt.Errorf("Invalid authentication data")
+	return "", errors.New("cannot find account email")
 }
 
 // Logout handles a user logout request with this provider. It should revoke


### PR DESCRIPTION
When a user is logging in through Google's SSO we fetch the Google+
person and extract the email. The capitalization of the email type has
changed and the code was not finding it anymore.

Fixes https://github.com/weaveworks/service-conf/issues/3554