### PR TITLE
Cope with Kubernetes changing 'pod_name' to 'pod'

### DIFF
--- a/dashboard-api/dashboard/cadvisor.go
+++ b/dashboard-api/dashboard/cadvisor.go
@@ -10,7 +10,7 @@ var cadvisorDashboard = Dashboard{
 			Panels: []Panel{{
 				Type:  PanelLine,
 				Unit:  Unit{Format: UnitNumeric, Explanation: "CPU seconds / second"},
-				Query: `sum (rate(container_cpu_usage_seconds_total{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}[{{range}}])) by (pod_name)`,
+				Query: `sum (label_replace(rate(container_cpu_usage_seconds_total{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}[{{range}}]), 'pod', '$0', 'pod_name', '.+')) by (pod)`,
 			}},
 		}},
 	}, {
@@ -19,7 +19,7 @@ var cadvisorDashboard = Dashboard{
 			Panels: []Panel{{
 				Type:  PanelLine,
 				Unit:  Unit{Format: UnitBytes},
-				Query: `sum (container_memory_working_set_bytes{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}) by (pod_name)`,
+				Query: `sum (label_replace(container_memory_working_set_bytes{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}, 'pod', '$0', 'pod_name', '.+')) by (pod)`,
 			}},
 		}},
 	}, {
@@ -38,7 +38,7 @@ var cadvisorDashboard = Dashboard{
 				Type:     PanelLine,
 				Optional: true,
 				Unit:     Unit{Format: UnitNumeric, Explanation: "Page faults / second"},
-				Query:    `sum (rate(container_memory_failures_total{scope='container',failure_type='pgmajfault',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}[1m])) by (pod_name)`,
+				Query:    `sum (label_replace(rate(container_memory_failures_total{scope='container',failure_type='pgmajfault',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}[1m]), 'pod', '$0', 'pod_name', '.+')) by (pod)`,
 			}},
 		}},
 	}, {
@@ -51,13 +51,13 @@ var cadvisorDashboard = Dashboard{
 				Unit:     Unit{Format: UnitNumeric, Explanation: "GPU seconds / second"},
 				// Already a rate: "Percent of time over the past sample period during which the accelerator was actively processing."
 				// See also: https://github.com/google/cadvisor/blob/08f0c239/metrics/prometheus.go#L334-L335
-				Query: `avg (container_accelerator_duty_cycle{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}) by (pod_name)`,
+				Query: `avg (label_replace(container_accelerator_duty_cycle{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}, 'pod', '$0', 'pod_name', '.+')) by (pod)`,
 			}, {
 				Title:    "GPU memory usage",
 				Type:     PanelLine,
 				Optional: true,
 				Unit:     Unit{Format: UnitBytes},
-				Query:    `sum (container_accelerator_memory_used_bytes{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}) by (pod_name)`,
+				Query:    `sum (label_replace(container_accelerator_memory_used_bytes{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}, 'pod', '$0', 'pod_name', '.+')) by (pod)`,
 			}},
 		}},
 	}, {
@@ -67,12 +67,12 @@ var cadvisorDashboard = Dashboard{
 				Title: "Incoming",
 				Type:  PanelLine,
 				Unit:  Unit{Format: UnitBytes},
-				Query: `sum (rate(container_network_receive_bytes_total{image!='',interface='eth0',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}[{{range}}])) by (pod_name)`,
+				Query: `sum (label_replace(rate(container_network_receive_bytes_total{image!='',interface='eth0',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}[{{range}}]), 'pod', '$0', 'pod_name', '.+')) by (pod)`,
 			}, {
 				Title: "Outgoing",
 				Type:  PanelLine,
 				Unit:  Unit{Format: UnitBytes},
-				Query: `sum (rate(container_network_transmit_bytes_total{image!='',interface='eth0',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}[{{range}}])) by (pod_name)`,
+				Query: `sum (label_replace(rate(container_network_transmit_bytes_total{image!='',interface='eth0',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}[{{range}}]), 'pod', '$0', 'pod_name', '.+')) by (pod)`,
 			}},
 		}},
 	}, {
@@ -85,25 +85,25 @@ var cadvisorDashboard = Dashboard{
 				Type:     PanelLine,
 				Optional: true,
 				Unit:     Unit{Format: UnitBytes},
-				Query:    `sum (rate(container_fs_reads_bytes_total{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}[{{range}}])) by (pod_name)`,
+				Query:    `sum (label_replace(rate(container_fs_reads_bytes_total{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}[{{range}}]), 'pod', '$0', 'pod_name', '.+')) by (pod)`,
 			}, {
 				Title:    "Bandwidth (write)",
 				Type:     PanelLine,
 				Optional: true,
 				Unit:     Unit{Format: UnitBytes},
-				Query:    `sum (rate(container_fs_writes_bytes_total{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}[{{range}}])) by (pod_name)`,
+				Query:    `sum (label_replace(rate(container_fs_writes_bytes_total{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}[{{range}}]), 'pod', '$0', 'pod_name', '.+')) by (pod)`,
 			}},
 		}, {
 			Panels: []Panel{{
 				Title: "Operations per second (read)",
 				Type:  PanelLine,
 				Unit:  Unit{Format: UnitNumeric},
-				Query: `sum (rate(container_fs_reads_total{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}[{{range}}])) by (pod_name)`,
+				Query: `sum (label_replace(rate(container_fs_reads_total{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}[{{range}}]), 'pod', '$0', 'pod_name', '.+')) by (pod)`,
 			}, {
 				Title: "Operations per second (write)",
 				Type:  PanelLine,
 				Unit:  Unit{Format: UnitNumeric},
-				Query: `sum (rate(container_fs_writes_total{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}[{{range}}])) by (pod_name)`,
+				Query: `sum (label_replace(rate(container_fs_writes_total{image!='',namespace='{{namespace}}',_weave_pod_name='{{workload}}'}[{{range}}]), 'pod', '$0', 'pod_name', '.+')) by (pod)`,
 			}},
 		}},
 	}},

