### PR TITLE
Add explicit weaveworks-internal flag to tag staff's organisations

### DIFF
--- a/common/featureflag/flags.go
+++ b/common/featureflag/flags.go
@@ -11,5 +11,9 @@ const Billing = "billing"
 // the "billing" flag, in the admin UI.
 const NoBilling = "no-billing"
 
+// WeaveworksInternal feature flag is used to mark our staff's accounts.
+// This is intended as documentation for why the NoBilling flag has been set for a certain accounts.
+const WeaveworksInternal = "weaveworks-internal"
+
 // WeeklyReportable feature flag enables weekly reports to be sent to the members of an organization
 const WeeklyReportable = "weekly-reportable"

--- a/users/api/org_test.go
+++ b/users/api/org_test.go
@@ -618,6 +618,7 @@ func Test_Organization_CreateOrg_never_delinquent_for_weaver(t *testing.T) {
 	org, err := database.FindOrganizationByID(context.TODO(), eid)
 	assert.NoError(t, err)
 	assert.Contains(t, org.FeatureFlags, featureflag.NoBilling)
+	assert.Contains(t, org.FeatureFlags, featureflag.WeaveworksInternal)
 	assert.False(t, org.RefuseDataAccess)
 	assert.False(t, org.RefuseDataUpload)
 }

--- a/users/db/migrations/056_set_weaveworks_internal_flag.sql
+++ b/users/db/migrations/056_set_weaveworks_internal_flag.sql
@@ -1,0 +1,16 @@
+update organizations
+set feature_flags = array_append(feature_flags, 'weaveworks-internal')
+where id in (
+    select distinct o.id
+    from organizations o
+    inner join team_memberships tm on o.team_id = tm.team_id
+    where o.deleted_at is null
+        and o.feature_flags @> array['no-billing']
+        and not o.feature_flags @> array['weaveworks-internal']
+        and tm.user_id not in (
+            select u.id
+            from users u
+            where u.email not like '%@weave.works'
+                and u.id is null
+        )
+);


### PR DESCRIPTION
From now on, this will be added automatically for all organisations
created by weave.works emails.

As a migration step, this will also add it to every non-deleted,
non-billing organisation where every single email is a @weave.works
email - my hope is that while I'm sure this will miss some, it
shouldn't have any false positives.

This fixes #2720 