### PR TITLE
update rbac.authorization.k8s.io/v1beta1 to rbac.authorization.k8s.io/v1

### DIFF
--- a/dashboard-api/hacking/cortex.yaml
+++ b/dashboard-api/hacking/cortex.yaml
@@ -22,7 +22,7 @@ items:
       labels:
         name: weave-cortex
       namespace: cortex
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       name: weave-cortex
@@ -40,7 +40,7 @@ items:
           - '*'
         verbs:
           - '*'
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
       name: weave-cortex


### PR DESCRIPTION
Updated deprecated APIs (rbac.authorization.k8s.io) from v1beta1 to v1 in prep for upgrade from k8s 1.15 to 1.16