### PR TITLE
scope-data-cleaning: Fix handling of empty lines

### DIFF
--- a/scope-data-cleaning/main.go
+++ b/scope-data-cleaning/main.go
@@ -265,7 +265,11 @@ func main() {
 	// Now start feeding the queue
 	records = bufio.NewScanner(recordsReader)
 	for records.Scan() {
-		queue <- records.Text()
+		line := records.Text()
+		if line == "" || line[1] == '#' {
+			continue
+		}
+		queue <- line
 	}
 	checkFatal(records.Err())
 	close(queue)


### PR DESCRIPTION
Copy-paste the empty/comment line handling code from a few lines up.

53b3482 claimed to add support for empty lines and comment lines. It
did no such thing - it added support for counting empty lines and
comment lines, but the job crashed whenever it tried to do anything
with a file containing any of those things.

I still don't know if this _actually_ works, but I know it no longer
crashes when it starts to work on the current prod-records file, which
starts with an empty line.