--- a/dashboard-api/dashboard/testdata/TestGolden-cadvisor-resources.golden
+++ b/dashboard-api/dashboard/testdata/TestGolden-cadvisor-resources.golden
@@ -14,7 +14,7 @@
                 "format": "numeric",
                 "explanation": "CPU seconds / second"
               },
-              "query": "sum (rate(container_cpu_usage_seconds_total{image!='',namespace='default',_weave_pod_name='authfe'}[2m])) by (pod_name)"
+              "query": "sum (label_replace(rate(container_cpu_usage_seconds_total{image!='',namespace='default',_weave_pod_name='authfe'}[2m]), 'pod', '$0', 'pod_name', '.+')) by (pod)"
             }
           ]
         }
@@ -31,7 +31,7 @@
               "unit": {
                 "format": "bytes"
               },
-              "query": "sum (container_memory_working_set_bytes{image!='',namespace='default',_weave_pod_name='authfe'}) by (pod_name)"
+              "query": "sum (label_replace(container_memory_working_set_bytes{image!='',namespace='default',_weave_pod_name='authfe'}, 'pod', '$0', 'pod_name', '.+')) by (pod)"
             }
           ]
         }
@@ -48,7 +48,7 @@
               "unit": {
                 "format": "bytes"
               },
-              "query": "sum (rate(container_network_receive_bytes_total{image!='',interface='eth0',namespace='default',_weave_pod_name='authfe'}[2m])) by (pod_name)"
+              "query": "sum (label_replace(rate(container_network_receive_bytes_total{image!='',interface='eth0',namespace='default',_weave_pod_name='authfe'}[2m]), 'pod', '$0', 'pod_name', '.+')) by (pod)"
             },
             {
               "title": "Outgoing",
@@ -56,7 +56,7 @@
               "unit": {
                 "format": "bytes"
               },
-              "query": "sum (rate(container_network_transmit_bytes_total{image!='',interface='eth0',namespace='default',_weave_pod_name='authfe'}[2m])) by (pod_name)"
+              "query": "sum (label_replace(rate(container_network_transmit_bytes_total{image!='',interface='eth0',namespace='default',_weave_pod_name='authfe'}[2m]), 'pod', '$0', 'pod_name', '.+')) by (pod)"
             }
           ]
         }
@@ -73,7 +73,7 @@
               "unit": {
                 "format": "numeric"
               },
-              "query": "sum (rate(container_fs_reads_total{image!='',namespace='default',_weave_pod_name='authfe'}[2m])) by (pod_name)"
+              "query": "sum (label_replace(rate(container_fs_reads_total{image!='',namespace='default',_weave_pod_name='authfe'}[2m]), 'pod', '$0', 'pod_name', '.+')) by (pod)"
             },
             {
               "title": "Operations per second (write)",
@@ -81,7 +81,7 @@
               "unit": {
                 "format": "numeric"
               },
-              "query": "sum (rate(container_fs_writes_total{image!='',namespace='default',_weave_pod_name='authfe'}[2m])) by (pod_name)"
+              "query": "sum (label_replace(rate(container_fs_writes_total{image!='',namespace='default',_weave_pod_name='authfe'}[2m]), 'pod', '$0', 'pod_name', '.+')) by (pod)"
             }
           ]
         }

--- a/dashboard-api/dashboard/testdata/TestGoldenWithOptionalPanels-cadvisor-resources-with-optional-panels.golden
+++ b/dashboard-api/dashboard/testdata/TestGoldenWithOptionalPanels-cadvisor-resources-with-optional-panels.golden
@@ -14,7 +14,7 @@
                 "format": "numeric",
                 "explanation": "CPU seconds / second"
               },
-              "query": "sum (rate(container_cpu_usage_seconds_total{image!='',namespace='default',_weave_pod_name='authfe'}[2m])) by (pod_name)"
+              "query": "sum (label_replace(rate(container_cpu_usage_seconds_total{image!='',namespace='default',_weave_pod_name='authfe'}[2m]), 'pod', '$0', 'pod_name', '.+')) by (pod)"
             }
           ]
         }
@@ -31,7 +31,7 @@
               "unit": {
                 "format": "bytes"
               },
