### PR TITLE
users/db: Add method to retrieve a specific login

### DIFF
--- a/users/db/db.go
+++ b/users/db/db.go
@@ -42,6 +42,9 @@ type DB interface {
 	// Note: Must be idempotent!
 	AddLoginToUser(ctx context.Context, userID, provider, id string, session json.RawMessage) error
 
+	// GetLogin takes a login provider name and id, and returns that login object
+	GetLogin(ctx context.Context, provider, id string) (*login.Login, error)
+
 	// DetachLoginFromUser removes all entries an entry denoting this
 	// user is linked to the remote login.
 	DetachLoginFromUser(ctx context.Context, userID, provider string) error

--- a/users/db/memory/user.go
+++ b/users/db/memory/user.go
@@ -128,6 +128,16 @@ func (d *DB) AddLoginToUser(_ context.Context, userID, provider, providerID stri
 	return nil
 }
 
+// GetLogin takes a login provider name and id, and returns that login object
+func (d *DB) GetLogin(_ context.Context, provider, providerID string) (*login.Login, error) {
+	for _, l := range d.logins {
+		if l.Provider == provider && l.ProviderID == providerID {
+			return l, nil
+		}
+	}
+	return nil, users.ErrNotFound
+}
+
 // DetachLoginFromUser detaches the specified login from a user. e.g. if you
 // want to attach it to a different user, do this first.
 func (d *DB) DetachLoginFromUser(_ context.Context, userID, provider string) error {

--- a/users/db/timed.go
+++ b/users/db/timed.go
@@ -99,6 +99,14 @@ func (t timed) AddLoginToUser(ctx context.Context, userID, provider, id string, 
 	})
 }
 
+func (t timed) GetLogin(ctx context.Context, provider, id string) (l *login.Login, err error) {
+	t.timeRequest(ctx, "GetLogin", func(ctx context.Context) error {
+		l, err = t.d.GetLogin(ctx, provider, id)
+		return err
+	})
+	return
+}
+
 func (t timed) DetachLoginFromUser(ctx context.Context, userID, provider string) error {
 	return t.timeRequest(ctx, "DetachLoginFromUser", func(ctx context.Context) error {
 		return t.d.DetachLoginFromUser(ctx, userID, provider)

--- a/users/db/traced.go
+++ b/users/db/traced.go
@@ -64,6 +64,11 @@ func (t traced) AddLoginToUser(ctx context.Context, userID, provider, id string,
 	return t.d.AddLoginToUser(ctx, userID, provider, id, session)
 }
 
+func (t traced) GetLogin(ctx context.Context, provider, id string) (l *login.Login, err error) {
+	defer t.trace("GetLogin", provider, id, l, err)
+	return t.d.GetLogin(ctx, provider, id)
+}
+
 func (t traced) DetachLoginFromUser(ctx context.Context, userID, provider string) (err error) {
 	defer t.trace("DetachLoginFromUser", userID, provider, err)
 	return t.d.DetachLoginFromUser(ctx, userID, provider)


### PR DESCRIPTION
We list logins all the time, but we never actually just get
one. Concretely, we store the users's access key only in the login
entry in the database, so if I want to use the current access key for
the current login, I would have to list all logins and then filter for
a matching one - or by adding this method.