### PR TITLE
Remove code to proxy http requests over gRPC

### DIFF
--- a/authfe/config.go
+++ b/authfe/config.go
@@ -206,7 +206,6 @@ type proxyConfig struct {
 	hostAndPort string
 	protocol    string
 	readOnly    bool
-	grpcHost    string
 
 	// Set this based on the flags
 	http.Handler
@@ -215,7 +214,6 @@ type proxyConfig struct {
 func (p *proxyConfig) RegisterFlags(name string, f *flag.FlagSet) {
 	p.name = name
 	f.StringVar(&p.hostAndPort, name, "", fmt.Sprintf("Hostname & port for %s service", name))
-	f.StringVar(&p.protocol, name+".protocol", "http", fmt.Sprintf("Protocol to connect to this %s service via (Must be: http or grpc)", name))
+	f.StringVar(&p.protocol, name+".protocol", "http", fmt.Sprintf("Protocol to connect to this %s service via (Must be: http or https)", name))
 	f.BoolVar(&p.readOnly, name+".readonly", false, fmt.Sprintf("Make %s service, read-only (will only accept GETs)", name))
-	f.StringVar(&p.grpcHost, name+"-grpc", "", fmt.Sprintf("Use gRPC for %s, instead of protocol (backwards compat)", name))
 }

--- a/authfe/main.go
+++ b/authfe/main.go
@@ -83,7 +83,7 @@ func main() {
 
 	// Initialize all the proxies
 	for name, proxyCfg := range cfg.proxies() {
-		if proxyCfg.hostAndPort == "" && proxyCfg.grpcHost == "" {
+		if proxyCfg.hostAndPort == "" {
 			log.Warningf("Host for %s not given; will not be proxied", name)
 		}
 		for _, n := range strings.Split(cfg.httpKeepAlives, ",") {

--- a/authfe/proxy.go
+++ b/authfe/proxy.go
@@ -18,7 +18,6 @@ import (
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go"
 	log "github.com/sirupsen/logrus"
-	httpgrpc_server "github.com/weaveworks/common/httpgrpc/server"
 	"github.com/weaveworks/common/logging"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/user"
@@ -27,12 +26,7 @@ import (
 const defaultPort = "80"
 
 func newProxy(cfg proxyConfig) (http.Handler, error) {
-	if cfg.grpcHost != "" {
-		return httpgrpc_server.NewClient(cfg.grpcHost)
-	}
 	switch cfg.protocol {
-	case "grpc":
-		return httpgrpc_server.NewClient(cfg.hostAndPort)
 	case "https", "http":
 		return newHTTPProxy(cfg)
 	case "mock":

--- a/authfe/proxy_test.go
+++ b/authfe/proxy_test.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -13,16 +11,8 @@ import (
 	"time"
 
 	gorillaws "github.com/gorilla/websocket"
-	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	jaegercfg "github.com/uber/jaeger-client-go/config"
-	"github.com/weaveworks/common/httpgrpc"
-	httpgrpc_server "github.com/weaveworks/common/httpgrpc/server"
-	"github.com/weaveworks/common/middleware"
-	"github.com/weaveworks/common/user"
 	"golang.org/x/net/websocket"
-	"google.golang.org/grpc"
 )
 
 func TestProxyWebSocket(t *testing.T) {
@@ -125,94 +115,4 @@ func TestProxyReadOnly(t *testing.T) {
 	assert.NoError(t, err, "Failed to get URL")
 	assert.Equal(t, resp.StatusCode, http.StatusServiceUnavailable)
 	assert.True(t, atomic.LoadUint32(&handlerCalled) == 1, "Server was called")
-}
-
-type testGRPCServer struct {
-	*httpgrpc_server.Server
-	URL        string
-	grpcServer *grpc.Server
-}
-
-func newTestGRPCServer(handler http.Handler) (*testGRPCServer, error) {
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return nil, err
-	}
-
-	server := &testGRPCServer{
-		Server:     httpgrpc_server.NewServer(middleware.Tracer{}.Wrap(handler)),
-		grpcServer: grpc.NewServer(),
-		URL:        "direct://" + lis.Addr().String(),
-	}
-
-	httpgrpc.RegisterHTTPServer(server.grpcServer, server.Server)
-	go server.grpcServer.Serve(lis)
-
-	return server, nil
-}
-
-func TestProxyGRPCTracing(t *testing.T) {
-	jaeger := jaegercfg.Configuration{}
-	closer, err := jaeger.InitGlobalTracer("test")
-	defer closer.Close()
-	require.NoError(t, err)
-
-	server, err := newTestGRPCServer(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			span := opentracing.SpanFromContext(r.Context())
-			if span == nil {
-				w.WriteHeader(418)
-				fmt.Fprint(w, "Span missing!")
-			} else {
-				w.WriteHeader(200)
-				fmt.Fprint(w, span.BaggageItem("name"))
-			}
-		}),
-	)
-
-	require.NoError(t, err)
-	defer server.grpcServer.GracefulStop()
-
-	// Setup a proxy server pointing at the server
-	proxy, err := newProxy(proxyConfig{grpcHost: server.URL, protocol: "http"})
-	require.NoError(t, err)
-	proxyServer := httptest.NewServer(
-		middleware.Merge(
-			middleware.Func(func(next http.Handler) http.Handler {
-				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					// Act like authfe and inject the orgID header
-					ctx := user.InjectOrgID(r.Context(), "fakeOrg")
-					err := user.InjectOrgIDIntoHTTPRequest(ctx, r)
-
-					// Either start or continue a span
-					span := opentracing.SpanFromContext(ctx)
-					if span == nil {
-						span, ctx = opentracing.StartSpanFromContext(ctx, "Test")
-					}
-					r = r.WithContext(ctx)
-					// Add some baggage to be sure everything is propagated
-					span.SetBaggageItem("name", "world")
-
-					require.NoError(t, err)
-					next.ServeHTTP(w, r)
-				})
-			}),
-		).Wrap(proxy),
-	)
-
-	defer proxyServer.Close()
-	ctx := context.Background()
-	ctx = user.InjectOrgID(ctx, "fakeOrg")
-
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s%s", proxyServer.URL, "/foo"), nil)
-	require.NoError(t, err)
-	req = req.WithContext(ctx)
-
-	resp, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err, "error making request")
-
-	body := make([]byte, 50)
-	c, _ := resp.Body.Read(body)
-	assert.Equal(t, 200, resp.StatusCode)
-	assert.Equal(t, "world", string(body[:c]))
 }


### PR DESCRIPTION
We are not using this any more.
Part of https://github.com/weaveworks/service-conf/issues/3169

An error type from httpgrpc is still used by the users service; this cannot be removed without gyrations for backward-compatibility.