### PR TITLE
users: Fix github key uploading

### DIFF
--- a/users/api/admin.go
+++ b/users/api/admin.go
@@ -726,7 +726,15 @@ func (a *API) adminGetUserToken(w http.ResponseWriter, r *http.Request) {
 
 func getSpecificLogin(login string, logins []*login.Login) (*string, error) {
 	for _, l := range logins {
-		if l.Provider == login {
+		if l.Provider != login {
+			continue
+		}
+
+		// Backwards compatibility: auth0 logins are "connection|id", but
+		// pre-auth0 we just stored "id" in provider id.
+		// So consider direct access keys to be "not matching", and force
+		// user to reauthenticate through auth0 this time.
+		if strings.Contains(l.ProviderID, "|") {
 			return &l.ProviderID, nil
 		}
 	}

--- a/users/api/admin_test.go
+++ b/users/api/admin_test.go
@@ -100,12 +100,26 @@ func TestAPI_adminChangeOrgFields_BillingNeverShrinkTrialPeriod(t *testing.T) {
 	assert.True(t, prevExpires.Equal(newOrg.TrialExpiresAt))
 }
 
-func TestAPI_adminGetUserToken(t *testing.T) {
+func TestAPI_adminGetOldUserToken(t *testing.T) {
 	setup(t)
 	defer cleanup(t)
 
 	usr, _ := database.CreateUser(ctx, "test@test", nil)
 	database.AddLoginToUser(ctx, usr.ID, "github", "12345", ghSession)
+
+	w := httptest.NewRecorder()
+	r := requestAs(t, usr, "GET",
+		fmt.Sprintf("/admin/users/users/%v/logins/github/token", usr.ID), nil)
+	app.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestAPI_adminGetUserToken(t *testing.T) {
+	setup(t)
+	defer cleanup(t)
+
+	usr, _ := database.CreateUser(ctx, "test@test", nil)
+	database.AddLoginToUser(ctx, usr.ID, "github", "github|12345", ghSession)
 
 	w := httptest.NewRecorder()
 	r := requestAs(t, usr, "GET",


### PR DESCRIPTION
As a user who had previously authorized github outside auth0,
calling GetAccessToken against auth0 obviously doesn't work if my user
doesn't exist in auth0 yet - and if the user exist, we might not
actually find the auth0 version of the login first.

Instead, look for clear traces of auth0-iness, and only return
those keys. This will force a re-authentication, which I'm OK with
given it's how to create my login in our central login service. In
fact, I'm pretty sure it won't actually require any user action once
we're using the same github application as before.