### PR TITLE
users/admin: Sort PlatformVersion better

### DIFF
--- a/users/api/admin.go
+++ b/users/api/admin.go
@@ -313,7 +313,7 @@ func getSortableColumns() map[string]string {
 		"LastSentWeeklyReportAt": "organizations.last_sent_weekly_report_at",
 		"DeletedAt":              "organizations.deleted_at",
 		"Platform":               "organizations.platform",
-		"PlatformVersion":        "(nullif(string_to_array(substring(organizations.platform_version from '^(?:v)([0-9.]+)'), '.')::int[],'{}'), organizations.platform_version)",
+		"PlatformVersion":        "nullif(string_to_array(substring(organizations.platform_version from '^(??:v)([0-9.]+)'), '.')::int[],'{}')",
 		"TrialRemaining":         "organizations.trial_expires_at",
 	}
 }


### PR DESCRIPTION
Before I started in yesterday's broken commit, the admin frontend would blow up
if you tried to sort by platform version, and had versions like
`v1.20.2-34+350770ed07a558` - so that's not ideal. I tried to fix that, but made
two errors: first, sorting by `int[]` and then `text` is perfectly supported in
postgres, but not the way I had the query builder build the query - it seems to
have all been cast to `text[]` or something? Second, I didn't escape my question
mark, so actually everything was broken.

This time, screw sorting by special versions of a release - I just wanted to see
the newest and oldest platform versions and who uses them, I don't care about
sorting by the bit after the +.