-              "query": "sum (container_memory_working_set_bytes{image!='',namespace='default',_weave_pod_name='authfe'}) by (pod_name)"
+              "query": "sum (label_replace(container_memory_working_set_bytes{image!='',namespace='default',_weave_pod_name='authfe'}, 'pod', '$0', 'pod_name', '.+')) by (pod)"
             }
           ]
         }
@@ -60,7 +60,7 @@
                 "format": "numeric",
                 "explanation": "Page faults / second"
               },
-              "query": "sum (rate(container_memory_failures_total{scope='container',failure_type='pgmajfault',namespace='default',_weave_pod_name='authfe'}[1m])) by (pod_name)"
+              "query": "sum (label_replace(rate(container_memory_failures_total{scope='container',failure_type='pgmajfault',namespace='default',_weave_pod_name='authfe'}[1m]), 'pod', '$0', 'pod_name', '.+')) by (pod)"
             }
           ]
         }
@@ -79,7 +79,7 @@
                 "format": "numeric",
                 "explanation": "GPU seconds / second"
               },
-              "query": "avg (container_accelerator_duty_cycle{image!='',namespace='default',_weave_pod_name='authfe'}) by (pod_name)"
+              "query": "avg (label_replace(container_accelerator_duty_cycle{image!='',namespace='default',_weave_pod_name='authfe'}, 'pod', '$0', 'pod_name', '.+')) by (pod)"
             },
             {
               "title": "GPU memory usage",
@@ -88,7 +88,7 @@
               "unit": {
                 "format": "bytes"
               },
-              "query": "sum (container_accelerator_memory_used_bytes{image!='',namespace='default',_weave_pod_name='authfe'}) by (pod_name)"
+              "query": "sum (label_replace(container_accelerator_memory_used_bytes{image!='',namespace='default',_weave_pod_name='authfe'}, 'pod', '$0', 'pod_name', '.+')) by (pod)"
             }
           ]
         }
@@ -105,7 +105,7 @@
               "unit": {
                 "format": "bytes"
               },
-              "query": "sum (rate(container_network_receive_bytes_total{image!='',interface='eth0',namespace='default',_weave_pod_name='authfe'}[2m])) by (pod_name)"
+              "query": "sum (label_replace(rate(container_network_receive_bytes_total{image!='',interface='eth0',namespace='default',_weave_pod_name='authfe'}[2m]), 'pod', '$0', 'pod_name', '.+')) by (pod)"
             },
             {
               "title": "Outgoing",
@@ -113,7 +113,7 @@
               "unit": {
                 "format": "bytes"
               },
-              "query": "sum (rate(container_network_transmit_bytes_total{image!='',interface='eth0',namespace='default',_weave_pod_name='authfe'}[2m])) by (pod_name)"
+              "query": "sum (label_replace(rate(container_network_transmit_bytes_total{image!='',interface='eth0',namespace='default',_weave_pod_name='authfe'}[2m]), 'pod', '$0', 'pod_name', '.+')) by (pod)"
             }
           ]
         }
@@ -131,7 +131,7 @@
               "unit": {
                 "format": "bytes"
               },
-              "query": "sum (rate(container_fs_reads_bytes_total{image!='',namespace='default',_weave_pod_name='authfe'}[2m])) by (pod_name)"
+              "query": "sum (label_replace(rate(container_fs_reads_bytes_total{image!='',namespace='default',_weave_pod_name='authfe'}[2m]), 'pod', '$0', 'pod_name', '.+')) by (pod)"
             },
             {
               "title": "Bandwidth (write)",
@@ -140,7 +140,7 @@
               "unit": {
                 "format": "bytes"
               },
-              "query": "sum (rate(container_fs_writes_bytes_total{image!='',namespace='default',_weave_pod_name='authfe'}[2m])) by (pod_name)"
+              "query": "sum (label_replace(rate(container_fs_writes_bytes_total{image!='',namespace='default',_weave_pod_name='authfe'}[2m]), 'pod', '$0', 'pod_name', '.+')) by (pod)"
             }
           ]
         },
@@ -152,7 +152,7 @@
               "unit": {
                 "format": "numeric"
               },
-              "query": "sum (rate(container_fs_reads_total{image!='',namespace='default',_weave_pod_name='authfe'}[2m])) by (pod_name)"
+              "query": "sum (label_replace(rate(container_fs_reads_total{image!='',namespace='default',_weave_pod_name='authfe'}[2m]), 'pod', '$0', 'pod_name', '.+')) by (pod)"
             },
             {
               "title": "Operations per second (write)",
@@ -160,7 +160,7 @@
               "unit": {
                 "format": "numeric"
               },
-              "query": "sum (rate(container_fs_writes_total{image!='',namespace='default',_weave_pod_name='authfe'}[2m])) by (pod_name)"
+              "query": "sum (label_replace(rate(container_fs_writes_total{image!='',namespace='default',_weave_pod_name='authfe'}[2m]), 'pod', '$0', 'pod_name', '.+')) by (pod)"
             }
           ]
         }


### PR DESCRIPTION
Fixes #2662 

Use a label_replace() to make the output uniform, always `pod`.

Use `.+` rather than `.*` so we only get a column when the source matches.