### PR TITLE
Fix detection of changed images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
           name: Publish docker images to final repository
           command: |
             set -o pipefail
-            export LAST_BUILD_COMMIT=$(curl -sS 'https://circleci.com/api/v1/project/weaveworks/service/tree/'$CIRCLE_BRANCH'?circle-token='$CIRCLE_TOKEN'&filter=successful&limit=50' | jq -r 'map(select(.build_parameters.CIRCLE_JOB == "upload")) | .[0].vcs_revision')
+            export LAST_BUILD_COMMIT=$(curl -sS 'https://circleci.com/api/v1/project/weaveworks/service/tree/'$CIRCLE_BRANCH'?circle-token='$CIRCLE_TOKEN'&filter=successful&limit=50' | jq -r 'map(select(.workflows.job_name == "upload")) | .[0].vcs_revision')
             echo Last successful build was commit $LAST_BUILD_COMMIT
             mkdir ~/.aws
             echo $AWS_ECR_CREDENTIALS | base64 -d > ~/.aws/credentials
@@ -133,7 +133,7 @@ jobs:
           name: Dry-run of publishing docker images
           command: |
             set -o pipefail
-            export LAST_BUILD_COMMIT=$(curl -sS 'https://circleci.com/api/v1/project/weaveworks/service/tree/main?circle-token='$CIRCLE_TOKEN'&filter=successful&limit=50' | jq -r 'map(select(.build_parameters.CIRCLE_JOB == "upload")) | .[0].vcs_revision')
+            export LAST_BUILD_COMMIT=$(curl -sS 'https://circleci.com/api/v1/project/weaveworks/service/tree/main?circle-token='$CIRCLE_TOKEN'&filter=successful&limit=50' | jq -r 'map(select(.workflows.job_name == "upload")) | .[0].vcs_revision')
             echo Last successful build was commit $LAST_BUILD_COMMIT
             mkdir ~/.aws
             echo $AWS_ECR_CREDENTIALS | base64 -d > ~/.aws/credentials


### PR DESCRIPTION
CircleCI recently(?) removed the field we were reading to determine
the last successful job, so we need to use the one that's still there.

This fix is copy-pasted from weaveworks/service-conf@2f526f42c