### PR TITLE
authfe: Don't stop load balancing just because pods restart

### DIFF
--- a/authfe/balance/consistent.go
+++ b/authfe/balance/consistent.go
@@ -76,6 +76,7 @@ cacheLoop:
 		}
 		logging.Global().Debugf("removing instance %s", key)
 		removals = append(removals, endpoint)
+		delete(c.cache, key)
 	}
 	c.c.RemoveEndpoints(removals...)
 


### PR DESCRIPTION
When a pod is restarted (not as in deleted and recreated, but as in process
killed pod continues), consistent would delete the node from algo_consistent.
Then when consistent discovered it was started again, it would not tell
algo_consistent about that, because the entry was already in cache.

This cleans up the cache, so we actually continue to load balance even when the
cluster is struggling.