### PR TITLE
billing-ingester: Put internal_instance_id in prod config, too

### DIFF
--- a/billing-ingester/fluent.conf
+++ b/billing-ingester/fluent.conf
@@ -31,6 +31,7 @@
     <labels>
       status success
       amount_type ${amount_type}
+      internal_instance_id ${internal_instance_id}
     </labels>
   </metric>
   <metric>
@@ -41,6 +42,7 @@
     <labels>
       status success
       amount_type ${amount_type}
+      internal_instance_id ${internal_instance_id}
     </labels>
   </metric>
 </filter>


### PR DESCRIPTION
This lets us see billing information per customer directly in
prometheus.