### PR TITLE
Slow down weekly reports

### DIFF
--- a/users-sync/weeklyreporter/job.go
+++ b/users-sync/weeklyreporter/job.go
@@ -45,7 +45,7 @@ func (j *ReporterJob) sendOutWeeklyReportForAllInstances(ctx context.Context, no
 	}
 	j.log.Infof("WeeklyReports: sending out emails to members of %d instances", len(resp.Organizations))
 
-	limiter := rate.NewLimiter(5, 1)
+	limiter := rate.NewLimiter(0.1, 1)
 
 	for _, organization := range resp.Organizations {
 		limiter.Wait(ctx)


### PR DESCRIPTION
1 every 10 seconds will spread the load out over about 4 hours, for the number being done at the time of this PR.

(1300 reports take about 70 minutes with previous rate limit)