### PR TITLE
users: Fix invitation signup behaviour

### DIFF
--- a/users/api/login.go
+++ b/users/api/login.go
@@ -315,8 +315,10 @@ func (a *API) verify(w http.ResponseWriter, r *http.Request) {
 	connection := r.FormValue("connection")
 	returnURL := r.FormValue("next")
 	var loginURL string
+	if r.FormValue("code") != "" && connection == "" {
+		connection = "email"
+	}
 	if connection != "" {
-		// FIXME: does this work with next parameter?
 		loginURL = a.logins.LoginURL(r, connection)
 	} else {
 		loginURL = "/login"

--- a/users/api/login_test.go
+++ b/users/api/login_test.go
@@ -114,6 +114,11 @@ func Test_Verify(t *testing.T) {
 			"/mock-login/",
 			&[4]string{"email", "test@test.test", "1", ""},
 		},
+		{
+			"/api/users/verify?code=1234",
+			"/mock-login/",
+			nil,
+		},
 	} {
 		w := httptest.NewRecorder()
 		r, _ := http.NewRequest("GET", testCase.requestURL, nil)

--- a/users/cmd/users/main.go
+++ b/users/cmd/users/main.go
@@ -94,6 +94,7 @@ func main() {
 	logins.Flags(flag.CommandLine)
 	logins.Register("google", login.NewGoogleConnection())
 	logins.Register("github", login.NewGithubConnection())
+	logins.Register("email", login.NewEmailConnection())
 	dbCfg.RegisterFlags(flag.CommandLine, "postgres://postgres@users-db.weave.local/users?sslmode=disable", "URI where the database can be found (for dev you can use memory://)", "/migrations", "Migrations directory.")
 	procurementCfg.RegisterFlags(flag.CommandLine)
 	billingCfg.RegisterFlags(flag.CommandLine)

--- a/users/login/email.go
+++ b/users/login/email.go
@@ -1,0 +1,14 @@
+package login
+
+import (
+	"github.com/coreos/go-oidc"
+)
+
+// NewEmailConnection returns a Connection that describes the email connection
+// Note: email logins happen through PasswordlessLogin, not this interface
+func NewEmailConnection() Connection {
+	return Connection{
+		Scopes:         []string{oidc.ScopeOpenID, "profile", "email"},
+		ConnectionName: "email",
+	}
+}


### PR DESCRIPTION
At the moment, weave cloud doesn't have a proper organization
entity. Therefore, I've not synced weave cloud's teams/organizations
to auth0. So when you get invited by another user to join your team,
it's not a "proper invite", it's literally just an email login
attempt.

Because an invite is inherently sent from a different user than clicks
on the link, and because the email login is effectively using OIDC on
our side, the state we're returned after signup doesn't match our
expected state, so the code generates CSRF errors.

This workaround makes the invite email link to the login verification
page. That page now has a special case for logged-out & signed up, so it can
send you back to auth0 to get you signed in to weave cloud. Since you
literally just signed up/in to auth0, they just send you straight
back, and now you pass all CSRF protection.

Neat? No.

Works? Actually, yeah.