### PR TITLE
tests: Use image that exists in notification eventmanager e2e tests

### DIFF
--- a/notification-eventmanager/e2e/docker-compose.yaml
+++ b/notification-eventmanager/e2e/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
     - POSTGRES_DB=notifications
 
   sqslocal:
-    image: "pakohan/elasticmq"
+    image: "softwaremill/elasticmq:0.14.7"
     expose:
      - "9324"
 


### PR DESCRIPTION
pakohan's docker repository returns 404. The name elasticmq appears to
still point to a softwaremill repo, so try that - and try pinning the
version to the very oldest in the repo, just in case there's API
changes in the last three or so years.