### PR TITLE
Fix instance creation date appearing in weekly report emails

### DIFF
--- a/users/weeklyreports/email.go
+++ b/users/weeklyreports/email.go
@@ -11,7 +11,7 @@ const (
 	dayOfWeekFormat = "Mon"
 	dateDayFormat   = "2"
 	dateShortFormat = "Jan 2"
-	dateLongFormat  = "October 2nd, 2006"
+	dateLongFormat  = "January 2nd, 2006"
 )
 
 // EmailSummary contains all the data for rendering the weekly summary report in the email.


### PR DESCRIPTION
Fixes #2630.

It seems that the layout passed to [time.Format](https://golang.org/pkg/time/#Time.Format) function has been wrong all along as it contained `October` instead of `January` for the month format :man_facepalming:

I added a broader unit test for the weekly report emails which fails without the fix.
