### PR TITLE
Notify marketing about logins, not page loads

### DIFF
--- a/users/api/auth.go
+++ b/users/api/auth.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/weaveworks/service/users"
 	"github.com/weaveworks/service/users/tokens"
@@ -60,10 +59,6 @@ func (a *API) authenticateUserVia(handler func(*users.User, http.ResponseWriter,
 			if err != nil {
 				continue
 			}
-			// User actions always go through this endpoint because authfe checks the
-			// authentication endpoint every time. We use this to tell marketing about
-			// login activity.
-			a.marketingQueues.UserAccess(user.Email, time.Now())
 			handler(user, w, r)
 			return
 		}

--- a/users/api/login.go
+++ b/users/api/login.go
@@ -149,6 +149,8 @@ func (a *API) attachLoginProvider(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		a.marketingQueues.UserCreated(u.Email, u.FirstName, u.LastName, u.Company, u.CreatedAt, extraState)
+	} else {
+		a.marketingQueues.UserAccess(u.Email, time.Now())
 	}
 
 	if err := a.db.AddLoginToUser(ctx, u.ID, providerID, claims.ID, authSession); err != nil {


### PR DESCRIPTION
We used to notify marketing about user activity every single time we
loaded a page from the server. That's a bit excessive.

Granted, because our sessions were infinite, it's hard to do it any
other way. However, we _do_ expire sessions these days - I've stripped
out the auto-renew from sessions. Not very often mind you, but it does
happen. As marketing isn't all that excited about finding out every
single page load, why don't we just notify them whenever a user
actually logs in?