### PR TITLE
Add test to see that we update algo_consistent when pods restart

### DIFF
--- a/authfe/balance/consistent_test.go
+++ b/authfe/balance/consistent_test.go
@@ -59,4 +59,9 @@ func TestEndpointUpdates(t *testing.T) {
 	assert.Equal(t, 0, cw.c.totalLoad)
 	cw.Put(endpoint2)
 	cw.Put(endpoint4)
+
+	// Replace with previously removed endpoint (i.e. temporary failed health
+	// check). This should reflect into the algo
+	cw.update(event("4"))
+	assert.Equal(t, 1, cw.c.numEndpoints)
 }


### PR DESCRIPTION
This should have been committed together with the bugfix in the parent
commit