### PR TITLE
Pin Ruby prometheus-client to previously working version

### DIFF
--- a/billing-ingester/Dockerfile
+++ b/billing-ingester/Dockerfile
@@ -1,7 +1,7 @@
 FROM fluent/fluentd:v1.2.4
 RUN \
     apk add --no-cache --update g++ make ruby-dev && \
-    gem install bigdecimal 'fluent-plugin-bigquery: 2.0.0.beta' 'fluent-plugin-prometheus: 1.0.1' && \
+    gem install bigdecimal 'prometheus-client: 0.9.0' 'fluent-plugin-bigquery: 2.0.0.beta' 'fluent-plugin-prometheus: 1.0.1' && \
     apk del --no-cache g++ make ruby-dev
 COPY schema_events.json /bigquery/
 COPY fluent-dev.conf /fluentd/etc/

--- a/logging/Dockerfile
+++ b/logging/Dockerfile
@@ -1,7 +1,7 @@
 FROM fluent/fluentd:v1.2.4
 RUN \
     apk add --no-cache --update g++ make ruby-dev && \
-    gem install bigdecimal 'fluent-plugin-bigquery: 2.0.0.beta' 'fluent-plugin-prometheus: 1.0.1' && \
+    gem install bigdecimal 'fluent-plugin-bigquery: 2.0.0.beta' 'prometheus-client: 0.9.0' 'fluent-plugin-prometheus: 1.0.1' && \
     apk del --no-cache g++ make ruby-dev
 COPY schema_service_events.json /bigquery/
 COPY fluent.conf /fluentd/etc/


### PR DESCRIPTION
Rebuilding logging and billing-ingester images resulted in non-working versions because they pulled in a newer version of prometheus-client. Pin to the version used the last time it worked.