### PR TITLE
users/admin: Change k8s platform sorting

### DIFF
--- a/users/api/admin.go
+++ b/users/api/admin.go
@@ -313,7 +313,7 @@ func getSortableColumns() map[string]string {
 		"LastSentWeeklyReportAt": "organizations.last_sent_weekly_report_at",
 		"DeletedAt":              "organizations.deleted_at",
 		"Platform":               "organizations.platform",
-		"PlatformVersion":        "nullif(string_to_array(regexp_replace(organizations.platform_version, '[^0-9.]', '', 'g'), '.')::int[],'{}')",
+		"PlatformVersion":        "(nullif(string_to_array(substring(organizations.platform_version from '^(?:v)([0-9.]+)'), '.')::int[],'{}'), organizations.platform_version)",
 		"TrialRemaining":         "organizations.trial_expires_at",
 	}
 }


### PR DESCRIPTION
When confronted with a version that was e.g. a git hash, we would remove all
the letters, and hope the remaining numbers could be intelligently compared.

This creates a tuple of (extracted version, plaintext version). The first part
sorts every release by number (i.e. 1.19 comes between 1.20 and 1.2), and the
second part is a tiebreaker - sort "-gke-200" separately from "-gke-400", but
as that bit is user-controlled and did break the production sorting, let's just
accept that "-gke-2" will count as bigger than "-gke-100", because being too
clever is how things become fragile.