### PR TITLE
Don't send emails if context is cancelled

### DIFF
--- a/users/emailer/smtp.go
+++ b/users/emailer/smtp.go
@@ -76,7 +76,9 @@ func smtpEmailSender(u *url.URL) (func(ctx context.Context, e *email.Email) erro
 		uid := uuid.New().String()
 		id.Add("X-Entity-Ref-ID", uid)
 		e.Headers = id
-		limiter.Wait(context.Background())
+		if err := limiter.Wait(ctx); err != nil {
+			return err
+		}
 
 		span.LogFields(otlog.String("sending now", e.Subject))
 		return e.Send(addr, auth)


### PR DESCRIPTION
If we pass the correct context into Wait() and check for errors, then if the context is cancelled by the user giving up we won't go ahead and send the email.